### PR TITLE
feat: add company switching and enhanced guidance system

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,6 @@
 import { config } from '../config.js';
 import { getValidAccessToken } from '../auth/tokens.js';
+import { getCurrentCompanyId } from '../config/companies.js';
 
 export async function makeApiRequest(
   method: string,
@@ -8,13 +9,14 @@ export async function makeApiRequest(
   body?: Record<string, unknown>,
 ): Promise<unknown> {
   const baseUrl = config.freee.apiUrl;
-  const companyId = config.freee.companyId;
+  const companyId = await getCurrentCompanyId();
 
-  const accessToken = await getValidAccessToken();
+  const accessToken = await getValidAccessToken(companyId);
 
   if (!accessToken) {
     throw new Error(
       `認証が必要です。freee_authenticate ツールを使用して認証を行ってください。\n` +
+      `現在の事業所ID: ${companyId}\n` +
       `または、FREEE_CLIENT_ID環境変数が正しく設定されているか確認してください。`
     );
   }
@@ -43,11 +45,13 @@ export async function makeApiRequest(
     const errorData = await response.json().catch(() => ({}));
     throw new Error(
       `認証エラーが発生しました。freee_authenticate ツールを使用して再認証を行ってください。\n` +
+      `現在の事業所ID: ${companyId}\n` +
       `エラー詳細: ${response.status} ${JSON.stringify(errorData)}\n\n` +
       `確認事項:\n` +
       `1. FREEE_CLIENT_ID環境変数が正しく設定されているか\n` +
       `2. freee側でアプリケーション設定が正しいか（リダイレクトURI等）\n` +
-      `3. トークンの有効期限が切れていないか`
+      `3. 現在の事業所(${companyId})に対するトークンの有効期限が切れていないか\n` +
+      `4. 事業所IDが正しいか（freee_get_current_company で確認）`
     );
   }
 

--- a/src/auth/tokens.ts
+++ b/src/auth/tokens.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import { config } from '../config.js';
+import { getCurrentCompanyId } from '../config/companies.js';
 
 export interface TokenData {
   access_token: string;
@@ -11,19 +12,24 @@ export interface TokenData {
   scope: string;
 }
 
-function getTokenFilePath(): string {
+function getTokenFilePath(companyId?: string): string {
   const configDir = path.join(os.homedir(), '.config', 'freee-mcp');
+  if (companyId) {
+    return path.join(configDir, `tokens-${companyId}.json`);
+  }
+  // Legacy support for old token file
   return path.join(configDir, 'tokens.json');
 }
 
-export async function saveTokens(tokens: TokenData): Promise<void> {
-  const tokenPath = getTokenFilePath();
+export async function saveTokens(tokens: TokenData, companyId?: string): Promise<void> {
+  const currentCompanyId = companyId || await getCurrentCompanyId();
+  const tokenPath = getTokenFilePath(currentCompanyId);
   const configDir = path.dirname(tokenPath);
 
   try {
     console.error(`📁 Creating directory: ${configDir}`);
     await fs.mkdir(configDir, { recursive: true });
-    console.error(`💾 Writing tokens to: ${tokenPath}`);
+    console.error(`💾 Writing tokens for company ${currentCompanyId} to: ${tokenPath}`);
     await fs.writeFile(tokenPath, JSON.stringify(tokens, null, 2), { mode: 0o600 });
     console.error('✅ Tokens saved successfully');
   } catch (error) {
@@ -32,14 +38,29 @@ export async function saveTokens(tokens: TokenData): Promise<void> {
   }
 }
 
-export async function loadTokens(): Promise<TokenData | null> {
-  const tokenPath = getTokenFilePath();
+export async function loadTokens(companyId?: string): Promise<TokenData | null> {
+  const currentCompanyId = companyId || await getCurrentCompanyId();
+  const tokenPath = getTokenFilePath(currentCompanyId);
 
   try {
     const data = await fs.readFile(tokenPath, 'utf8');
     return JSON.parse(data) as TokenData;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      // Try legacy token file for backward compatibility
+      if (companyId === undefined) {
+        const legacyPath = getTokenFilePath();
+        try {
+          const legacyData = await fs.readFile(legacyPath, 'utf8');
+          const legacyTokens = JSON.parse(legacyData) as TokenData;
+          // Migrate to new format
+          await saveTokens(legacyTokens, currentCompanyId);
+          await fs.unlink(legacyPath); // Remove legacy file
+          return legacyTokens;
+        } catch {
+          // Legacy file doesn't exist, return null
+        }
+      }
       return null;
     }
     console.error('Failed to load tokens:', error);
@@ -51,7 +72,7 @@ export function isTokenValid(tokens: TokenData): boolean {
   return Date.now() < tokens.expires_at;
 }
 
-export async function refreshAccessToken(refreshToken: string): Promise<TokenData> {
+export async function refreshAccessToken(refreshToken: string, companyId?: string): Promise<TokenData> {
   const response = await fetch(config.oauth.tokenEndpoint, {
     method: 'POST',
     headers: {
@@ -79,19 +100,20 @@ export async function refreshAccessToken(refreshToken: string): Promise<TokenDat
     scope: tokenResponse.scope || config.oauth.scope,
   };
 
-  await saveTokens(tokens);
+  await saveTokens(tokens, companyId);
   return tokens;
 }
 
-export async function clearTokens(): Promise<void> {
-  const tokenPath = getTokenFilePath();
+export async function clearTokens(companyId?: string): Promise<void> {
+  const currentCompanyId = companyId || await getCurrentCompanyId();
+  const tokenPath = getTokenFilePath(currentCompanyId);
 
   try {
     await fs.unlink(tokenPath);
-    console.error('Tokens cleared successfully');
+    console.error(`Tokens for company ${currentCompanyId} cleared successfully`);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      console.error('No tokens to clear (file does not exist)');
+      console.error(`No tokens to clear for company ${currentCompanyId} (file does not exist)`);
       return;
     }
     console.error('Failed to clear tokens:', error);
@@ -99,8 +121,9 @@ export async function clearTokens(): Promise<void> {
   }
 }
 
-export async function getValidAccessToken(): Promise<string | null> {
-  const tokens = await loadTokens();
+export async function getValidAccessToken(companyId?: string): Promise<string | null> {
+  const currentCompanyId = companyId || await getCurrentCompanyId();
+  const tokens = await loadTokens(currentCompanyId);
   if (!tokens) {
     return null;
   }
@@ -110,7 +133,7 @@ export async function getValidAccessToken(): Promise<string | null> {
   }
 
   try {
-    const newTokens = await refreshAccessToken(tokens.refresh_token);
+    const newTokens = await refreshAccessToken(tokens.refresh_token, currentCompanyId);
     return newTokens.access_token;
   } catch (error) {
     console.error('Failed to refresh token:', error);

--- a/src/config/companies.ts
+++ b/src/config/companies.ts
@@ -1,0 +1,111 @@
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { config } from '../config.js';
+
+export interface CompanyConfig {
+  id: string;
+  name?: string;
+  description?: string;
+  addedAt: number;
+  lastUsed?: number;
+}
+
+export interface CompaniesConfig {
+  defaultCompanyId: string;
+  currentCompanyId: string;
+  companies: Record<string, CompanyConfig>;
+}
+
+function getConfigFilePath(): string {
+  const configDir = path.join(os.homedir(), '.config', 'freee-mcp');
+  return path.join(configDir, 'config.json');
+}
+
+async function ensureConfigDir(): Promise<void> {
+  const configDir = path.dirname(getConfigFilePath());
+  await fs.mkdir(configDir, { recursive: true });
+}
+
+export async function loadCompaniesConfig(): Promise<CompaniesConfig> {
+  const configPath = getConfigFilePath();
+
+  try {
+    const data = await fs.readFile(configPath, 'utf8');
+    return JSON.parse(data) as CompaniesConfig;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      // Create default config with environment variable company ID
+      const defaultCompanyId = config.freee.companyId;
+      const defaultConfig: CompaniesConfig = {
+        defaultCompanyId,
+        currentCompanyId: defaultCompanyId,
+        companies: {
+          [defaultCompanyId]: {
+            id: defaultCompanyId,
+            name: 'Default Company',
+            description: 'Company from environment variable',
+            addedAt: Date.now(),
+            lastUsed: Date.now(),
+          },
+        },
+      };
+      await saveCompaniesConfig(defaultConfig);
+      return defaultConfig;
+    }
+    throw error;
+  }
+}
+
+export async function saveCompaniesConfig(config: CompaniesConfig): Promise<void> {
+  await ensureConfigDir();
+  const configPath = getConfigFilePath();
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
+}
+
+export async function getCurrentCompanyId(): Promise<string> {
+  const config = await loadCompaniesConfig();
+  return config.currentCompanyId;
+}
+
+export async function setCurrentCompany(
+  companyId: string,
+  name?: string,
+  description?: string
+): Promise<void> {
+  const config = await loadCompaniesConfig();
+  
+  // Add or update company info
+  if (!config.companies[companyId]) {
+    config.companies[companyId] = {
+      id: companyId,
+      name: name || `Company ${companyId}`,
+      description: description || undefined,
+      addedAt: Date.now(),
+    };
+  } else if (name || description) {
+    // Update existing company info if provided
+    if (name) config.companies[companyId].name = name;
+    if (description) config.companies[companyId].description = description;
+  }
+
+  // Update last used timestamp
+  config.companies[companyId].lastUsed = Date.now();
+  
+  // Set as current company
+  config.currentCompanyId = companyId;
+  
+  await saveCompaniesConfig(config);
+}
+
+export async function getCompanyList(): Promise<CompanyConfig[]> {
+  const config = await loadCompaniesConfig();
+  return Object.values(config.companies).sort((a, b) => 
+    (b.lastUsed || 0) - (a.lastUsed || 0)
+  );
+}
+
+export async function getCompanyInfo(companyId: string): Promise<CompanyConfig | null> {
+  const config = await loadCompaniesConfig();
+  return config.companies[companyId] || null;
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,26 +1,35 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import crypto from 'crypto';
 import open from 'open';
+import { z } from 'zod';
 import { config } from '../config.js';
 import { makeApiRequest } from '../api/client.js';
 import { loadTokens, clearTokens } from '../auth/tokens.js';
 import { generatePKCE, buildAuthUrl } from '../auth/oauth.js';
 import { registerAuthenticationRequest } from '../auth/server.js';
+import { 
+  getCurrentCompanyId, 
+  setCurrentCompany, 
+  getCompanyList, 
+  getCompanyInfo 
+} from '../config/companies.js';
 
 export function addAuthenticationTools(server: McpServer): void {
   server.tool(
     'freee_current_user',
-    'freee APIの現在のユーザー情報を取得します。認証状態、会社ID、ユーザー詳細が含まれます。',
+    'freee APIの現在のユーザー情報を取得します。認証状態、事業所ID、ユーザー詳細が含まれます。【認証テスト用・API動作確認に最適】',
     {},
     async () => {
       try {
-        const companyId = config.freee.companyId;
+        const companyId = await getCurrentCompanyId();
+        const companyInfo = await getCompanyInfo(companyId);
+        
         if (!companyId) {
           return {
             content: [
               {
                 type: 'text',
-                text: 'FREEE_COMPANY_ID環境変数が設定されていません。',
+                text: '会社IDが設定されていません。freee_set_company ツールを使用して会社を設定してください。',
               },
             ],
           };
@@ -33,7 +42,8 @@ export function addAuthenticationTools(server: McpServer): void {
             {
               type: 'text',
               text: `現在のユーザー情報:\n` +
-                    `設定されている会社ID: ${companyId}\n` +
+                    `現在の会社ID: ${companyId}\n` +
+                    `会社名: ${companyInfo?.name || 'Unknown'}\n` +
                     `ユーザー詳細:\n${JSON.stringify(userInfo, null, 2)}`,
             },
           ],
@@ -44,10 +54,11 @@ export function addAuthenticationTools(server: McpServer): void {
             {
               type: 'text',
               text: `ユーザー情報の取得に失敗しました: ${error instanceof Error ? error.message : String(error)}\n\n` +
-                    `以下を確認してください:\n` +
-                    `1. 認証が完了しているか（freee_authenticate ツールを使用）\n` +
-                    `2. FREEE_COMPANY_ID環境変数が正しく設定されているか\n` +
-                    `3. ネットワーク接続が正常か`,
+                    `🔧 解決手順:\n` +
+                    `1. freee_status - 現在の状態を確認\n` +
+                    `2. freee_authenticate - 認証を実行\n` +
+                    `3. freee_get_current_company - 事業所設定を確認\n\n` +
+                    `🆘 初めての場合: freee_getting_started`,
             },
           ],
         };
@@ -57,7 +68,7 @@ export function addAuthenticationTools(server: McpServer): void {
 
   server.tool(
     'freee_authenticate',
-    'freee APIのOAuth認証を開始します。永続的なコールバックサーバーを利用して認証を行います。',
+    'freee APIのOAuth認証を開始します。永続的なコールバックサーバーを利用して認証を行います。【事業所ごとに初回認証が必要】事業所設定後に実行してください。',
     {},
     async () => {
       try {
@@ -120,10 +131,11 @@ export function addAuthenticationTools(server: McpServer): void {
             {
               type: 'text',
               text: `認証開始に失敗しました: ${error instanceof Error ? error.message : String(error)}\n\n` +
-                    `以下を確認してください:\n` +
-                    `1. FREEE_CLIENT_ID環境変数が設定されているか\n` +
-                    `2. freee側でアプリケーション設定が正しいか\n` +
-                    `3. コールバックサーバー（${config.oauth.callbackPort}ポート）が起動しているか`,
+                    `🔧 解決手順:\n` +
+                    `1. freee_status - 環境変数の状態を確認\n` +
+                    `2. freee_getting_started - 初期設定ガイドを確認\n` +
+                    `3. リダイレクトURI設定: http://127.0.0.1:${config.oauth.callbackPort}/callback\n\n` +
+                    `🆘 初めての場合: freee_help`,
             },
           ],
         };
@@ -133,7 +145,7 @@ export function addAuthenticationTools(server: McpServer): void {
 
   server.tool(
     'freee_auth_status',
-    'freee APIの認証状態を確認します。保存されているトークンの情報を表示します。',
+    'freee APIの認証状態を確認します。保存されているトークンの情報を表示します。【認証トラブル時の確認用】',
     {},
     async () => {
       try {
@@ -143,7 +155,7 @@ export function addAuthenticationTools(server: McpServer): void {
             content: [
               {
                 type: 'text',
-                text: '認証されていません。freee_authenticate ツールを使用して認証を行ってください。',
+                text: '認証されていません。\n\n💡 次のステップ:\n1. freee_authenticate - 認証を実行\n2. freee_status - 状態を確認\n\n🆘 初めての場合: freee_getting_started',
               },
             ],
           };
@@ -170,7 +182,7 @@ export function addAuthenticationTools(server: McpServer): void {
           content: [
             {
               type: 'text',
-              text: `認証状態の確認に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+              text: `認証状態の確認に失敗しました: ${error instanceof Error ? error.message : String(error)}\n\n🔧 解決手順:\n1. freee_status - 全体的な状態を確認\n2. freee_getting_started - 初期設定ガイド`,
             },
           ],
         };
@@ -180,7 +192,7 @@ export function addAuthenticationTools(server: McpServer): void {
 
   server.tool(
     'freee_clear_auth',
-    'freee APIの認証情報をクリアします。保存されているトークンファイルを削除し、次回API使用時に再認証が必要になります。',
+    'freee APIの認証情報をクリアします。保存されているトークンファイルを削除し、次回API使用時に再認証が必要になります。【認証エラー時のリセット用】',
     {},
     async () => {
       try {
@@ -200,7 +212,424 @@ export function addAuthenticationTools(server: McpServer): void {
           content: [
             {
               type: 'text',
-              text: `認証情報のクリアに失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+              text: `認証情報のクリアに失敗しました: ${error instanceof Error ? error.message : String(error)}\n\n🔧 代替手順:\n1. freee_status - 状態を確認\n2. 手動でファイル削除: ~/.config/freee-mcp/tokens-*.json`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  // Company management tools
+  server.tool(
+    'freee_set_company',
+    '事業所を設定・切り替えます。新しい事業所の場合は自動的に追加されます。【重要】設定後は freee_authenticate で認証が必要です。',
+    {
+      company_id: z.string().describe('事業所ID（必須）'),
+      name: z.string().optional().describe('事業所名（オプション、新規追加時に設定）'),
+      description: z.string().optional().describe('事業所の説明（オプション）'),
+    },
+    async (args) => {
+      try {
+        const { company_id, name, description } = args;
+        
+        await setCurrentCompany(company_id, name, description);
+        
+        const companyInfo = await getCompanyInfo(company_id);
+        
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `事業所を切り替えました:\\n` +
+                    `事業所ID: ${company_id}\\n` +
+                    `事業所名: ${companyInfo?.name || 'Unknown'}\\n` +
+                    `説明: ${companyInfo?.description || 'なし'}\\n\\n` +
+                    `この事業所でAPIを使用するには、freee_authenticate ツールで認証を行ってください。\n\n💡 次のステップ: freee_authenticate → freee_current_user`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `事業所の設定に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'freee_get_current_company',
+    '現在設定されている事業所の情報を表示します。【現在の作業対象事業所の確認用】',
+    {},
+    async () => {
+      try {
+        const companyId = await getCurrentCompanyId();
+        const companyInfo = await getCompanyInfo(companyId);
+        
+        if (!companyInfo) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `現在の事業所ID: ${companyId}\\n事業所情報が見つかりません。`,
+              },
+            ],
+          };
+        }
+        
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `現在の事業所情報:\\n` +
+                    `事業所ID: ${companyInfo.id}\\n` +
+                    `事業所名: ${companyInfo.name}\\n` +
+                    `説明: ${companyInfo.description || 'なし'}\\n` +
+                    `追加日時: ${new Date(companyInfo.addedAt).toLocaleString()}\\n` +
+                    `最終使用: ${companyInfo.lastUsed ? new Date(companyInfo.lastUsed).toLocaleString() : 'なし'}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `事業所情報の取得に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'freee_list_companies',
+    '設定済みの事業所一覧を表示します。最近使用した順に並べられます。【事業所切り替え前の確認用】',
+    {},
+    async () => {
+      try {
+        const companies = await getCompanyList();
+        const currentCompanyId = await getCurrentCompanyId();
+        
+        if (companies.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: '設定済みの事業所がありません。freee_set_company ツールを使用して事業所を追加してください。',
+              },
+            ],
+          };
+        }
+        
+        const companyList = companies
+          .map((company) => {
+            const current = company.id === currentCompanyId ? ' (現在選択中)' : '';
+            const lastUsed = company.lastUsed 
+              ? `最終使用: ${new Date(company.lastUsed).toLocaleString()}`
+              : '未使用';
+            
+            return `• ${company.name} (ID: ${company.id})${current}\\n` +
+                   `  説明: ${company.description || 'なし'}\\n` +
+                   `  ${lastUsed}`;
+          })
+          .join('\\n\\n');
+        
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `設定済み事業所一覧 (${companies.length}件):\\n\\n${companyList}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `事業所一覧の取得に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  // Help and guidance tools
+  server.tool(
+    'freee_help',
+    'freee MCP サーバーの使い方とワークフローガイドを表示します。初めて使用する場合は最初にこのツールを実行してください。',
+    {},
+    async () => {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `# freee MCP サーバー 使い方ガイド
+
+## 📋 基本的なワークフロー
+
+### 1️⃣ 初回セットアップ
+\`freee_getting_started\` - 詳細な初期設定ガイド
+
+### 2️⃣ 事業所管理
+- \`freee_set_company [事業所ID] [名前] [説明]\` - 事業所を追加・切り替え
+- \`freee_get_current_company\` - 現在の事業所情報を確認
+- \`freee_list_companies\` - 設定済み事業所一覧
+
+### 3️⃣ 認証
+- \`freee_authenticate\` - OAuth認証（事業所ごとに必要）
+- \`freee_auth_status\` - 認証状態を確認
+- \`freee_clear_auth\` - 認証情報をクリア
+
+### 4️⃣ API使用
+- \`freee_current_user\` - ユーザー情報とテスト
+- \`get_*\`, \`post_*\`, \`put_*\`, \`delete_*\` - freee API
+
+### 5️⃣ 状態確認
+- \`freee_status\` - 現在の状態と次のアクション提案
+
+## 🚀 典型的な使用例
+
+### 新規事業所の追加
+\`\`\`
+freee_set_company 12345 "本社" "メイン事業所"
+freee_authenticate
+freee_current_user
+\`\`\`
+
+### 事業所の切り替え
+\`\`\`
+freee_list_companies
+freee_set_company 67890
+freee_current_user
+\`\`\`
+
+## ⚠️ 重要なポイント
+
+1. **事業所ごとの認証**: 各事業所で初回に認証が必要
+2. **環境変数**: FREEE_CLIENT_ID, FREEE_CLIENT_SECRET, FREEE_COMPANY_ID（デフォルト用）
+3. **ファイル保存場所**: ~/.config/freee-mcp/
+
+## 🆘 困ったときは
+- \`freee_getting_started\` - 初期設定ガイド
+- \`freee_status\` - 現在の状態確認
+- \`freee_help\` - このガイド（再表示）
+
+詳しくは各ツールの説明を参照してください。`,
+          },
+        ],
+      };
+    }
+  );
+
+  server.tool(
+    'freee_getting_started',
+    '初回セットアップの詳細ガイドを表示します。freee MCP サーバーを初めて使用する際に実行してください。',
+    {},
+    async () => {
+      try {
+        const currentCompanyId = await getCurrentCompanyId();
+        const companyInfo = await getCompanyInfo(currentCompanyId);
+        const tokens = await loadTokens(currentCompanyId);
+        
+        let setupStatus = '';
+        let nextSteps = '';
+        
+        if (!currentCompanyId || currentCompanyId === '0') {
+          setupStatus = '❌ 事業所が設定されていません';
+          nextSteps = '1. freee_set_company [事業所ID] で事業所を設定してください';
+        } else if (!companyInfo) {
+          setupStatus = '⚠️ 事業所情報が不完全です';
+          nextSteps = '1. freee_set_company で事業所情報を再設定してください';
+        } else if (!tokens) {
+          setupStatus = '⚠️ 認証が必要です';
+          nextSteps = '1. freee_authenticate で認証を行ってください';
+        } else {
+          setupStatus = '✅ セットアップ完了';
+          nextSteps = '1. freee_current_user でテストしてください\\n2. get_deals などのAPIツールが使用可能です';
+        }
+        
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `# freee MCP サーバー 初回セットアップガイド
+
+## 🔧 現在の状態
+${setupStatus}
+
+## 📋 セットアップ手順
+
+### 1. 環境変数の確認
+以下の環境変数が設定されている必要があります：
+- \`FREEE_CLIENT_ID\`: freee開発者アプリのクライアントID
+- \`FREEE_CLIENT_SECRET\`: freee開発者アプリのクライアントシークレット  
+- \`FREEE_COMPANY_ID\`: デフォルト事業所ID
+
+### 2. 事業所の設定
+\`\`\`
+freee_set_company [事業所ID] "[事業所名]" "[説明]"
+\`\`\`
+例: \`freee_set_company 12345 "株式会社サンプル" "本社"\`
+
+### 3. 認証の実行
+\`\`\`
+freee_authenticate
+\`\`\`
+- ブラウザが開いて認証画面が表示されます
+- freeeにログインして認証を完了してください
+
+### 4. 動作確認
+\`\`\`
+freee_current_user
+\`\`\`
+
+## 📍 次にすべきこと
+${nextSteps}
+
+## 🏢 複数事業所を使用する場合
+
+### 追加の事業所設定
+\`\`\`
+freee_set_company [別の事業所ID] "[名前]" "[説明]"
+freee_authenticate  # 新しい事業所用の認証
+\`\`\`
+
+### 事業所の切り替え
+\`\`\`
+freee_list_companies        # 一覧表示
+freee_set_company [事業所ID]  # 切り替え
+\`\`\`
+
+## 🔍 状態確認ツール
+- \`freee_status\` - 現在の状態と推奨アクション
+- \`freee_auth_status\` - 認証状態の詳細
+- \`freee_get_current_company\` - 現在の事業所情報
+
+## ❓ トラブルシューティング
+
+### 認証エラーの場合
+1. 環境変数（CLIENT_ID, CLIENT_SECRET）を確認
+2. freee開発者画面でリダイレクトURI設定を確認: \`http://127.0.0.1:8080/callback\`
+3. \`freee_clear_auth\` で認証情報をクリアして再認証
+
+### 事業所IDが分からない場合
+1. freee画面のURLから確認（例: /companies/12345/...）
+2. 既存の認証があれば \`freee_current_user\` で確認可能`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `初回セットアップガイドの表示中にエラーが発生しました: ${error instanceof Error ? error.message : String(error)}\\n\\nまずは環境変数の設定から始めてください。`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'freee_status',
+    '現在のfreee MCP サーバーの状態を確認し、次に実行すべきアクションを提案します。',
+    {},
+    async () => {
+      try {
+        const currentCompanyId = await getCurrentCompanyId();
+        const companyInfo = await getCompanyInfo(currentCompanyId);
+        const tokens = await loadTokens(currentCompanyId);
+        const companies = await getCompanyList();
+        
+        let status = '';
+        let recommendations = '';
+        let warnings = '';
+        
+        // 事業所設定の確認
+        if (!currentCompanyId || currentCompanyId === '0') {
+          status += '❌ **事業所**: 未設定\\n';
+          recommendations += '• freee_set_company [事業所ID] で事業所を設定\\n';
+        } else if (!companyInfo) {
+          status += '⚠️ **事業所**: 設定不完全\\n';
+          recommendations += '• freee_set_company で事業所情報を再設定\\n';
+        } else {
+          status += `✅ **事業所**: ${companyInfo.name} (ID: ${companyInfo.id})\\n`;
+        }
+        
+        // 認証状態の確認
+        if (!tokens) {
+          status += '❌ **認証**: 未認証\\n';
+          recommendations += '• freee_authenticate で認証を実行\\n';
+        } else {
+          const isValid = Date.now() < tokens.expires_at;
+          const expiryDate = new Date(tokens.expires_at).toLocaleString();
+          
+          if (isValid) {
+            status += `✅ **認証**: 有効 (期限: ${expiryDate})\\n`;
+            recommendations += '• freee_current_user でテスト実行\\n• get_deals, get_companies などのAPIツールが使用可能\\n';
+          } else {
+            status += `⚠️ **認証**: 期限切れ (${expiryDate})\\n`;
+            recommendations += '• 次回API実行時に自動更新されます\\n• 手動更新: freee_authenticate\\n';
+          }
+        }
+        
+        // 複数事業所の状況
+        status += `📊 **登録事業所数**: ${companies.length}件\\n`;
+        
+        if (companies.length > 1) {
+          recommendations += '• freee_list_companies で事業所一覧を確認\\n• freee_set_company [ID] で事業所切り替え\\n';
+        } else if (companies.length === 1) {
+          recommendations += '• freee_set_company [新しいID] で追加事業所を登録可能\\n';
+        }
+        
+        // 環境変数の確認
+        if (!config.freee.clientId || !config.freee.clientSecret) {
+          warnings += '⚠️ **環境変数**: FREEE_CLIENT_ID または FREEE_CLIENT_SECRET が未設定\\n';
+        }
+        
+        // 推奨アクションの判定
+        if (currentCompanyId && companyInfo && tokens && Date.now() < tokens.expires_at) {
+          recommendations += '\\n🚀 **すぐに使用可能**: freee APIツールが利用できます\\n';
+          recommendations += '**例**: get_deals, get_companies, get_users, など';
+        }
+        
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `# freee MCP サーバー 状態確認
+
+## 📊 現在の状態
+${status}
+${warnings ? '\\n## ⚠️ 警告\\n' + warnings : ''}
+
+## 📋 推奨アクション
+${recommendations}
+
+## 🆘 ヘルプ
+- \`freee_help\` - 全体的な使い方ガイド
+- \`freee_getting_started\` - 初回セットアップガイド
+- \`freee_list_companies\` - 事業所一覧
+- \`freee_auth_status\` - 認証状態の詳細`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `状態確認中にエラーが発生しました: ${error instanceof Error ? error.message : String(error)}\\n\\n基本的なセットアップから始めてください:\\n1. freee_getting_started\\n2. freee_set_company [事業所ID]\\n3. freee_authenticate`,
             },
           ],
         };


### PR DESCRIPTION
## Summary
- 事業所の動的切り替え機能を実装
- 包括的なMCPガイダンスツール（freee_help、freee_getting_started、freee_status）を追加
- 事業所ごとの認証トークン管理をサポート
- エラーメッセージを改良し、実行可能な提案を追加
- READMEを簡素化し、詳細はMCPツールに委譲

## 主な変更内容

### 🏢 事業所切り替え機能
- `freee_set_company` - 事業所の設定・切り替え
- `freee_get_current_company` - 現在の事業所情報表示
- `freee_list_companies` - 事業所一覧表示
- 事業所ごとの設定管理（~/.config/freee-mcp/config.json）
- 事業所ごとのトークン管理（tokens-{company_id}.json）

### 📚 ガイダンス機能
- `freee_help` - 全体的な使い方ガイド
- `freee_getting_started` - 初回セットアップガイド
- `freee_status` - 現在の状態確認と次のアクション提案
- 既存ツールの説明文にワークフローヒントを追加

### 🔧 技術的改善
- 動的company_id管理（環境変数がデフォルト）
- 既存トークンファイルからの自動マイグレーション
- 後方互換性の維持
- エラーメッセージの改良

## Test plan
- [x] ビルドが正常に完了すること
- [x] TypeScript型チェックが通ること
- [x] ESLintエラーがないこと
- [ ] 新しいMCPツールが正常に動作すること
- [ ] 事業所切り替えが正常に動作すること
- [ ] 既存機能が引き続き動作すること

🤖 Generated with [Claude Code](https://claude.ai/code)