### PR TITLE
feat: prepare package for npm publishing as @him0/freee-mcp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,14 +56,13 @@ This is a Model Context Protocol (MCP) server that exposes freee API endpoints a
 
 To use this MCP server with Claude Code, add the following configuration:
 
-#### Option 1: Development Mode (with watch)
+#### Option 1: NPM Package (Recommended)
 ```json
 {
   "mcpServers": {
     "freee": {
-      "command": "pnpm",
-      "args": ["tsx", "src/index.ts"],
-      "cwd": "/Users/him0/src/freee-mcp",
+      "command": "npx",
+      "args": ["@him0/freee-mcp"],
       "env": {
         "FREEE_CLIENT_ID": "your_client_id_here",
         "FREEE_CLIENT_SECRET": "your_client_secret_here",
@@ -75,17 +74,19 @@ To use this MCP server with Claude Code, add the following configuration:
 }
 ```
 
-#### Option 2: Built Version
+#### Option 2: Development Mode (for contributors)
 ```json
 {
   "mcpServers": {
     "freee": {
-      "command": "node",
-      "args": ["/Users/him0/src/freee-mcp/dist/index.cjs"],
+      "command": "pnpm",
+      "args": ["tsx", "src/index.ts"],
+      "cwd": "/path/to/your/freee-mcp",
       "env": {
         "FREEE_CLIENT_ID": "your_client_id_here",
         "FREEE_CLIENT_SECRET": "your_client_secret_here",
-        "FREEE_COMPANY_ID": "your_company_id_here"
+        "FREEE_COMPANY_ID": "your_company_id_here",
+        "FREEE_CALLBACK_PORT": "8080"
       }
     }
   }

--- a/README-TESTING.md
+++ b/README-TESTING.md
@@ -1,25 +1,29 @@
-# freee MCP Server 動作確認ガイド
+# @him0/freee-mcp 動作確認ガイド
 
-freee MCP Serverの実装したツールの動作確認方法について説明します。
+@him0/freee-mcp パッケージの実装したツールの動作確認方法について説明します。
 
 ## 🚀 動作確認方法
 
-### 1. 簡易ツール情報確認
+### 1. パッケージの動作確認
 
 ```bash
-node scripts/test-tools.js
+# パッケージが正常に実行できるかテスト
+npx @him0/freee-mcp --help
 ```
 
-- 利用可能なツール一覧を表示
-- 主要ツールの存在確認
-- Claude Code設定例の表示
+- パッケージのインストールと実行確認
+- 基本的な動作確認
 
 ### 2. MCP Inspector (推奨)
 
 GUIでツールをテストできる公式ツールです：
 
 ```bash
-pnpm inspector
+# 開発環境の場合
+pnpm dlx @modelcontextprotocol/inspector npx @him0/freee-mcp
+
+# または、一時的にインストールして使用
+npx @modelcontextprotocol/inspector npx @him0/freee-mcp
 ```
 
 これにより：
@@ -28,15 +32,13 @@ pnpm inspector
 - パラメータを入力してツールを実行可能
 - リアルタイムでレスポンスを確認可能
 
-### 3. 本格的なMCPプロトコルテスト
+### 3. Claude Code での実際のテスト
 
-```bash
-node scripts/test-mcp.js
-```
+Claude Code の MCP 設定を使用してテストします。
 
 - MCP JSON-RPC プロトコル経由でツールをテスト
-- インタラクティブモードでツール名を入力してテスト
-- 実際のMCPクライアントと同様の動作
+- 実際のClaude Code環境と同様の動作
+- 認証フローの確認
 
 ## 🔧 主要ツール
 
@@ -65,9 +67,8 @@ node scripts/test-mcp.js
 {
   "mcpServers": {
     "freee": {
-      "command": "pnpm",
-      "args": ["tsx", "src/index.ts"],
-      "cwd": "/Users/him0/src/freee-mcp",
+      "command": "npx",
+      "args": ["@him0/freee-mcp"],
       "env": {
         "FREEE_CLIENT_ID": "your_client_id_here",
         "FREEE_CLIENT_SECRET": "your_client_secret_here",
@@ -118,13 +119,17 @@ export FREEE_CLIENT_SECRET="your_client_secret"
 export FREEE_COMPANY_ID="your_company_id"
 ```
 
-### MCP Inspector が起動しない場合
+### パッケージが見つからない場合
 ```bash
-# パッケージの再インストール
-pnpm install
+# パッケージの存在確認
+npm view @him0/freee-mcp
 
-# 手動でInspectorを起動
-pnpx @modelcontextprotocol/inspector pnpm run start
+# 強制的に最新版を取得
+npx @him0/freee-mcp@latest
+
+# キャッシュクリア
+npm cache clean --force
+npx @him0/freee-mcp
 ```
 
 ## 📈 テスト結果の例

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# freee-mcp
+# @him0/freee-mcp
 
 freee APIをModel Context Protocol (MCP)サーバーとして提供する実装です。OpenAPI定義を使用して、freee APIのエンドポイントを自動的にMCPツールとして公開します。
 
@@ -18,15 +18,20 @@ freee APIをModel Context Protocol (MCP)サーバーとして提供する実装�
 
 ## 必要要件
 
-- Node.js v22
-- pnpm
+- Node.js v22+
 
 ## インストール
 
 ```bash
-git clone [repository-url]
-cd freee-mcp
-pnpm install
+npx @him0/freee-mcp
+```
+
+または、プロジェクトに追加する場合：
+
+```bash
+npm install @him0/freee-mcp
+# または
+pnpm add @him0/freee-mcp
 ```
 
 ## 環境設定
@@ -65,31 +70,23 @@ OAuth 2.0 + PKCE フローを使用した認証が必要です。以下の手順
 4. **自動更新**: アクセストークンの有効期限が切れた場合、リフレッシュトークンを使用して自動的に更新されます
 5. **タイムアウト**: 認証リクエストは5分でタイムアウトします
 
-## 開発
-
-```bash
-# 開発サーバーの起動(ウォッチモード)
-pnpm dev
-
-# ビルド
-pnpm build
-
-# 型チェック
-pnpm type-check
-
-# リント
-pnpm lint
-
-# フォーマット
-pnpm format
-```
-
 ## 使用方法
 
-ビルド後、以下のコマンドでサーバーを起動できます:
+### 単体実行
 
 ```bash
-pnpm start
+npx @him0/freee-mcp
+```
+
+### インストール後の実行
+
+```bash
+# グローバルインストール
+npm install -g @him0/freee-mcp
+freee-mcp
+
+# または
+npx freee-mcp
 ```
 
 ### MCPサーバーとしての登録
@@ -100,8 +97,8 @@ Claude デスクトップアプリケーションで使用するには、以下�
 {
   "mcpServers": {
     "freee": {
-      "command": "/usr/local/bin/node",
-      "args": ["/path/to/freee-mcp/dist/index.cjs"],
+      "command": "npx",
+      "args": ["@him0/freee-mcp"],
       "env": {
         "FREEE_CLIENT_ID": "your_client_id",
         "FREEE_CLIENT_SECRET": "your_client_secret",
@@ -114,6 +111,28 @@ Claude デスクトップアプリケーションで使用するには、以下�
 ```
 
 VSCode拡張機能で使用する場合は、同様の設定を `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` に追加してください。
+
+## 開発者向け
+
+開発に参加する場合は、以下のようにソースからビルドできます：
+
+```bash
+git clone https://github.com/him0/freee-mcp.git
+cd freee-mcp
+pnpm install
+
+# 開発サーバーの起動(ウォッチモード)
+pnpm dev
+
+# ビルド
+pnpm build
+
+# 型チェック
+pnpm type-check
+
+# リント
+pnpm lint
+```
 
 ## 利用可能なツール
 

--- a/TEST_SETUP.md
+++ b/TEST_SETUP.md
@@ -1,6 +1,6 @@
 # Test Setup Documentation
 
-This document outlines the comprehensive test setup implemented for the freee-mcp project using Vitest.
+This document outlines the comprehensive test setup implemented for the @him0/freee-mcp project using Vitest.
 
 ## Testing Framework
 
@@ -122,4 +122,4 @@ pnpm test:ui
 - **Code Coverage**: High coverage across all modules
 - **CI Status**: ✅ All tests passing in GitHub Actions
 
-This test setup ensures code quality, prevents regressions, and provides confidence in the freee-mcp integration functionality.
+This test setup ensures code quality, prevents regressions, and provides confidence in the @him0/freee-mcp integration functionality.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "name": "freee-mcp",
+  "name": "@him0/freee-mcp",
   "version": "0.2.0",
   "main": "dist/index.js",
   "bin": {
@@ -24,7 +24,7 @@
   },
   "author": "him0",
   "license": "ISC",
-  "description": "",
+  "description": "Model Context Protocol (MCP) server for freee API integration",
   "devDependencies": {
     "@modelcontextprotocol/inspector": "^0.14.2",
     "@types/crypto-js": "^4.2.2",
@@ -47,5 +47,22 @@
     "open": "^10.1.0",
     "zod": "^3.25.64"
   },
-  "packageManager": "pnpm@10.12.1"
+  "packageManager": "pnpm@10.12.1",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "freee",
+    "api",
+    "accounting",
+    "claude"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/him0/freee-mcp.git"
+  },
+  "files": [
+    "dist/",
+    "bin/",
+    "README.md"
+  ]
 }


### PR DESCRIPTION
## Summary
- Update package.json with scoped name @him0/freee-mcp and add essential npm metadata
- Update all documentation to use npx @him0/freee-mcp for installation and usage
- Restructure documentation to separate development and production usage patterns
- Update MCP configuration examples to use npm package instead of local builds

## Changes Made
- **package.json**: Added scoped name, description, keywords, repository URL, and files field
- **README.md**: Updated installation instructions to use `npx @him0/freee-mcp`, separated dev/prod usage
- **CLAUDE.md**: Updated MCP configuration examples for npm package usage
- **README-TESTING.md**: Updated testing instructions for npm package
- **TEST_SETUP.md**: Updated project name references

## Test Plan
- [x] All existing tests pass locally
- [x] Package builds successfully with `pnpm build`
- [x] Type checking passes with `pnpm type-check`
- [x] Linting passes with `pnpm lint`
- [ ] Verify npm publish works with `npm publish --access public` (after merge)
- [ ] Test npx installation after publishing

🤖 Generated with [Claude Code](https://claude.ai/code)