### PR TITLE
Fix MCP schema validation error by sanitizing property names

### DIFF
--- a/src/openapi/converter.ts
+++ b/src/openapi/converter.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import freeeApiSchema from '../data/freee-api-schema.json';
 import { OpenAPIOperation, OpenAPIPathItem, OpenAPIParameter } from '../api/types.js';
-import { convertParameterToZodSchema, convertPathToToolName } from './schema.js';
+import { convertParameterToZodSchema, convertPathToToolName, sanitizePropertyName } from './schema.js';
 import { makeApiRequest } from '../api/client.js';
 
 export function generateToolsFromOpenApi(server: McpServer): void {
@@ -20,7 +20,7 @@ export function generateToolsFromOpenApi(server: McpServer): void {
 
       const pathParams = operation.parameters?.filter((p) => p.in === 'path') || [];
       pathParams.forEach((param) => {
-        parameterSchema[param.name] = convertParameterToZodSchema(param);
+        parameterSchema[sanitizePropertyName(param.name)] = convertParameterToZodSchema(param);
       });
 
       const queryParams = operation.parameters?.filter((p) => p.in === 'query') || [];
@@ -29,7 +29,7 @@ export function generateToolsFromOpenApi(server: McpServer): void {
         if (param.name === 'company_id') {
           schema = schema.optional();
         }
-        parameterSchema[param.name] = schema;
+        parameterSchema[sanitizePropertyName(param.name)] = schema;
       });
 
       let bodySchema = z.any();

--- a/src/openapi/schema.ts
+++ b/src/openapi/schema.ts
@@ -47,3 +47,10 @@ export function convertPathToToolName(path: string): string {
 
   return toolName;
 }
+
+export function sanitizePropertyName(name: string): string {
+  // MCP property names must match pattern '^[a-zA-Z0-9_.-]{1,64}$'
+  return name
+    .replace(/[^a-zA-Z0-9_.-]/g, '_') // Replace invalid characters with underscore
+    .substring(0, 64); // Limit to 64 characters
+}


### PR DESCRIPTION
## Summary

- Fix MCP schema validation error that occurs when using `.mcp.json` configuration
- Add `sanitizePropertyName()` function to ensure property names match MCP pattern `^[a-zA-Z0-9_.-]{1,64}$`
- Apply sanitization to both path and query parameters in tool generation

## Problem

Fixes #15 - When using freee-mcp with Claude Code, API Error 400 occurs due to property names that don't conform to MCP's strict naming requirements.

## Solution

- Added `sanitizePropertyName()` function in `src/openapi/schema.ts`
- Modified `src/openapi/converter.ts` to apply sanitization to parameter names
- Ensures compatibility with current and future MCP framework versions

## Test plan

- [x] Build succeeds without errors
- [x] MCP tools generate with valid property names
- [x] Claude Code `.mcp.json` configuration works without errors

🤖 Generated with [Claude Code](https://claude.ai/code)