### PR TITLE
refactor: separate version bump PR and npm publish workflows

### DIFF
--- a/.github/workflows/publish-after-merge.yml
+++ b/.github/workflows/publish-after-merge.yml
@@ -1,0 +1,117 @@
+name: Publish After Version Bump Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        fetch-depth: 0
+      
+    - name: Configure git
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+      
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'pnpm'
+        registry-url: 'https://registry.npmjs.org'
+        
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+      
+    - name: Build project
+      run: pnpm build
+        
+    - name: Get version from package.json
+      id: version
+      run: |
+        VERSION=$(node -e "console.log(require('./package.json').version)")
+        echo "version=${VERSION}" >> $GITHUB_OUTPUT
+        
+    - name: Check if version is already published
+      id: check_published
+      run: |
+        if npm view @him0/freee-mcp@${{ steps.version.outputs.version }} version 2>/dev/null; then
+          echo "already_published=true" >> $GITHUB_OUTPUT
+          echo "Version ${{ steps.version.outputs.version }} is already published to npm"
+        else
+          echo "already_published=false" >> $GITHUB_OUTPUT
+          echo "Version ${{ steps.version.outputs.version }} is not yet published"
+        fi
+        
+    - name: Publish to npm (dry run)
+      if: steps.check_published.outputs.already_published != 'true'
+      run: npm publish --dry-run --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        
+    - name: Publish to npm
+      if: steps.check_published.outputs.already_published != 'true'
+      run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        
+    - name: Create tag
+      if: steps.check_published.outputs.already_published != 'true'
+      run: |
+        # Check if tag already exists
+        if git rev-parse v${{ steps.version.outputs.version }} >/dev/null 2>&1; then
+          echo "Tag v${{ steps.version.outputs.version }} already exists"
+        else
+          git tag v${{ steps.version.outputs.version }}
+          git push origin v${{ steps.version.outputs.version }}
+        fi
+        
+    - name: Generate release notes
+      if: steps.check_published.outputs.already_published != 'true'
+      id: release_notes
+      run: |
+        VERSION=${{ steps.version.outputs.version }}
+        PREVIOUS_TAG=$(git describe --abbrev=0 --tags HEAD^ 2>/dev/null || echo "")
+        
+        echo "## What's Changed" > release_notes.md
+        echo "" >> release_notes.md
+        
+        if [ -n "$PREVIOUS_TAG" ]; then
+          git log ${PREVIOUS_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges | grep -v "^- chore: bump version" >> release_notes.md || echo "- Various improvements and fixes" >> release_notes.md
+        else
+          echo "Initial release" >> release_notes.md
+        fi
+        
+        echo "" >> release_notes.md
+        echo "" >> release_notes.md
+        echo "## Package" >> release_notes.md
+        echo "- npm: https://www.npmjs.com/package/@him0/freee-mcp/v/${VERSION}" >> release_notes.md
+        echo "- Install: \`npm install @him0/freee-mcp@${VERSION}\`" >> release_notes.md
+        
+    - name: Create GitHub Release
+      if: steps.check_published.outputs.already_published != 'true'
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: v${{ steps.version.outputs.version }}
+        name: v${{ steps.version.outputs.version }}
+        body_path: release_notes.md
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release and Publish
+name: Create Version Bump PR
 
 on:
   workflow_dispatch:
@@ -14,12 +14,11 @@ on:
           - major
 
 jobs:
-  publish:
+  create-version-pr:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-      packages: write
     
     steps:
     - name: Checkout code
@@ -41,7 +40,6 @@ jobs:
       with:
         node-version: 20
         cache: 'pnpm'
-        registry-url: 'https://registry.npmjs.org'
         
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
@@ -87,54 +85,8 @@ jobs:
       run: |
         git push origin ${{ steps.branch.outputs.branch_name }}
         
-    - name: Publish to npm (dry run)
-      run: npm publish --dry-run --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        
-    - name: Publish to npm
-      run: npm publish --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        
-    - name: Create tag
-      run: |
-        git tag v${{ steps.version.outputs.new_version }}
-        git push origin v${{ steps.version.outputs.new_version }}
-        
-    - name: Generate release notes
-      id: release_notes
-      run: |
-        VERSION=${{ steps.version.outputs.new_version }}
-        PREVIOUS_TAG=$(git describe --abbrev=0 --tags HEAD^ 2>/dev/null || echo "")
-        
-        echo "## What's Changed" > release_notes.md
-        echo "" >> release_notes.md
-        
-        if [ -n "$PREVIOUS_TAG" ]; then
-          git log ${PREVIOUS_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges | grep -v "^- chore: bump version" >> release_notes.md || echo "- Various improvements and fixes" >> release_notes.md
-        else
-          echo "Initial release" >> release_notes.md
-        fi
-        
-        echo "" >> release_notes.md
-        echo "" >> release_notes.md
-        echo "## Package" >> release_notes.md
-        echo "- npm: https://www.npmjs.com/package/@him0/freee-mcp/v/${VERSION}" >> release_notes.md
-        echo "- Install: \`npm install @him0/freee-mcp@${VERSION}\`" >> release_notes.md
-        
-    - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
-      with:
-        tag_name: v${{ steps.version.outputs.new_version }}
-        name: v${{ steps.version.outputs.new_version }}
-        body_path: release_notes.md
-        draft: false
-        prerelease: false
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
     - name: Create Pull Request
+      id: pr
       uses: peter-evans/create-pull-request@v5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -144,15 +96,20 @@ jobs:
         body: |
           ## Version Bump
           
-          This PR updates the version to `${{ steps.version.outputs.new_version }}` after successful npm publish.
+          This PR updates the version to `${{ steps.version.outputs.new_version }}`.
           
           ### Changes
-          - Updated version in package.json
-          - Published to npm: https://www.npmjs.com/package/@him0/freee-mcp/v/${{ steps.version.outputs.new_version }}
-          - Created release: https://github.com/${{ github.repository }}/releases/tag/v${{ steps.version.outputs.new_version }}
+          - Updated version in package.json to ${{ steps.version.outputs.new_version }}
           
           ### Next Steps
-          Please merge this PR to update the main branch with the new version.
+          1. Review and merge this PR
+          2. After merge, the npm publish job will automatically run
+          3. A GitHub release will be created
+          
+          ### Pre-publish Checklist
+          - [ ] Version number is correct
+          - [ ] All tests pass
+          - [ ] Build artifacts are generated correctly
         labels: |
           release
           automated


### PR DESCRIPTION
## Summary
- Split the release workflow into two separate workflows for better control
- Version bump PR is created first, then npm publish happens after merge
- Adds safeguards to prevent duplicate publishes

## Changes
1. **Modified `release.yml`**:
   - Renamed to "Create Version Bump PR"
   - Removed npm publish steps
   - Only creates PR with version changes

2. **Added `publish-after-merge.yml`**:
   - Triggers on PR merge with `release` label
   - Handles npm publish, tag creation, and GitHub release
   - Includes checks to prevent duplicate publishes

## Benefits
- Version changes are reviewed before publishing
- Clear separation of concerns
- Better error handling and recovery
- Prevents accidental duplicate publishes

## Test Plan
1. [ ] Run the release workflow to create a version bump PR
2. [ ] Merge the PR and verify npm publish happens automatically
3. [ ] Verify GitHub release and tags are created correctly

🤖 Generated with [Claude Code](https://claude.ai/code)