### PR TITLE
fix: use create-pull-request action correctly to ensure package.json commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,6 @@ jobs:
         test -f dist/index.d.ts
         test -f bin/cli.js
         
-    - name: Create release branch
-      id: branch
-      run: |
-        BRANCH_NAME="release/v${{ github.event.inputs.version }}-$(date +%Y%m%d%H%M%S)"
-        git checkout -b $BRANCH_NAME
-        echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
-        
     - name: Bump version
       id: version
       run: |
@@ -78,20 +71,16 @@ jobs:
         NEW_VERSION=$(node -e "console.log(require('./package.json').version)")
         echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
         
-        git add package.json
-        git commit -m "chore: bump version to ${NEW_VERSION}"
-        
-    - name: Push release branch
-      run: |
-        git push origin ${{ steps.branch.outputs.branch_name }}
-        
     - name: Create Pull Request
       id: pr
       uses: peter-evans/create-pull-request@v5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        branch: ${{ steps.branch.outputs.branch_name }}
+        branch: release/v${{ steps.version.outputs.new_version }}-${{ github.run_number }}
         base: main
+        commit-message: "chore: bump version to ${{ steps.version.outputs.new_version }}"
+        add-paths: |
+          package.json
         title: "chore: bump version to ${{ steps.version.outputs.new_version }}"
         body: |
           ## Version Bump


### PR DESCRIPTION
## Summary
- Fixed release workflow to properly commit package.json updates to PR branch
- Removed redundant manual git operations that were conflicting with create-pull-request action

## Problem
The release workflow was using both manual git operations (branch creation, commit, push) and the `create-pull-request` action, which caused confusion. The `create-pull-request` action expects to handle all git operations itself.

## Solution
- Removed manual branch creation and push steps
- Simplified version bump step to only run `npm version`
- Configured `create-pull-request` action with:
  - Dynamic branch naming using version and run number
  - Explicit commit message
  - `add-paths` parameter to track package.json changes

## Test plan
- [ ] Trigger the release workflow manually
- [ ] Verify that a PR is created with the package.json version update
- [ ] Confirm the commit is properly included in the PR branch

🤖 Generated with [Claude Code](https://claude.ai/code)