### PR TITLE
fix: implement dynamic port allocation for OAuth callback server

### DIFF
--- a/src/auth/oauth.test.ts
+++ b/src/auth/oauth.test.ts
@@ -96,7 +96,7 @@ describe('oauth', () => {
         json: () => Promise.resolve(mockTokenResponse)
       });
 
-      const result = await exchangeCodeForTokens('test-code', 'test-verifier');
+      const result = await exchangeCodeForTokens('test-code', 'test-verifier', 'http://127.0.0.1:8080/callback');
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://accounts.secure.freee.co.jp/public_api/token',
@@ -132,7 +132,7 @@ describe('oauth', () => {
         json: () => Promise.resolve({ error: 'invalid_grant' })
       });
 
-      await expect(exchangeCodeForTokens('invalid-code', 'test-verifier'))
+      await expect(exchangeCodeForTokens('invalid-code', 'test-verifier', 'http://127.0.0.1:8080/callback'))
         .rejects.toThrow('Token exchange failed: 400');
     });
 
@@ -148,7 +148,7 @@ describe('oauth', () => {
         json: () => Promise.resolve(mockTokenResponse)
       });
 
-      const result = await exchangeCodeForTokens('test-code', 'test-verifier');
+      const result = await exchangeCodeForTokens('test-code', 'test-verifier', 'http://127.0.0.1:8080/callback');
 
       expect(result.token_type).toBe('Bearer');
       expect(result.scope).toBe('read write');

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -22,7 +22,7 @@ export function buildAuthUrl(codeChallenge: string, state: string, redirectUri: 
   return `${config.oauth.authorizationEndpoint}?${params.toString()}`;
 }
 
-export async function exchangeCodeForTokens(code: string, codeVerifier: string): Promise<TokenData> {
+export async function exchangeCodeForTokens(code: string, codeVerifier: string, redirectUri: string): Promise<TokenData> {
   const response = await fetch(config.oauth.tokenEndpoint, {
     method: 'POST',
     headers: {
@@ -33,7 +33,7 @@ export async function exchangeCodeForTokens(code: string, codeVerifier: string):
       client_id: config.freee.clientId,
       client_secret: config.freee.clientSecret,
       code,
-      redirect_uri: config.oauth.redirectUri,
+      redirect_uri: redirectUri,
       code_verifier: codeVerifier,
     }),
   });

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -44,7 +44,8 @@ vi.mock('../auth/oauth.js', () => ({
 }));
 
 vi.mock('../auth/server.js', () => ({
-  registerAuthenticationRequest: vi.fn()
+  registerAuthenticationRequest: vi.fn(),
+  getActualRedirectUri: vi.fn()
 }));
 
 const mockCrypto = vi.mocked(crypto);
@@ -125,6 +126,7 @@ describe('tools', () => {
           codeChallenge: 'test-challenge'
         });
         vi.mocked(mockBuildAuthUrl.buildAuthUrl).mockReturnValue('https://auth.url');
+        vi.mocked(mockRegisterAuthenticationRequest.getActualRedirectUri).mockReturnValue('http://127.0.0.1:8080/callback');
         mockCrypto.randomBytes = vi.fn().mockReturnValue({
           toString: vi.fn().mockReturnValue('test-state-hex')
         });
@@ -135,6 +137,7 @@ describe('tools', () => {
         const result = await handler();
 
         expect(mockGeneratePKCE.generatePKCE).toHaveBeenCalled();
+        expect(mockRegisterAuthenticationRequest.getActualRedirectUri).toHaveBeenCalled();
         expect(mockBuildAuthUrl.buildAuthUrl).toHaveBeenCalledWith(
           'test-challenge',
           'test-state-hex',

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -5,7 +5,7 @@ import { config } from '../config.js';
 import { makeApiRequest } from '../api/client.js';
 import { loadTokens, clearTokens } from '../auth/tokens.js';
 import { generatePKCE, buildAuthUrl } from '../auth/oauth.js';
-import { registerAuthenticationRequest } from '../auth/server.js';
+import { registerAuthenticationRequest, getActualRedirectUri } from '../auth/server.js';
 import {
   getCurrentCompanyId,
   setCurrentCompany,
@@ -99,7 +99,7 @@ export function addAuthenticationTools(server: McpServer): void {
 
         const { codeVerifier, codeChallenge } = generatePKCE();
         const state = crypto.randomBytes(16).toString('hex');
-        const authUrl = buildAuthUrl(codeChallenge, state, config.oauth.redirectUri);
+        const authUrl = buildAuthUrl(codeChallenge, state, getActualRedirectUri());
 
         registerAuthenticationRequest(state, codeVerifier);
 


### PR DESCRIPTION
Resolves #21

## Summary
- Implemented dynamic port allocation for OAuth callback server
- Multiple MCP server instances can now run simultaneously without port conflicts
- Automatic fallback to next available port when preferred port is occupied

## Changes
- Added `findAvailablePort()` function to scan for available ports
- Added `getActualRedirectUri()` and `getActualCallbackPort()` functions
- Updated OAuth flow to use dynamically allocated redirect URIs
- Updated all test cases to handle new function signatures

## Test Plan
- [x] Run pre-flight checks (type-check, lint, test, build)
- [ ] Test single instance startup (should use port 8080)
- [ ] Test multiple instances simultaneously (should use different ports)

🤖 Generated with [Claude Code](https://claude.ai/code)