### PR TITLE
Change default OAuth callback port from 8080 to 54321

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ This is a Model Context Protocol (MCP) server that exposes freee API endpoints a
 - `FREEE_CLIENT_ID` (required) - freee OAuth client ID
 - `FREEE_CLIENT_SECRET` (required) - freee OAuth client secret
 - `FREEE_COMPANY_ID` (required) - freee company ID
-- `FREEE_CALLBACK_PORT` (optional) - OAuth callback port, defaults to 8080
+- `FREEE_CALLBACK_PORT` (optional) - OAuth callback port, defaults to 54321
 
 ### Claude Code MCP Configuration
 
@@ -67,7 +67,7 @@ To use this MCP server with Claude Code, add the following configuration:
         "FREEE_CLIENT_ID": "your_client_id_here",
         "FREEE_CLIENT_SECRET": "your_client_secret_here",
         "FREEE_COMPANY_ID": "your_company_id_here",
-        "FREEE_CALLBACK_PORT": "8080"
+        "FREEE_CALLBACK_PORT": "54321"
       }
     }
   }
@@ -86,7 +86,7 @@ To use this MCP server with Claude Code, add the following configuration:
         "FREEE_CLIENT_ID": "your_client_id_here",
         "FREEE_CLIENT_SECRET": "your_client_secret_here",
         "FREEE_COMPANY_ID": "your_company_id_here",
-        "FREEE_CALLBACK_PORT": "8080"
+        "FREEE_CALLBACK_PORT": "54321"
       }
     }
   }

--- a/README-TESTING.md
+++ b/README-TESTING.md
@@ -73,7 +73,7 @@ Claude Code の MCP 設定を使用してテストします。
         "FREEE_CLIENT_ID": "your_client_id_here",
         "FREEE_CLIENT_SECRET": "your_client_secret_here",
         "FREEE_COMPANY_ID": "your_company_id_here",
-        "FREEE_CALLBACK_PORT": "8080"
+        "FREEE_CALLBACK_PORT": "54321"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ OAuth 2.0 + PKCE フローを使用した認証が必要です。以下の手順
   - [freee アプリストア](https://app.secure.freee.co.jp/developers) にアクセス
   - 新しいアプリケーションを作成
   - 以下の設定を行う:
-    - **リダイレクトURI**: `http://127.0.0.1:8080/callback` （デフォルトポート、環境変数で変更可能）
+    - **リダイレクトURI**: `http://127.0.0.1:54321/callback` （デフォルトポート、環境変数で変更可能）
     - アプリケーションの **Client ID** と **Client Secret** を取得
     - **権限設定**: 必要な機能の 参照・更新 にチェックを入れる
 
@@ -54,7 +54,7 @@ OAuth 2.0 + PKCE フローを使用した認証が必要です。以下の手順
    FREEE_CLIENT_ID=your_client_id          # 必須: freeeアプリの Client ID
    FREEE_CLIENT_SECRET=your_client_secret  # 必須: freeeアプリの Client Secret
    FREEE_COMPANY_ID=your_company_id        # 必須: デフォルト事業所ID
-   FREEE_CALLBACK_PORT=8080                # オプション: OAuthコールバックポート、デフォルトは 8080
+   FREEE_CALLBACK_PORT=54321               # オプション: OAuthコールバックポート、デフォルトは 54321
    ```
 
    **注意**: `FREEE_COMPANY_ID` はデフォルト事業所として使用されます。実行時に `freee_set_company` ツールで他の事業所に切り替えることができます。
@@ -64,7 +64,7 @@ OAuth 2.0 + PKCE フローを使用した認証が必要です。以下の手順
 
 ### 認証の仕組み
 
-1. **永続コールバックサーバー**: MCPサーバー起動時に指定ポート（デフォルト8080）でOAuthコールバック受付サーバーが起動します
+1. **永続コールバックサーバー**: MCPサーバー起動時に指定ポート（デフォルト54321）でOAuthコールバック受付サーバーが起動します
 2. **認証フロー**: `freee_authenticate` ツール実行時にブラウザで認証ページが開き、認証後にコールバックを受信します
 3. **トークン保存**: 認証後、トークンは `~/.config/freee-mcp/tokens.json` にユーザーベースで安全に保存されます（ファイル権限600）
 4. **自動更新**: アクセストークンの有効期限が切れた場合、リフレッシュトークンを使用して自動的に更新されます
@@ -103,7 +103,7 @@ Claude デスクトップアプリケーションで使用するには、以下�
         "FREEE_CLIENT_ID": "your_client_id",
         "FREEE_CLIENT_SECRET": "your_client_secret",
         "FREEE_COMPANY_ID": "your_company_id",
-        "FREEE_CALLBACK_PORT": "8080"
+        "FREEE_CALLBACK_PORT": "54321"
       }
     }
   }

--- a/scripts/test-tools.js
+++ b/scripts/test-tools.js
@@ -88,7 +88,7 @@ async function testFreeeTools() {
           "FREEE_CLIENT_ID": "your_client_id_here",
           "FREEE_CLIENT_SECRET": "your_client_secret_here", 
           "FREEE_COMPANY_ID": "your_company_id_here",
-          "FREEE_CALLBACK_PORT": "8080"
+          "FREEE_CALLBACK_PORT": "54321"
         }
       }
     }

--- a/src/auth/oauth.test.ts
+++ b/src/auth/oauth.test.ts
@@ -12,7 +12,7 @@ vi.mock('../config.js', () => ({
     oauth: {
       authorizationEndpoint: 'https://accounts.secure.freee.co.jp/public_api/authorize',
       tokenEndpoint: 'https://accounts.secure.freee.co.jp/public_api/token',
-      redirectUri: 'http://127.0.0.1:8080/callback',
+      redirectUri: 'http://127.0.0.1:54321/callback',
       scope: 'read write'
     }
   }
@@ -66,14 +66,14 @@ describe('oauth', () => {
     it('should build correct authorization URL', () => {
       const codeChallenge = 'test-challenge';
       const state = 'test-state';
-      const redirectUri = 'http://127.0.0.1:8080/callback';
+      const redirectUri = 'http://127.0.0.1:54321/callback';
 
       const result = buildAuthUrl(codeChallenge, state, redirectUri);
 
       expect(result).toContain('https://accounts.secure.freee.co.jp/public_api/authorize');
       expect(result).toContain('response_type=code');
       expect(result).toContain('client_id=test-client-id');
-      expect(result).toContain('redirect_uri=http%3A%2F%2F127.0.0.1%3A8080%2Fcallback');
+      expect(result).toContain('redirect_uri=http%3A%2F%2F127.0.0.1%3A54321%2Fcallback');
       expect(result).toContain('scope=read+write');
       expect(result).toContain('state=test-state');
       expect(result).toContain('code_challenge=test-challenge');
@@ -96,7 +96,7 @@ describe('oauth', () => {
         json: () => Promise.resolve(mockTokenResponse)
       });
 
-      const result = await exchangeCodeForTokens('test-code', 'test-verifier', 'http://127.0.0.1:8080/callback');
+      const result = await exchangeCodeForTokens('test-code', 'test-verifier', 'http://127.0.0.1:54321/callback');
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://accounts.secure.freee.co.jp/public_api/token',
@@ -110,7 +110,7 @@ describe('oauth', () => {
             client_id: 'test-client-id',
             client_secret: 'test-client-secret',
             code: 'test-code',
-            redirect_uri: 'http://127.0.0.1:8080/callback',
+            redirect_uri: 'http://127.0.0.1:54321/callback',
             code_verifier: 'test-verifier',
           }),
         }
@@ -132,7 +132,7 @@ describe('oauth', () => {
         json: () => Promise.resolve({ error: 'invalid_grant' })
       });
 
-      await expect(exchangeCodeForTokens('invalid-code', 'test-verifier', 'http://127.0.0.1:8080/callback'))
+      await expect(exchangeCodeForTokens('invalid-code', 'test-verifier', 'http://127.0.0.1:54321/callback'))
         .rejects.toThrow('Token exchange failed: 400');
     });
 
@@ -148,7 +148,7 @@ describe('oauth', () => {
         json: () => Promise.resolve(mockTokenResponse)
       });
 
-      const result = await exchangeCodeForTokens('test-code', 'test-verifier', 'http://127.0.0.1:8080/callback');
+      const result = await exchangeCodeForTokens('test-code', 'test-verifier', 'http://127.0.0.1:54321/callback');
 
       expect(result.token_type).toBe('Bearer');
       expect(result.scope).toBe('read write');

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-const CALLBACK_PORT = parseInt(process.env.FREEE_CALLBACK_PORT || '8080', 10);
+const CALLBACK_PORT = parseInt(process.env.FREEE_CALLBACK_PORT || '54321', 10);
 
 export const config = {
   freee: {

--- a/src/mcp/handlers.test.ts
+++ b/src/mcp/handlers.test.ts
@@ -19,7 +19,7 @@ vi.mock('../config.js', () => ({
       version: '1.0.0'
     },
     oauth: {
-      callbackPort: 8080
+      callbackPort: 54321
     }
   }
 }));

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -12,8 +12,8 @@ vi.mock('../config.js', () => ({
       companyId: '12345'
     },
     oauth: {
-      redirectUri: 'http://127.0.0.1:8080/callback',
-      callbackPort: 8080
+      redirectUri: 'http://127.0.0.1:54321/callback',
+      callbackPort: 54321
     }
   }
 }));
@@ -126,7 +126,7 @@ describe('tools', () => {
           codeChallenge: 'test-challenge'
         });
         vi.mocked(mockBuildAuthUrl.buildAuthUrl).mockReturnValue('https://auth.url');
-        vi.mocked(mockRegisterAuthenticationRequest.getActualRedirectUri).mockReturnValue('http://127.0.0.1:8080/callback');
+        vi.mocked(mockRegisterAuthenticationRequest.getActualRedirectUri).mockReturnValue('http://127.0.0.1:54321/callback');
         mockCrypto.randomBytes = vi.fn().mockReturnValue({
           toString: vi.fn().mockReturnValue('test-state-hex')
         });
@@ -141,7 +141,7 @@ describe('tools', () => {
         expect(mockBuildAuthUrl.buildAuthUrl).toHaveBeenCalledWith(
           'test-challenge',
           'test-state-hex',
-          'http://127.0.0.1:8080/callback'
+          'http://127.0.0.1:54321/callback'
         );
         expect(mockRegisterAuthenticationRequest.registerAuthenticationRequest).toHaveBeenCalledWith(
           'test-state-hex',

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -565,7 +565,7 @@ freee_set_company [事業所ID]  # 切り替え
 
 ### 認証エラーの場合
 1. 環境変数（CLIENT_ID, CLIENT_SECRET）を確認
-2. freee開発者画面でリダイレクトURI設定を確認: \`http://127.0.0.1:8080/callback\`
+2. freee開発者画面でリダイレクトURI設定を確認: \`http://127.0.0.1:54321/callback\`
 3. \`freee_clear_auth\` で認証情報をクリアして再認証
 
 ### 事業所IDが分からない場合

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
       FREEE_CLIENT_ID: 'test-client-id',
       FREEE_CLIENT_SECRET: 'test-client-secret',
       FREEE_COMPANY_ID: '12345',
-      FREEE_CALLBACK_PORT: '8080'
+      FREEE_CALLBACK_PORT: '54321'
     },
     // テスト実行時のセットアップ
     setupFiles: ['src/test-utils/setup.ts'],


### PR DESCRIPTION
- Update default port in src/config.ts to avoid conflicts with common development servers
- Update all documentation (README.md, CLAUDE.md, README-TESTING.md) with new port
- Update all test files to use new port number
- Update error messages and example configurations

The port 54321 was chosen as it's in a less commonly used range and less likely to conflict with other development tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default OAuth callback port from 8080 to 54321. Users need to update their Freee API redirect URI configuration from `http://127.0.0.1:8080/callback` to `http://127.0.0.1:54321/callback`. Ensure the `FREEE_CALLBACK_PORT` environment variable is set to `54321` in your deployment and local development configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->