### PR TITLE
Update Company ID Variable Name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ MCP server that exposes freee API endpoints as MCP tools:
 
 - `FREEE_CLIENT_ID` (required) - OAuth client ID
 - `FREEE_CLIENT_SECRET` (required) - OAuth client secret
-- `FREEE_COMPANY_ID` (required) - Company ID
+- `FREEE_DEFAULT_COMPANY_ID` (required) - Company ID
 - `FREEE_CALLBACK_PORT` (optional) - OAuth callback port, defaults to 54321
 
 ### MCP Configuration
@@ -41,7 +41,7 @@ Add to Claude Code config:
       "env": {
         "FREEE_CLIENT_ID": "your_client_id",
         "FREEE_CLIENT_SECRET": "your_client_secret",
-        "FREEE_COMPANY_ID": "your_company_id",
+        "FREEE_DEFAULT_COMPANY_ID": "your_company_id",
         "FREEE_CALLBACK_PORT": "54321"
       }
     }

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ OAuth 2.0 + PKCE フローを使用した認証が必要です。以下の手順
    ```bash
    FREEE_CLIENT_ID=your_client_id          # 必須: freeeアプリの Client ID
    FREEE_CLIENT_SECRET=your_client_secret  # 必須: freeeアプリの Client Secret
-   FREEE_COMPANY_ID=your_company_id        # 必須: デフォルト事業所ID
+   FREEE_DEFAULT_COMPANY_ID=your_company_id        # 必須: デフォルト事業所ID
    FREEE_CALLBACK_PORT=54321               # オプション: OAuthコールバックポート、デフォルトは 54321
    ```
 
-   **注意**: `FREEE_COMPANY_ID` はデフォルト事業所として使用されます。実行時に `freee_set_company` ツールで他の事業所に切り替えることができます。
+   **注意**: `FREEE_DEFAULT_COMPANY_ID` はデフォルト事業所として使用されます。実行時に `freee_set_company` ツールで他の事業所に切り替えることができます。
 
 3. **認証方法**:
    初回API使用時またはトークンの有効期限切れ時に、`freee_authenticate` ツールを使用して認証を行います。一度認証すると、同じトークンで複数の事業所にアクセスできます。
@@ -102,7 +102,7 @@ Claude デスクトップアプリケーションで使用するには、以下�
       "env": {
         "FREEE_CLIENT_ID": "your_client_id",
         "FREEE_CLIENT_SECRET": "your_client_secret",
-        "FREEE_COMPANY_ID": "your_company_id",
+        "FREEE_DEFAULT_COMPANY_ID": "your_company_id",
         "FREEE_CALLBACK_PORT": "54321"
       }
     }

--- a/scripts/test-tools.js
+++ b/scripts/test-tools.js
@@ -86,8 +86,8 @@ async function testFreeeTools() {
         "cwd": process.cwd(),
         "env": {
           "FREEE_CLIENT_ID": "your_client_id_here",
-          "FREEE_CLIENT_SECRET": "your_client_secret_here", 
-          "FREEE_COMPANY_ID": "your_company_id_here",
+          "FREEE_CLIENT_SECRET": "your_client_secret_here",
+          "FREEE_DEFAULT_COMPANY_ID": "your_company_id_here",
           "FREEE_CALLBACK_PORT": "54321"
         }
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ export const config = {
   freee: {
     clientId: process.env.FREEE_CLIENT_ID || '',
     clientSecret: process.env.FREEE_CLIENT_SECRET || '',
-    companyId: process.env.FREEE_COMPANY_ID || '0',
+    companyId: process.env.FREEE_DEFAULT_COMPANY_ID || '0',
     apiUrl: 'https://api.freee.co.jp',
   },
   oauth: {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -462,7 +462,7 @@ freee_current_user
 ## ⚠️ 重要なポイント
 
 1. **ユーザー認証**: 初回に一度認証が必要（全事業所で共通）
-2. **環境変数**: FREEE_CLIENT_ID, FREEE_CLIENT_SECRET, FREEE_COMPANY_ID（デフォルト用）
+2. **環境変数**: FREEE_CLIENT_ID, FREEE_CLIENT_SECRET, FREEE_DEFAULT_COMPANY_ID（デフォルト用）
 3. **ファイル保存場所**: ~/.config/freee-mcp/
 
 ## 🆘 困ったときは
@@ -519,7 +519,7 @@ ${setupStatus}
 以下の環境変数が設定されている必要があります：
 - \`FREEE_CLIENT_ID\`: freee開発者アプリのクライアントID
 - \`FREEE_CLIENT_SECRET\`: freee開発者アプリのクライアントシークレット
-- \`FREEE_COMPANY_ID\`: デフォルト事業所ID
+- \`FREEE_DEFAULT_COMPANY_ID\`: デフォルト事業所ID
 
 ### 2. 事業所の設定
 \`\`\`

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
       // テスト用のデフォルト値を設定
       FREEE_CLIENT_ID: 'test-client-id',
       FREEE_CLIENT_SECRET: 'test-client-secret',
-      FREEE_COMPANY_ID: '12345',
+      FREEE_DEFAULT_COMPANY_ID: '12345',
       FREEE_CALLBACK_PORT: '54321'
     },
     // テスト実行時のセットアップ


### PR DESCRIPTION
環境変数 FREEE_COMPANY_ID を FREEE_DEFAULT_COMPANY_ID に改名しました。 この変更により、デフォルト事業所IDであることがより明確になります。

変更内容:
- src/config.ts: 環境変数の参照を更新
- vitest.config.ts: テスト環境変数を更新
- scripts/test-tools.js: 設定例を更新
- src/mcp/tools.ts: ドキュメント文字列を更新
- CLAUDE.md: 環境変数ドキュメントを更新
- README.md: 環境変数ドキュメントを更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation and setup guides to reflect environment variable naming changes.

* **Chores**
  * Updated environment variable references in configuration and test files for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->