### PR TITLE
feat: 複数freee API対応（会計・人事労務・請求書・工数管理）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,16 +16,24 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 MCP server that exposes freee API endpoints as MCP tools:
 
-- **Schema**: `src/data/freee-api-schema.json` contains OpenAPI definition
+- **Schema**: Multiple OpenAPI schemas in `openapi/` directory
+  - `accounting-api-schema.json` - 会計API (https://api.freee.co.jp)
+  - `hr-api-schema.json` - 人事労務API (https://api.freee.co.jp/hr)
+  - `invoice-api-schema.json` - 請求書API (https://api.freee.co.jp/iv)
+  - `pm-api-schema.json` - 工数管理API (https://api.freee.co.jp/pm)
+- **Schema Loader**: `src/openapi/schema-loader.ts` loads and manages all API schemas
 - **Tool Generation**: Two modes available (selected via CLI subcommand):
-  - **Client Mode** (`freee-mcp client`): Sub-command tools per HTTP method
+  - **Client Mode** (`freee-mcp client`): Sub-command tools per HTTP method **[RECOMMENDED]**
     - `generateClientModeTool()` in `src/openapi/client-mode.ts` creates method-specific tools
     - Tools: `freee_api_get`, `freee_api_post`, `freee_api_put`, `freee_api_delete`, `freee_api_patch`, `freee_api_list_paths`
-    - Validates paths against OpenAPI schema before execution
+    - Automatically detects API type from path and uses correct base URL
+    - Validates paths against all OpenAPI schemas before execution
     - Reduces context window usage significantly (6 tools vs hundreds)
+    - Supports all 4 freee APIs seamlessly
   - **Individual Mode** (`freee-mcp api` or default): One tool per endpoint
     - `generateToolsFromOpenApi()` in `src/openapi/converter.ts` converts OpenAPI paths to MCP tools
-    - Naming: GET → `get_*`, POST → `post_*`, PUT → `put_*_by_id`, DELETE → `delete_*_by_id`
+    - Naming with API prefix: `accounting_get_deals`, `hr_get_employees`, `invoice_get_delivery_slips`, `pm_get_projects`
+    - Each tool automatically uses the correct base URL for its API
 - **Requests**: `makeApiRequest()` in `src/api/client.ts` handles API calls with auto-auth and company_id injection
 
 ### Configuration

--- a/openapi/accounting-api-schema.json
+++ b/openapi/accounting-api-schema.json
@@ -13,7 +13,10 @@
   ],
   "security": [
     {
-      "oauth2": ["write", "read"]
+      "oauth2": [
+        "write",
+        "read"
+      ]
     }
   ],
   "tags": [
@@ -145,9 +148,11 @@
   "paths": {
     "/api/1/partners": {
       "get": {
-        "tags": ["Partners"],
+        "tags": [
+          "Partners"
+        ],
         "summary": "取引先一覧の取得",
-        "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の取引先一覧を取得する</p>\n<ul>\n<li>振込元口座ID（payer_walletable_id）, 振込手数料負担（transfer_fee_handling_side）は法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で利用可能です。</li></ul>",
+        "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の取引先一覧を取得する</p>\n<ul>\n<li>振込元口座ID（payer_walletable_id）, 振込手数料負担（transfer_fee_handling_side）は法人スタータープラン（および旧法人プロフェッショナルプラン）以上で利用可能です。</li></ul>",
         "operationId": "get_partners",
         "parameters": [
           {
@@ -262,12 +267,13 @@
         }
       },
       "post": {
-        "tags": ["Partners"],
+        "tags": [
+          "Partners"
+        ],
         "summary": "取引先の作成",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の取引先を作成する</p>\n<ul>\n<li>取引先名称（name）は重複不可です。</li>\n<li>codeを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。</li>\n<li>取引先コードの利用を有効にしている場合は、\n  <ul>\n    <li>codeの指定は必須です。</li>\n    <li>name、codeそれぞれ重複不可です。</li>\n  </ul>\n</li>\n<li>振込元口座ID（payer_walletable_id）, 振込手数料負担（transfer_fee_handling_side）, 支払期日設定（payment_term_attributes）, 請求の入金期日設定（invoice_payment_term_attributes）は法人スタータープラン（および旧法人プロフェッショナルプラン）以上で利用可能です。</li></ul>",
         "operationId": "create_partner",
         "requestBody": {
-          "description": "取引先の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -338,7 +344,9 @@
     },
     "/api/1/partners/{id}": {
       "get": {
-        "tags": ["Partners"],
+        "tags": [
+          "Partners"
+        ],
         "summary": "取引先の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の取引先を取得する</p>\n<ul>\n<li>振込元口座ID（payer_walletable_id）, 振込手数料負担（transfer_fee_handling_side）, 支払期日設定（payment_term_attributes）, 請求の入金期日設定（invoice_payment_term_attributes）は法人スタータープラン（および旧法人プロフェッショナルプラン）以上で利用可能です。</li></ul>",
         "operationId": "get_partner",
@@ -430,7 +438,9 @@
         }
       },
       "put": {
-        "tags": ["Partners"],
+        "tags": [
+          "Partners"
+        ],
         "summary": "取引先の更新",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した取引先の情報を更新する</p>\n<ul>\n<li>取引先名称（name）は重複不可です。</li>\n<li>codeを指定、更新することはできません。</li>\n<li>振込元口座ID（payer_walletable_id）, 振込手数料負担（transfer_fee_handling_side）, 支払期日設定（payment_term_attributes）, 請求の入金期日設定（invoice_payment_term_attributes）は法人スタータープラン（および旧法人プロフェッショナルプラン）以上で利用可能です。</li>\n<li>支払期日設定（payment_term_attributes）, 請求の入金期日設定（invoice_payment_term_attributes）にnull型を入力することにより、期日を未設定に変更可能です。</li></ul>",
         "operationId": "update_partner",
@@ -448,7 +458,6 @@
           }
         ],
         "requestBody": {
-          "description": "取引先の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -527,7 +536,9 @@
         }
       },
       "delete": {
-        "tags": ["Partners"],
+        "tags": [
+          "Partners"
+        ],
         "summary": "取引先の削除",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の取引先を削除する</p>",
         "operationId": "destroy_partner",
@@ -615,8 +626,10 @@
     },
     "/api/1/partners/code/{code}": {
       "put": {
-        "tags": ["Partners"],
-        "summary": "取引先の更新",
+        "tags": [
+          "Partners"
+        ],
+        "summary": "取引先コードでの取引先の更新",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>取引先コードをキーに、指定した取引先の情報を更新する</p>\n<ul>\n<li>このAPIを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。</li>\n<li>コードを日本語に設定している場合は、URLエンコードしてURLに含めるようにしてください。</li>\n<li>取引先名称（name）は重複不可です。</li>\n<li>振込元口座ID（payer_walletable_id）, 振込手数料負担（transfer_fee_handling_side）, 支払期日設定（payment_term_attributes）, 請求の入金期日設定（invoice_payment_term_attributes）は法人スタータープラン（および旧法人プロフェッショナルプラン）以上で利用可能です。</li>\n<li>支払期日設定（payment_term_attributes）, 請求の入金期日設定（invoice_payment_term_attributes）にnull型を入力することにより、期日を未設定に変更可能です。</li></ul>",
         "operationId": "update_partner_by_code",
         "parameters": [
@@ -631,7 +644,6 @@
           }
         ],
         "requestBody": {
-          "description": "取引先の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -710,9 +722,413 @@
         }
       }
     },
+    "/api/1/partners/upsert_by_code": {
+      "put": {
+        "tags": [
+          "Partners"
+        ],
+        "summary": "取引先の更新（存在しない場合は作成）",
+        "description": "\n<h2 id=\"\">概要</h2>\n\n<p>取引先コードをキーに、指定した取引先の情報を更新（存在しない場合は作成）する</p>\n<ul>\n<li>このAPIを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。</li>\n<li>取引先名称（name）は重複不可です。</li>\n<li>振込元口座ID（payer_walletable_id）, 振込手数料負担（transfer_fee_handling_side）, 支払期日設定（payment_term_attributes）, 請求の入金期日設定（invoice_payment_term_attributes）は法人スタータープラン（および旧法人プロフェッショナルプラン）以上で利用可能です。</li>\n<li>支払期日設定（payment_term_attributes）, 請求の入金期日設定（invoice_payment_term_attributes）にnull型を入力することにより、期日を未設定に変更可能です。</li></ul>",
+        "operationId": "api/v1/partners#upsert_by_code",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "code",
+                  "company_id",
+                  "partner"
+                ],
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "取引先コード",
+                    "example": "code001"
+                  },
+                  "company_id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "minimum": 1,
+                    "description": "事業所ID",
+                    "example": 1
+                  },
+                  "partner": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "取引先名 (255文字以内、重複不可)",
+                        "example": "新しい取引先"
+                      },
+                      "available": {
+                        "type": "boolean",
+                        "description": "true: 使用可能、false: 使用停止",
+                        "example": false
+                      },
+                      "shortcut1": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "ショートカット１ (255文字以内)",
+                        "example": "NEWPARTNER"
+                      },
+                      "shortcut2": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "ショートカット２ (255文字以内)",
+                        "example": "502"
+                      },
+                      "org_code": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "事業所種別（null: 未設定、1: 法人、2: 個人）",
+                        "example": 1,
+                        "enum": [
+                          1,
+                          2
+                        ],
+                        "nullable": true
+                      },
+                      "country_code": {
+                        "type": "string",
+                        "description": "地域（JP: 国内、ZZ:国外）、指定しない場合JPになります。",
+                        "example": "JP",
+                        "enum": [
+                          "JP",
+                          "ZZ"
+                        ]
+                      },
+                      "long_name": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "正式名称（255文字以内）",
+                        "example": "新しい取引先正式名称"
+                      },
+                      "name_kana": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "カナ名称（255文字以内）",
+                        "example": "アタラシイトリヒキサキメイショウ"
+                      },
+                      "default_title": {
+                        "type": "string",
+                        "description": "敬称（御中、様、(空白)の3つから選択）",
+                        "example": "御中"
+                      },
+                      "phone": {
+                        "type": "string",
+                        "description": "電話番号",
+                        "example": "03-1234-xxxx"
+                      },
+                      "contact_name": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "担当者 氏名 (255文字以内)",
+                        "example": "営業担当"
+                      },
+                      "email": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "担当者 メールアドレス (255文字以内)",
+                        "example": "contact@example.com"
+                      },
+                      "payer_walletable_id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "minimum": 1,
+                        "description": "振込元口座ID（一括振込ファイル用）:（walletableのtypeが'bank_account'のidのみ指定できます。また、未設定にする場合は、nullを指定してください。）",
+                        "example": 1,
+                        "nullable": true
+                      },
+                      "transfer_fee_handling_side": {
+                        "type": "string",
+                        "description": "振込手数料負担（一括振込ファイル用）: (振込元(当方): payer, 振込先(先方): payee)、指定しない場合payerになります。",
+                        "example": "payer",
+                        "enum": [
+                          "payer",
+                          "payee"
+                        ]
+                      },
+                      "qualified_invoice_issuer": {
+                        "type": "boolean",
+                        "description": "インボイス制度適格請求書発行事業者（true: 対象事業者、false: 非対象事業者）\n<a target=\"_blank\" href=\"https://www.invoice-kohyo.nta.go.jp/index.html\">国税庁インボイス制度適格請求書発行事業者公表サイト</a>\n",
+                        "example": false
+                      },
+                      "invoice_registration_number": {
+                        "type": "string",
+                        "maxLength": 14,
+                        "minLength": 13,
+                        "pattern": "^T?[1-9][0-9]{12}$",
+                        "description": "インボイス制度適格請求書発行事業者登録番号\n- 先頭T数字13桁の固定14桁の文字列\n<a target=\"_blank\" href=\"https://www.invoice-kohyo.nta.go.jp/index.html\">国税庁インボイス制度適格請求書発行事業者公表サイト</a>\n",
+                        "example": "T1000000000001",
+                        "nullable": true
+                      },
+                      "address_attributes": {
+                        "type": "object",
+                        "properties": {
+                          "zipcode": {
+                            "type": "string",
+                            "maxLength": 8,
+                            "description": "郵便番号（8文字以内）",
+                            "example": "000-0000"
+                          },
+                          "prefecture_code": {
+                            "type": "integer",
+                            "format": "int64",
+                            "minimum": -1,
+                            "maximum": 46,
+                            "description": "都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄",
+                            "example": 4
+                          },
+                          "street_name1": {
+                            "type": "string",
+                            "maxLength": 255,
+                            "description": "市区町村・番地（255文字以内）",
+                            "example": "ＸＸ区ＹＹ１−１−１"
+                          },
+                          "street_name2": {
+                            "type": "string",
+                            "maxLength": 255,
+                            "description": "建物名・部屋番号など（255文字以内）",
+                            "example": "ビル１Ｆ"
+                          }
+                        }
+                      },
+                      "partner_doc_setting_attributes": {
+                        "type": "object",
+                        "properties": {
+                          "sending_method": {
+                            "type": "string",
+                            "description": "請求書送付方法(email:メール、posting:郵送、email_and_posting:メールと郵送、null:設定しない)",
+                            "example": "posting",
+                            "enum": [
+                              "email",
+                              "posting",
+                              "email_and_posting"
+                            ],
+                            "nullable": true
+                          }
+                        }
+                      },
+                      "partner_bank_account_attributes": {
+                        "type": "object",
+                        "properties": {
+                          "bank_name": {
+                            "type": "string",
+                            "description": "銀行名",
+                            "example": "freee銀行"
+                          },
+                          "bank_name_kana": {
+                            "type": "string",
+                            "description": "銀行名（カナ）",
+                            "example": "フリーギンコウ"
+                          },
+                          "bank_code": {
+                            "type": "string",
+                            "description": "銀行コード",
+                            "example": "0001"
+                          },
+                          "branch_name": {
+                            "type": "string",
+                            "description": "支店名",
+                            "example": "銀座支店"
+                          },
+                          "branch_kana": {
+                            "type": "string",
+                            "description": "支店名（カナ）",
+                            "example": "ギンザシテン"
+                          },
+                          "branch_code": {
+                            "type": "string",
+                            "description": "支店番号",
+                            "example": "101"
+                          },
+                          "account_type": {
+                            "type": "string",
+                            "description": "口座種別(ordinary:普通、checking：当座、earmarked：納税準備預金、savings：貯蓄、other:その他)、指定しない場合ordinaryになります。",
+                            "example": "ordinary",
+                            "enum": [
+                              "ordinary",
+                              "checking",
+                              "earmarked",
+                              "savings",
+                              "other"
+                            ]
+                          },
+                          "account_number": {
+                            "type": "string",
+                            "description": "口座番号",
+                            "example": "1010101"
+                          },
+                          "long_account_name": {
+                            "type": "string",
+                            "description": "受取人名",
+                            "example": "freee太郎"
+                          },
+                          "account_name": {
+                            "type": "string",
+                            "description": "受取人名（カナ）",
+                            "example": "フリータロウ"
+                          }
+                        }
+                      },
+                      "payment_term_attributes": {
+                        "type": "object",
+                        "properties": {
+                          "cutoff_day": {
+                            "type": "integer",
+                            "format": "int64",
+                            "minimum": 1,
+                            "maximum": 32,
+                            "description": "締め日（29, 30, 31日の末日を指定する場合は、32を指定してください。）",
+                            "example": 15
+                          },
+                          "additional_months": {
+                            "type": "integer",
+                            "format": "int64",
+                            "minimum": 0,
+                            "maximum": 6,
+                            "description": "支払月（当月を指定する場合は、0を指定してください。）",
+                            "example": 1
+                          },
+                          "fixed_day": {
+                            "type": "integer",
+                            "format": "int64",
+                            "minimum": 1,
+                            "maximum": 32,
+                            "description": "支払日（29, 30, 31日の末日を指定する場合は、32を指定してください。）",
+                            "example": 32
+                          }
+                        },
+                        "nullable": true
+                      },
+                      "invoice_payment_term_attributes": {
+                        "type": "object",
+                        "properties": {
+                          "cutoff_day": {
+                            "type": "integer",
+                            "format": "int64",
+                            "minimum": 1,
+                            "maximum": 32,
+                            "description": "締め日（29, 30, 31日の末日を指定する場合は、32を指定してください。）",
+                            "example": 15
+                          },
+                          "additional_months": {
+                            "type": "integer",
+                            "format": "int64",
+                            "minimum": 0,
+                            "maximum": 6,
+                            "description": "入金月（当月を指定する場合は、0を指定してください。）",
+                            "example": 1
+                          },
+                          "fixed_day": {
+                            "type": "integer",
+                            "format": "int64",
+                            "minimum": 1,
+                            "maximum": 32,
+                            "description": "入金日（29, 30, 31日の末日を指定する場合は、32を指定してください。）",
+                            "example": 32
+                          }
+                        },
+                        "nullable": true
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/paths/~1api~11~1partners~1upsert_by_code/put/requestBody/content/application~1json/schema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/partnerResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/partnerResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequestError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequestNotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/1/forms/selectables": {
       "get": {
-        "tags": ["Selectables"],
+        "tags": [
+          "Selectables"
+        ],
         "summary": "フォーム用選択項目情報の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所のフォーム用選択項目情報を取得する</p>",
         "operationId": "get_forms_selectables",
@@ -734,7 +1150,9 @@
             "description": "取得する項目(項目: account_item)",
             "schema": {
               "type": "string",
-              "enum": ["account_item"]
+              "enum": [
+                "account_item"
+              ]
             }
           }
         ],
@@ -794,7 +1212,9 @@
     },
     "/api/1/account_items/{id}": {
       "get": {
-        "tags": ["Account items"],
+        "tags": [
+          "Account items"
+        ],
         "summary": "勘定科目の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した勘定科目を取得する</p>\n<p>事業所の設定で勘定科目コードを使用する設定にしている場合、レスポンスで勘定科目コード(code)を返します</p>",
         "operationId": "get_account_item",
@@ -886,7 +1306,9 @@
         }
       },
       "put": {
-        "tags": ["Account items"],
+        "tags": [
+          "Account items"
+        ],
         "summary": "勘定科目の更新",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した勘定科目を更新する</p>\n\n<h2 id=\"_2\">注意点</h2>\n<p>tax_codeは、指定した事業所の税区分一覧の取得APIでavailableの値がtrue、かつ経過措置税区分ではない5%の税区分を確認して、そのcodeを指定して勘定科目の更新をしてください。例 課対仕入の場合、34を指定してください</p>\n<p>codeを利用するには、事業所の設定で勘定科目コードを使用する設定にする必要があります。</p>",
         "operationId": "update_account_item",
@@ -894,6 +1316,7 @@
           {
             "name": "id",
             "in": "path",
+            "description": "勘定科目ID",
             "required": true,
             "schema": {
               "type": "integer",
@@ -903,7 +1326,6 @@
           }
         ],
         "requestBody": {
-          "description": "勘定科目の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -982,7 +1404,9 @@
         }
       },
       "delete": {
-        "tags": ["Account items"],
+        "tags": [
+          "Account items"
+        ],
         "summary": "勘定科目の削除",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した勘定科目を削除する</p>\n<h2 id=\"\">注意点</h2>\n<ul>\n  <li>削除できる勘定科目は、追加で作成したカスタム勘定科目のみです。</li>\n  <li>デフォルトで存在する勘定科目や口座の勘定科目は削除できません。</li>\n</ul>",
         "operationId": "destroy_account_item",
@@ -990,6 +1414,7 @@
           {
             "name": "id",
             "in": "path",
+            "description": "勘定科目ID",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1059,7 +1484,9 @@
     },
     "/api/1/account_items": {
       "get": {
-        "tags": ["Account items"],
+        "tags": [
+          "Account items"
+        ],
         "summary": "勘定科目一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の勘定科目一覧を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>default_tax_code : リクエストした日時を基準とした税区分コード</li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<p>default_tax_code は勘定科目作成・更新時に利用するものではありません</p>\n<p>事業所の設定で勘定科目コードを使用する設定にしている場合、レスポンスで勘定科目コード(code)を返します</p>",
         "operationId": "get_account_items",
@@ -1079,6 +1506,22 @@
             "name": "base_date",
             "in": "query",
             "description": "基準日:指定した場合、勘定科目に紐づく税区分(default_tax_code)が、基準日の税率に基づいて返ります。",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start_update_date",
+            "in": "query",
+            "description": "更新日で絞込：開始日(yyyy-mm-dd)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "end_update_date",
+            "in": "query",
+            "description": "更新日で絞込：終了日(yyyy-mm-dd)",
             "schema": {
               "type": "string"
             }
@@ -1138,12 +1581,13 @@
         }
       },
       "post": {
-        "tags": ["Account items"],
+        "tags": [
+          "Account items"
+        ],
         "summary": "勘定科目の作成",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の勘定科目を作成する</p>\n\n<h2 id=\"_2\">注意点</h2>\n<p>tax_codeは、指定した事業所の税区分一覧の取得APIでavailableの値がtrue、かつ経過措置税区分ではない5%の税区分を確認して、そのcodeを指定して勘定科目の作成をしてください。例 課対仕入の場合、34を指定してください</p>\n<p>codeを利用するには、事業所の設定で勘定科目コードを使用する設定にする必要があります。</p>",
         "operationId": "create_account_item",
         "requestBody": {
-          "description": "勘定科目の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -1212,9 +1656,238 @@
         }
       }
     },
+    "/api/1/account_items/code/upsert": {
+      "put": {
+        "tags": [
+          "Account items"
+        ],
+        "summary": "勘定科目の更新（存在しない場合は作成）",
+        "description": "\n<h2 id=\"\">概要</h2>\n\n<p>勘定科目コードをキーに、指定した勘定科目の情報を更新（存在しない場合は作成）する</p>\n\n<h2 id=\"_2\">注意点</h2>\n<p>tax_codeは、指定した事業所の税区分一覧の取得APIでavailableの値がtrue、かつ経過措置税区分ではない5%の税区分を確認して、そのcodeを指定して勘定科目の更新をしてください。例 課対仕入の場合、34を指定してください</p>\n<p>codeを利用するには、事業所の設定で勘定科目コードを使用する設定にする必要があります。</p>",
+        "operationId": "api/v1/account_items#upsert_by_code",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "company_id",
+                  "account_item"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "maxLength": 20,
+                    "description": "勘定科目コード",
+                    "example": "999",
+                    "pattern": "^[0-9a-zA-Z_-]+$"
+                  },
+                  "company_id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "minimum": 1,
+                    "description": "事業所ID",
+                    "example": 1
+                  },
+                  "account_item": {
+                    "type": "object",
+                    "required": [
+                      "account_category_id",
+                      "corresponding_expense_id",
+                      "corresponding_income_id",
+                      "group_name",
+                      "tax_code"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "maxLength": 30,
+                        "description": "勘定科目名 (30文字以内)\n口座に紐付かない勘定科目の更新時は必須です。\n口座に紐付く勘定科目の更新時は指定することができません。\n",
+                        "example": "新しい勘定科目"
+                      },
+                      "shortcut": {
+                        "type": "string",
+                        "maxLength": 20,
+                        "description": "ショートカット1 (20文字以内)",
+                        "example": "NEWACCOUNTITEM"
+                      },
+                      "shortcut_num": {
+                        "type": "string",
+                        "maxLength": 20,
+                        "description": "ショートカット2 (20文字以内)",
+                        "example": "999"
+                      },
+                      "tax_code": {
+                        "type": "integer",
+                        "format": "int64",
+                        "minimum": 0,
+                        "maximum": 2147483647,
+                        "description": "税区分コード 指定できるコードは本APIの注意点をご確認ください。",
+                        "example": 1
+                      },
+                      "group_name": {
+                        "type": "string",
+                        "description": "決算書表示名（小カテゴリー） Selectablesフォーム用選択項目情報エンドポイント(account_groups.name)で取得可能です",
+                        "example": "その他預金"
+                      },
+                      "account_category_id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "minimum": 1,
+                        "description": "勘定科目カテゴリーID Selectablesフォーム用選択項目情報エンドポイント(account_groups.account_category_id)で取得可能です",
+                        "example": 1
+                      },
+                      "corresponding_income_id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "minimum": 1,
+                        "description": "収入取引相手勘定科目ID",
+                        "example": 1
+                      },
+                      "corresponding_expense_id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "minimum": 1,
+                        "description": "支出取引相手勘定科目ID",
+                        "example": 1
+                      },
+                      "accumulated_dep_account_item_id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "minimum": 1,
+                        "description": "減価償却累計額勘定科目ID（法人のみ利用可能）",
+                        "example": 1
+                      },
+                      "searchable": {
+                        "type": "integer",
+                        "format": "int64",
+                        "minimum": 2,
+                        "maximum": 3,
+                        "description": "検索可能:2, 検索不可：3(登録時未指定の場合は2で登録されます。更新時未指定の場合はsearchableは変更されません。)",
+                        "example": 2
+                      },
+                      "items": {
+                        "type": "array",
+                        "description": "品目",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "format": "int64",
+                              "minimum": 1,
+                              "example": 1
+                            }
+                          }
+                        }
+                      },
+                      "partners": {
+                        "type": "array",
+                        "description": "取引先",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "format": "int64",
+                              "minimum": 1,
+                              "example": 1
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/paths/~1api~11~1account_items~1code~1upsert/put/requestBody/content/application~1json/schema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accountItemResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accountItemResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequestError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/serviceUnavailableError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/1/tags": {
       "get": {
-        "tags": ["Tags"],
+        "tags": [
+          "Tags"
+        ],
         "summary": "メモタグ一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所のメモタグ一覧を取得する</p>",
         "operationId": "get_tags",
@@ -1276,7 +1949,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["tags"],
+                  "required": [
+                    "tags"
+                  ],
                   "properties": {
                     "tags": {
                       "type": "array",
@@ -1332,12 +2007,13 @@
         }
       },
       "post": {
-        "tags": ["Tags"],
+        "tags": [
+          "Tags"
+        ],
         "summary": "メモタグの作成",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所のメモタグを作成する</p>",
         "operationId": "create_tag",
         "requestBody": {
-          "description": "メモタグの作成",
           "content": {
             "application/json": {
               "schema": {
@@ -1408,7 +2084,9 @@
     },
     "/api/1/tags/{id}": {
       "get": {
-        "tags": ["Tags"],
+        "tags": [
+          "Tags"
+        ],
         "summary": "メモタグの取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所のメモタグを取得する</p>",
         "operationId": "get_tag",
@@ -1500,7 +2178,9 @@
         }
       },
       "put": {
-        "tags": ["Tags"],
+        "tags": [
+          "Tags"
+        ],
         "summary": "メモタグの更新",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所のメモタグを更新する</p>",
         "operationId": "update_tag",
@@ -1518,7 +2198,6 @@
           }
         ],
         "requestBody": {
-          "description": "メモタグの更新",
           "content": {
             "application/json": {
               "schema": {
@@ -1597,7 +2276,9 @@
         }
       },
       "delete": {
-        "tags": ["Tags"],
+        "tags": [
+          "Tags"
+        ],
         "summary": "メモタグの削除",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所のメモタグを削除する</p>",
         "operationId": "destroy_tag",
@@ -1685,7 +2366,9 @@
     },
     "/api/1/sections": {
       "get": {
-        "tags": ["Sections"],
+        "tags": [
+          "Sections"
+        ],
         "summary": "部門一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の部門一覧を取得する</p>\n<p>事業所の設定で部門コードを使用する設定にしている場合、レスポンスで部門コード(code)を返します</p>\n\n<h2 id=\"_2\">レスポンスの例</h2>\n\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/sections?company_id=1</p>\n</blockquote>\n\n<pre><code>// プレミアムプラン、法人スタンダードプラン（および旧法人ベーシックプラン）以上\n{\n  &quot;sections&quot; : [\n    {\n      &quot;id&quot; : 101,\n      &quot;company_id&quot; : 1,\n      &quot;name&quot; : &quot;開発部門&quot;,\n      &quot;long_name&quot;: &quot;開発部門&quot;,\n      &quot;shortcut1&quot; : &quot;DEVELOPER&quot;,\n      &quot;shortcut2&quot; : &quot;123&quot;,\n      &quot;indent_count&quot;: 1,\n      &quot;parent_id&quot;: 11\n    },\n    ...\n  ]\n}\n// それ以外のプラン\n{\n  &quot;sections&quot; : [\n    {\n      &quot;id&quot; : 101,\n      &quot;company_id&quot; : 1,\n      &quot;name&quot; : &quot;開発部門&quot;,\n      &quot;long_name&quot;: &quot;開発部門&quot;,\n      &quot;shortcut1&quot; : &quot;DEVELOPER&quot;,\n      &quot;shortcut2&quot; : &quot;123&quot;\n    },\n    ...\n  ]\n}</code></pre>\n",
         "operationId": "get_sections",
@@ -1700,6 +2383,22 @@
               "format": "int64",
               "minimum": 1
             }
+          },
+          {
+            "name": "start_update_date",
+            "in": "query",
+            "description": "更新日で絞込：開始日(yyyy-mm-dd)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "end_update_date",
+            "in": "query",
+            "description": "更新日で絞込：終了日(yyyy-mm-dd)",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1709,7 +2408,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["sections"],
+                  "required": [
+                    "sections"
+                  ],
                   "properties": {
                     "sections": {
                       "type": "array",
@@ -1765,12 +2466,13 @@
         }
       },
       "post": {
-        "tags": ["Sections"],
+        "tags": [
+          "Sections"
+        ],
         "summary": "部門の作成",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の部門を作成する</p>\n<p>codeを利用するには、事業所の設定で部門コードを使用する設定にする必要があります。</p>\n\n<h2 id=\"_2\">レスポンスの例</h2>\n\n<pre><code>// プレミアムプラン、法人スタンダードプラン（および旧法人ベーシックプラン）以上\n{\n  &quot;section&quot; : {\n    &quot;id&quot; : 102,\n    &quot;company_id&quot; : 1,\n    &quot;name&quot; : &quot;開発部門&quot;,\n    &quot;shortcut1&quot; : &quot;DEVELOPER&quot;,\n    &quot;shortcut2&quot; : &quot;123&quot;,\n    &quot;indent_count&quot;: 1,\n    &quot;parent_id&quot;: 101\n  }\n}\n// それ以外のプラン\n{\n  &quot;section&quot; : {\n    &quot;id&quot; : 102,\n    &quot;company_id&quot; : 1,\n    &quot;name&quot; : &quot;開発部門&quot;,\n    &quot;shortcut1&quot; : &quot;DEVELOPER&quot;,\n    &quot;shortcut2&quot; : &quot;123&quot;\n  }\n}</code></pre>\n",
         "operationId": "create_section",
         "requestBody": {
-          "description": "部門の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -1841,7 +2543,9 @@
     },
     "/api/1/sections/{id}": {
       "get": {
-        "tags": ["Sections"],
+        "tags": [
+          "Sections"
+        ],
         "summary": "部門の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の部門を取得する</p>\n<p>事業所の設定で部門コードを使用する設定にしている場合、レスポンスで部門コード(code)を返します</p>\n\n<h2 id=\"_2\">レスポンスの例</h2>\n\n<pre><code>// プレミアムプラン、法人スタンダードプラン（および旧法人ベーシックプラン）以上\n{\n  &quot;section&quot; : {\n    &quot;id&quot; : 102,\n    &quot;company_id&quot; : 1,\n    &quot;name&quot; : &quot;開発部門&quot;,\n    &quot;long_name&quot;: &quot;開発部門&quot;,\n    &quot;shortcut1&quot; : &quot;DEVELOPER&quot;,\n    &quot;shortcut2&quot; : &quot;123&quot;,\n    &quot;indent_count&quot;: 1,\n    &quot;parent_id&quot;: 101\n  }\n}\n// それ以外のプラン\n{\n  &quot;section&quot; : {\n    &quot;id&quot; : 102,\n    &quot;company_id&quot; : 1,\n    &quot;name&quot; : &quot;開発部門&quot;,\n    &quot;long_name&quot;: &quot;開発部門&quot;,\n    &quot;shortcut1&quot; : &quot;DEVELOPER&quot;,\n    &quot;shortcut2&quot; : &quot;123&quot;\n  }\n}</code></pre>\n",
         "operationId": "get_section",
@@ -1933,7 +2637,9 @@
         }
       },
       "put": {
-        "tags": ["Sections"],
+        "tags": [
+          "Sections"
+        ],
         "summary": "部門の更新",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の部門を更新する</p>\n<p>codeを利用するには、事業所の設定で部門コードを使用する設定にする必要があります。</p>\n\n<h2 id=\"_2\">レスポンスの例</h2>\n\n<pre><code>// プレミアムプラン、法人スタンダードプラン（および旧法人ベーシックプラン）以上\n{\n  &quot;section&quot; : {\n    &quot;id&quot; : 102,\n    &quot;company_id&quot; : 1,\n    &quot;name&quot; : &quot;開発部門&quot;,\n    &quot;long_name&quot;: &quot;開発部門&quot;,\n    &quot;shortcut1&quot; : &quot;DEVELOPER&quot;,\n    &quot;shortcut2&quot; : &quot;123&quot;,\n    &quot;indent_count&quot;: 1,\n    &quot;parent_id&quot;: 101\n  }\n}\n// それ以外のプラン\n{\n  &quot;section&quot; : {\n    &quot;id&quot; : 102,\n    &quot;company_id&quot; : 1,\n    &quot;name&quot; : &quot;開発部門&quot;,\n    &quot;long_name&quot;: &quot;開発部門&quot;,\n    &quot;shortcut1&quot; : &quot;DEVELOPER&quot;,\n    &quot;shortcut2&quot; : &quot;123&quot;\n  }\n}</code></pre>\n",
         "operationId": "update_section",
@@ -1950,7 +2656,6 @@
           }
         ],
         "requestBody": {
-          "description": "部門の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -2019,7 +2724,9 @@
         }
       },
       "delete": {
-        "tags": ["Sections"],
+        "tags": [
+          "Sections"
+        ],
         "summary": "部門の削除",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の部門を削除する</p>",
         "operationId": "destroy_section",
@@ -2094,9 +2801,158 @@
         }
       }
     },
+    "/api/1/sections/code/upsert": {
+      "put": {
+        "tags": [
+          "Sections"
+        ],
+        "summary": "部門の更新（存在しない場合は作成）",
+        "description": "<h2 id=\"\">概要</h2>\n<p>部門コードをキーに、指定した部門の情報を更新（存在しない場合は作成）する</p>\n<h2 id=\"_1\">注意点</h2>\n<p>codeを利用するには、事業所の設定で部門コードを使用する設定にする必要があります。</p>",
+        "operationId": "api/v1/sections#upsert_by_code",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "company_id",
+                  "code",
+                  "section"
+                ],
+                "properties": {
+                  "company_id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "minimum": 1,
+                    "description": "事業所ID",
+                    "example": 1
+                  },
+                  "code": {
+                    "type": "string",
+                    "maxLength": 20,
+                    "description": "部門コード",
+                    "example": "code001",
+                    "pattern": "^[0-9a-zA-Z_-]+$"
+                  },
+                  "section": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "maxLength": 30,
+                        "description": "部門名 (30文字以内)",
+                        "example": "開発部門"
+                      },
+                      "long_name": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "正式名称 (255文字以内)",
+                        "example": "xxxx開発部門"
+                      },
+                      "shortcut1": {
+                        "type": "string",
+                        "maxLength": 20,
+                        "description": "ショートカット１ (20文字以内)",
+                        "example": "DEVELOPER"
+                      },
+                      "shortcut2": {
+                        "type": "string",
+                        "maxLength": 20,
+                        "description": "ショートカット２ (20文字以内)",
+                        "example": "123"
+                      },
+                      "parent_code": {
+                        "type": "string",
+                        "maxLength": 20,
+                        "description": "親部門コード。親部門コードの値が空の場合は、codeで指定した部門が親部門になる。",
+                        "example": "code001",
+                        "pattern": "^[0-9a-zA-Z_-]+$"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/paths/~1api~11~1sections~1code~1upsert/put/requestBody/content/application~1json/schema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sectionResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sectionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequestError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/1/invoices": {
       "get": {
-        "tags": ["Invoices"],
+        "tags": [
+          "Invoices"
+        ],
         "summary": "請求書一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の請求書一覧を取得する</p>\n",
         "operationId": "get_invoices",
@@ -2201,7 +3057,10 @@
             "description": "入金ステータス  (unsettled: 入金待ち, settled: 入金済み)",
             "schema": {
               "type": "string",
-              "enum": ["unsettled", "settled"]
+              "enum": [
+                "unsettled",
+                "settled"
+              ]
             }
           },
           {
@@ -2289,96 +3148,13 @@
             }
           }
         }
-      },
-      "post": {
-        "tags": ["Invoices"],
-        "summary": "請求書の作成（廃止）",
-        "deprecated": true,
-        "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の請求書を作成する</p>\n\n<h2 id=\"_1\">注意点</h2>\n<b>インボイス制度に伴い、freee会計の帳票機能がfreee請求書に移行しました。これに伴い、2023年10月からfreee会計の「請求書の作成」エンドポイントは廃止され、freee請求書APIに移行しました。詳細は<a href=\"https://developer.freee.co.jp/news/6369\" target=\"_blank\"> freee会計 APIの仕様変更（インボイス制度対応）について</a>をご確認ください。</b>\n<ul>\n<li> <p>partner_code, partner_idはどちらかの指定が必須です。ただし両方同時に指定することはできません。</p> </li>\n<li> <p>請求書ステータス(invoice_status)を下書き(draft)以外で作成する場合、請求内容の合計金額が0円以上になる必要があります。</p> </li>\n<li> <p>partner_codeを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。</p> </li>\n<li> <p>本APIでは請求内容(invoice_contents)は、最大100行までになります。</p> </li>\n</ul>",
-        "operationId": "create_invoice",
-        "requestBody": {
-          "description": "請求書の作成",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/invoiceCreateParams"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/invoiceCreateParams"
-              }
-            }
-          },
-          "required": false
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/invoiceResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/badRequestError"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/unauthorizedError"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/forbiddenError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/badRequestNotFoundError"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/internalServerError"
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/api/1/invoices/{id}": {
       "get": {
-        "tags": ["Invoices"],
+        "tags": [
+          "Invoices"
+        ],
         "summary": "請求書の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の請求書を取得する</p>",
         "operationId": "get_invoice",
@@ -2468,193 +3244,13 @@
             }
           }
         }
-      },
-      "put": {
-        "tags": ["Invoices"],
-        "summary": "請求書の更新",
-        "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の請求書を更新する</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n<li> <p>入金済みの請求書に対する金額関連の変更はできません。</p> </li>\n<li> <p>請求書WFを利用している場合、承認済み請求書は承認権限を持たないユーザーでは更新できません。</p> </li>\n<li> <p>請求書ステータス(invoice_status)を下書き(draft)以外で更新する場合、請求内容の合計金額が0円以上になる必要があります。</p> </li>\n<li> <p>partner_code, partner_idを両方同時に指定することはできません。</p> </li>\n<li> <p>partner_codeを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。</p> </li>\n<li> <p>本APIでは請求内容(invoice_contents)は、最大100行までになります。</p> </li>\n</ul>",
-        "operationId": "update_invoice",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "請求書ID",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 1
-            }
-          }
-        ],
-        "requestBody": {
-          "description": "請求書の更新",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/invoiceUpdateParams"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/invoiceUpdateParams"
-              }
-            }
-          },
-          "required": false
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/invoiceResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/badRequestError"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/unauthorizedError"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/forbiddenError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/badRequestNotFoundError"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/internalServerError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": ["Invoices"],
-        "summary": "請求書の削除",
-        "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の請求書を削除する</p>",
-        "operationId": "destroy_invoice",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 1
-            }
-          },
-          {
-            "name": "company_id",
-            "in": "query",
-            "description": "事業所ID",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 1
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          },
-          "400": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/badRequestError"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/unauthorizedError"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/forbiddenError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/badRequestNotFoundError"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/internalServerError"
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/api/1/quotations": {
       "get": {
-        "tags": ["Quotations"],
+        "tags": [
+          "Quotations"
+        ],
         "summary": "見積書一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の見積書一覧を取得する</p>\n",
         "operationId": "get_quotations",
@@ -2726,7 +3322,11 @@
             "description": "見積書ステータス  (unsubmitted: 送付待ち, submitted: 送付済み, all: 全て)",
             "schema": {
               "type": "string",
-              "enum": ["all", "unsubmitted", "submitted"]
+              "enum": [
+                "all",
+                "unsubmitted",
+                "submitted"
+              ]
             }
           },
           {
@@ -2814,96 +3414,13 @@
             }
           }
         }
-      },
-      "post": {
-        "tags": ["Quotations"],
-        "summary": "見積書の作成（廃止）",
-        "deprecated": true,
-        "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の見積書を作成する</p>\n\n<h2 id=\"_1\">注意点</h2>\n<b>インボイス制度に伴い、freee会計の帳票機能がfreee請求書に移行しました。これに伴い、2023年10月からfreee会計の「見積書の作成」エンドポイントは廃止され、freee請求書APIに移行しました。詳細は<a href=\"https://developer.freee.co.jp/news/6369\" target=\"_blank\"> freee会計 APIの仕様変更（インボイス制度対応）について</a>をご確認ください。</b>\n<ul>\n<li> <p>partner_code, partner_idはどちらかの指定が必須です。ただし両方同時に指定することはできません。</p> </li>\n<li> <p>partner_codeを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。</p> </li>\n<li> <p>本APIでは見積内容(quotation_contents)は、最大100行までになります。</p> </li>\n</ul>",
-        "operationId": "create_quotation",
-        "requestBody": {
-          "description": "見積書の作成",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/quotationCreateParams"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/quotationCreateParams"
-              }
-            }
-          },
-          "required": false
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/quotationResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/badRequestError"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/unauthorizedError"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/forbiddenError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/badRequestNotFoundError"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/internalServerError"
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/api/1/quotations/{id}": {
       "get": {
-        "tags": ["Quotations"],
+        "tags": [
+          "Quotations"
+        ],
         "summary": "見積書の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の見積書詳細を取得する</p>",
         "operationId": "get_quotation",
@@ -2993,195 +3510,15 @@
             }
           }
         }
-      },
-      "put": {
-        "tags": ["Quotations"],
-        "summary": "見積書の更新",
-        "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の見積書を更新する</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n<li> <p>partner_code, partner_idを両方同時に指定することはできません。</p> </li>\n<li> <p>partner_codeを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。</p> </li>\n<li> <p>本APIでは見積内容(quotation_contents)は、最大100行までになります。</p> </li>\n</ul>",
-        "operationId": "update_quotation",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "見積書ID",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 1
-            }
-          }
-        ],
-        "requestBody": {
-          "description": "見積書の更新",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/quotationUpdateParams"
-              }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/quotationUpdateParams"
-              }
-            }
-          },
-          "required": false
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/quotationResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/badRequestError"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/unauthorizedError"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/forbiddenError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/badRequestNotFoundError"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/internalServerError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": ["Quotations"],
-        "summary": "見積書の削除",
-        "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の見積書を削除する</p>",
-        "operationId": "destroy_quotation",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 1
-            }
-          },
-          {
-            "name": "company_id",
-            "in": "query",
-            "description": "事業所ID",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": 1
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "",
-            "content": {}
-          },
-          "400": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/badRequestError"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/unauthorizedError"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/forbiddenError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/badRequestNotFoundError"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/internalServerError"
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/api/1/deals": {
       "get": {
-        "tags": ["Deals"],
+        "tags": [
+          "Deals"
+        ],
         "summary": "取引（収入・支出）一覧の取得",
-        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の取引（収入・支出）一覧を取得する</p>\n<h2 id=\"_2\">定義</h2>\n<ul>\n<li>\n<p>issue_date : 発生日</p>\n</li>\n<li>\n<p>due_date : 支払期日</p>\n</li>\n<li>\n<p>amount : 金額</p>\n</li>\n<li>\n<p>due_amount : 支払残額</p>\n</li>\n<li>\n<p>type</p>\n<ul>\n<li>income : 収入</li>\n<li>expense : 支出</li>\n</ul>\n</li>\n<li>\n<p>details : 取引の明細行</p>\n</li>\n<li>\n<p>accruals : 取引の債権債務行</p>\n</li>\n<li>\n<p>renews : 取引の+更新行</p>\n</li>\n<li>\n<p>payments : 取引の支払行</p>\n</li>\n<li>\n<p>from_walletable_type</p>\n<ul>\n<li>bank_account : 銀行口座</li>\n<li>credit_card : クレジットカード</li>\n<li>wallet : 現金</li>\n<li>private_account_item : プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）</li>\n</ul>\n</li>\n<li>\n<p>registered_from</p>\n<ul>\n<li>all : すべての取引</li>\n<li>me : 自身が登録した取引</li>\n</ul>\n</li>\n</ul>\n<h2 id=\"_3\">注意点</h2>\n<ul>\n<li>セグメントタグ情報は法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で利用可能です。利用可能なセグメントの数は、法人アドバンスプラン（および旧法人プロフェッショナルプラン）の場合は1つ、法人エンタープライズプランの場合は3つです。</li>\n<li>partner_codeを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。またpartner_codeとpartner_idは同時に指定することはできません。</li>\n</ul>",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の取引（収入・支出）一覧を取得する</p>\n<h2 id=\"_2\">定義</h2>\n<ul>\n<li>\n<p>issue_date : 発生日</p>\n</li>\n<li>\n<p>due_date : 支払期日</p>\n</li>\n<li>\n<p>amount : 金額</p>\n</li>\n<li>\n<p>due_amount : 支払残額</p>\n</li>\n<li>\n<p>type</p>\n<ul>\n<li>income : 収入</li>\n<li>expense : 支出</li>\n</ul>\n</li>\n<li>\n<p>details : 取引の明細行</p>\n</li>\n<li>\n<p>accruals : 取引の債権債務行</p>\n</li>\n<li>\n<p>renews : 取引の+更新行</p>\n</li>\n<li>\n<p>payments : 取引の支払行</p>\n</li>\n<li>\n<p>from_walletable_type</p>\n<ul>\n<li>bank_account : 銀行口座</li>\n<li>credit_card : クレジットカード</li>\n<li>wallet : 現金</li>\n<li>private_account_item : プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）</li>\n</ul>\n</li>\n</ul>\n<h2 id=\"_3\">注意点</h2>\n<ul>\n<li>セグメントタグ情報は法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で利用可能です。利用可能なセグメントの数は、法人アドバンスプラン（および旧法人プロフェッショナルプラン）の場合は1つ、法人エンタープライズプランの場合は3つです。</li>\n<li>partner_codeを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。またpartner_codeとpartner_idは同時に指定することはできません。</li>\n</ul>",
         "operationId": "get_deals",
         "parameters": [
           {
@@ -3229,7 +3566,10 @@
             "description": "決済状況で絞込 (未決済: unsettled, 完了: settled)",
             "schema": {
               "type": "string",
-              "enum": ["unsettled", "settled"]
+              "enum": [
+                "unsettled",
+                "settled"
+              ]
             }
           },
           {
@@ -3238,7 +3578,10 @@
             "description": "収支区分 (収入: income, 支出: expense)",
             "schema": {
               "type": "string",
-              "enum": ["income", "expense"]
+              "enum": [
+                "income",
+                "expense"
+              ]
             }
           },
           {
@@ -3312,21 +3655,15 @@
             }
           },
           {
-            "name": "registered_from",
-            "in": "query",
-            "description": "取引登録元アプリで絞込（me: 本APIを叩くアプリ自身から登録した取引のみ）",
-            "schema": {
-              "type": "string",
-              "enum": ["me"]
-            }
-          },
-          {
             "name": "accruals",
             "in": "query",
             "description": "取引の債権債務行の表示（without: 表示しない(デフォルト), with: 表示する）",
             "schema": {
               "type": "string",
-              "enum": ["without", "with"]
+              "enum": [
+                "without",
+                "with"
+              ]
             }
           }
         ],
@@ -3337,7 +3674,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["deals", "meta"],
+                  "required": [
+                    "deals",
+                    "meta"
+                  ],
                   "properties": {
                     "deals": {
                       "type": "array",
@@ -3347,7 +3687,9 @@
                     },
                     "meta": {
                       "type": "object",
-                      "required": ["total_count"],
+                      "required": [
+                        "total_count"
+                      ],
                       "properties": {
                         "total_count": {
                           "type": "integer",
@@ -3416,12 +3758,13 @@
         }
       },
       "post": {
-        "tags": ["Deals"],
+        "tags": [
+          "Deals"
+        ],
         "summary": "取引（収入・支出）の作成",
-        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の取引（収入・支出）を作成する</p>\n<h2 id=\"_2\">定義</h2>\n<ul>\n<li>\n<p>issue_date : 発生日</p>\n</li>\n<li>\n<p>due_date : 支払期日</p>\n</li>\n<li>\n<p>amount : 金額</p>\n</li>\n<li>\n<p>due_amount : 支払残額</p>\n</li>\n<li>\n<p>type</p>\n<ul>\n<li>income : 収入</li>\n<li>expense : 支出</li>\n</ul>\n</li>\n<li>\n<p>ref_number : 管理番号</p>\n</li>\n<li>\n<p>details : 取引の明細行(最大40行)</p>\n</li>\n<li>\n<p>payments : 取引の支払行</p>\n</li>\n<li>\n<p>receipt_ids : ファイルボックス（証憑ファイル）ID</p>\n</li>\n<li>\n<p>from_walletable_type</p>\n<ul>\n<li>bank_account : 銀行口座</li>\n<li>credit_card : クレジットカード</li>\n<li>wallet : 現金</li>\n<li>private_account_item : プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）</li>\n</ul>\n</li>\n</ul>\n<h2 id=\"_3\">注意点</h2>\n<ul>\n    <li><p>本APIでは+更新行(renews)の操作ができません。取引（収入・支出）の+更新の作成APIをご利用ください。</p></li>\n    <li><p>セグメントタグ情報は法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で利用可能です。利用可能なセグメントの数は、法人アドバンスプラン（および旧法人プロフェッショナルプラン）の場合は1つ、法人エンタープライズプランの場合は3つです。</p></li>\n    <li>\n        <p>partner_codeを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。またpartner_codeとpartner_idは同時に指定することはできません。</p></li>\n    <li>\n        <p>本APIでは取引の明細行(details)は、最大40行までになります。</p>\n    </li>\n</ul>\n",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の取引（収入・支出）を作成する</p>\n<h2 id=\"_2\">定義</h2>\n<ul>\n<li>\n<p>issue_date : 発生日</p>\n</li>\n<li>\n<p>due_date : 支払期日</p>\n</li>\n<li>\n<p>amount : 金額</p>\n</li>\n<li>\n<p>due_amount : 支払残額</p>\n</li>\n<li>\n<p>type</p>\n<ul>\n<li>income : 収入</li>\n<li>expense : 支出</li>\n</ul>\n</li>\n<li>\n<p>ref_number : 管理番号</p>\n</li>\n<li>\n<p>details : 取引の明細行(最大40行)</p>\n</li>\n<li>\n<p>payments : 取引の支払行</p>\n</li>\n<li>\n<p>receipt_ids : ファイルボックス（証憑ファイル）ID</p>\n</li>\n<li>\n<p>from_walletable_type</p>\n<ul>\n<li>bank_account : 銀行口座</li>\n<li>credit_card : クレジットカード</li>\n<li>wallet : 現金</li>\n<li>private_account_item : プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）</li>\n</ul>\n</li>\n</ul>\n<h2 id=\"_3\">注意点</h2>\n<ul>\n    <li><p>本APIでは+更新行(renews)の操作ができません。取引（収入・支出）の+更新の作成APIをご利用ください。</p></li>\n    <li><p>セグメントタグ情報は法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で利用可能です。利用可能なセグメントの数は、法人アドバンスプラン（および旧法人プロフェッショナルプラン）の場合は1つ、法人エンタープライズプランの場合は3つです。</p></li>\n    <li>\n        <p>partner_codeを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。またpartner_codeとpartner_idは同時に指定することはできません。</p></li>\n    <li>\n        <p>account_item_codeを利用するには、事業所の設定から勘定科目コードの利用を有効にする必要があります。またaccount_item_codeとaccount_item_idは同時に指定することはできません。</p></li>\n    <li>\n        <p>item_codeを利用するには、事業所の設定から品目コードの利用を有効にする必要があります。またitem_codeとitem_idは同時に指定することはできません。</p></li>\n    <li>\n        <p>section_codeを利用するには、事業所の設定から部門コードの利用を有効にする必要があります。またsection_codeとsection_idは同時に指定することはできません。</p></li>\n    <li>\n        <p>segment_1_tag_codeを利用するには、事業所の設定からセグメントタグコードの利用を有効にする必要があります。またsegment_1_tag_codeとsegment_1_tag_idは同時に指定することはできません。</p></li>\n    <li>\n        <p>segment_2_tag_codeを利用するには、事業所の設定からセグメントタグコードの利用を有効にする必要があります。またsegment_2_tag_codeとsegment_2_tag_idは同時に指定することはできません。</p></li>\n    <li>\n        <p>segment_3_tag_codeを利用するには、事業所の設定からセグメントタグコードの利用を有効にする必要があります。またsegment_3_tag_codeとsegment_3_tag_idは同時に指定することはできません。</p></li>\n    <li>\n        <p>本APIでは取引の明細行(details)は、最大40行までになります。</p>\n    </li>\n</ul>\n",
         "operationId": "create_deal",
         "requestBody": {
-          "description": "取引（収入・支出）の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -3502,7 +3845,9 @@
     },
     "/api/1/deals/{id}": {
       "get": {
-        "tags": ["Deals"],
+        "tags": [
+          "Deals"
+        ],
         "summary": "取引（収入・支出）の取得",
         "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の取引（収入・支出）を取得する</p>\n<h2 id=\"_2\">定義</h2>\n<ul>\n<li>\n<p>issue_date : 発生日</p>\n</li>\n<li>\n<p>due_date : 支払期日</p>\n</li>\n<li>\n<p>amount : 金額</p>\n</li>\n<li>\n<p>due_amount : 支払残額</p>\n</li>\n<li>\n<p>type</p>\n<ul>\n<li>income : 収入</li>\n<li>expense : 支出</li>\n</ul>\n</li>\n<li>\n<p>details : 取引の明細行</p>\n</li>\n<li>\n<p>accruals : 取引の債権債務行</p>\n</li>\n<li>\n<p>renews : 取引の+更新行</p>\n</li>\n<li>\n<p>payments : 取引の支払行</p>\n</li>\n<li>\n<p>from_walletable_type</p>\n<ul>\n<li>bank_account : 銀行口座</li>\n<li>credit_card : クレジットカード</li>\n<li>wallet : 現金</li>\n<li>private_account_item : プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）</li>\n</ul>\n</li>\n</ul>\n<h2 id=\"_3\">注意点</h2>\n<ul>\n<li>セグメントタグ情報は法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で利用可能です。利用可能なセグメントの数は、法人アドバンスプラン（および旧法人プロフェッショナルプラン）の場合は1つ、法人エンタープライズプランの場合は3つです。</li>\n</ul>",
         "operationId": "get_deal",
@@ -3534,7 +3879,10 @@
             "description": "取引の債権債務行の表示（without: 表示しない(デフォルト), with: 表示する）",
             "schema": {
               "type": "string",
-              "enum": ["without", "with"]
+              "enum": [
+                "without",
+                "with"
+              ]
             }
           }
         ],
@@ -3602,7 +3950,9 @@
         }
       },
       "put": {
-        "tags": ["Deals"],
+        "tags": [
+          "Deals"
+        ],
         "summary": "取引（収入・支出）の更新",
         "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の取引（収入・支出）を更新する</p>\n<h2 id=\"_2\">定義</h2>\n<ul>\n<li>\n<p>issue_date : 発生日</p>\n</li>\n<li>\n<p>due_date : 支払期日</p>\n</li>\n<li>\n<p>amount : 金額</p>\n</li>\n<li>\n<p>due_amount : 支払残額</p>\n</li>\n<li>\n<p>type</p>\n<ul>\n<li>income : 収入</li>\n<li>expense : 支出</li>\n</ul>\n</li>\n<li>\n<p>details : 取引の明細行(最大40行)</p>\n</li>\n<li>\n<p>renews : 取引の+更新行</p>\n</li>\n<li>\n<p>payments : 取引の支払行</p>\n</li>\n<li>\n<p>from_walletable_type</p>\n<ul>\n<li>bank_account : 銀行口座</li>\n<li>credit_card : クレジットカード</li>\n<li>wallet : 現金</li>\n<li>private_account_item : プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）</li>\n</ul>\n</li>\n<li>\n<p>receipt_ids : ファイルボックス（証憑ファイル）ID</p>\n</li>\n</ul>\n<h2 id=\"_3\">注意点</h2>\n<ul>\n    <li><p>本APIでは支払行(payments)の操作ができません。取引（収入・支出）の支払行の作成・更新・削除APIをご利用ください。</p></li>\n    <li><p>本APIでは+更新行(renews)の操作ができません。取引（収入・支出）の+更新の作成・更新・削除APIをご利用ください。</p></li>\n    <li><p>本APIでは収入／支出の切替えができません。既存の取引を削除後、再度作成してください。</p></li>\n    <li><p>本APIで取引を更新すると、消費税の計算方法は必ず内税方式が選択されます。</p></li>\n    <li><p>セグメントタグ情報は法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で利用可能です。利用可能なセグメントの数は、法人アドバンスプラン（および旧法人プロフェッショナルプラン）の場合は1つ、法人エンタープライズプランの場合は3つです。</p></li>\n    <li><p>partner_codeを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。またpartner_codeとpartner_idは同時に指定することはできません。</p></li>\n    <li><p>freee請求書から登録された取引は品目・部門・メモタグ・セグメント1、2、3のみ更新可能です。</p></li>\n    <li>\n        <p>本APIでは取引の明細行(details)は、最大40行までになります。</p>\n    </li>\n</ul>",
         "operationId": "update_deal",
@@ -3620,7 +3970,6 @@
           }
         ],
         "requestBody": {
-          "description": "取引（収入・支出）の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -3699,7 +4048,9 @@
         }
       },
       "delete": {
-        "tags": ["Deals"],
+        "tags": [
+          "Deals"
+        ],
         "summary": "取引（収入・支出）の削除",
         "description": "<h2 id=\"\">概要</h2>\n<p>指定した取引（収入・支出）を削除する</p>\n",
         "operationId": "destroy_deal",
@@ -3787,7 +4138,9 @@
     },
     "/api/1/deals/{id}/renews": {
       "post": {
-        "tags": ["Renews"],
+        "tags": [
+          "Renews"
+        ],
         "summary": "取引（収入・支出）の+更新の作成",
         "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の取引（収入・支出）の+更新を作成する</p>\n<h2 id=\"_2\">定義</h2>\n<ul> <li> <p>issue_date : 発生日</p> </li>\n<li> <p>due_date : 支払期日</p> </li>\n<li> <p>amount : 金額</p> </li>\n<li> <p>due_amount : 支払残額</p> </li>\n<li> <p>type</p>\n<ul> <li>income : 収入</li>\n<li>expense : 支出</li> </ul> </li>\n<li> <p>details : 取引の明細行</p> </li>\n<li> <p>accruals : 取引の債権債務行</p> </li>\n<li> <p>renews : 取引の+更新行</p> </li>\n<li> <p>payments : 取引の支払行</p> </li>\n<li> <p>from_walletable_type</p>\n<ul> <li>bank_account : 銀行口座</li>\n<li>credit_card : クレジットカード</li>\n<li>wallet : 現金</li>\n<li>private_account_item : プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）</li>\n</ul> </li> </ul>\n<h2 id=\"_3\">注意点</h2>\n<ul> <li>本APIではdetails(取引の明細行)、accruals(債権債務行)、renewsのdetails(+更新の明細行)のみ操作可能です。</li>\n<li>本APIで取引を更新すると、消費税の計算方法は必ず内税方式が選択されます。</li> </ul>\n",
         "operationId": "create_deal_renew",
@@ -3804,7 +4157,6 @@
           }
         ],
         "requestBody": {
-          "description": "取引（収入・支出）の+更新の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -3875,7 +4227,9 @@
     },
     "/api/1/deals/{id}/renews/{renew_id}": {
       "put": {
-        "tags": ["Renews"],
+        "tags": [
+          "Renews"
+        ],
         "summary": "取引（収入・支出）の+更新の更新",
         "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の取引（収入・支出）の+更新を更新する</p>\n<h2 id=\"_2\">定義</h2>\n<ul> <li> <p>issue_date : 発生日</p> </li>\n<li> <p>due_date : 支払期日</p> </li>\n<li> <p>amount : 金額</p> </li>\n<li> <p>due_amount : 支払残額</p> </li>\n<li> <p>type</p>\n<ul> <li>income : 収入</li>\n<li>expense : 支出</li> </ul> </li>\n<li> <p>details : 取引の明細行</p> </li>\n<li> <p>accruals : 取引の債権債務行</p> </li>\n<li> <p>renews : 取引の+更新行</p> </li>\n<li> <p>payments : 取引の支払行</p> </li>\n<li> <p>from_walletable_type</p>\n<ul> <li>bank_account : 銀行口座</li>\n<li>credit_card : クレジットカード</li>\n<li>wallet : 現金</li>\n<li>private_account_item : プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）</li>\n</ul> </li> </ul>\n<h2 id=\"_3\">注意点</h2>\n<ul> <li>本APIでは+更新の更新のみ可能です。取引や支払行に対する更新はできません。</li> <li>renew_idにはrenewsのid(+更新ID)を指定してください。renewsのdetailsのid(+更新の明細行ID)を指定できません。</li> <li>月締めされている仕訳に紐づく＋更新行の編集・削除はできません。</li> <li>承認済み仕訳に紐づく＋更新行の編集・削除は管理者権限のユーザーのみ可能です。</li>\n<li>本APIで取引を更新すると、消費税の計算方法は必ず内税方式が選択されます。</li> </ul>\n",
         "operationId": "update_deal_renew",
@@ -3904,7 +4258,6 @@
           }
         ],
         "requestBody": {
-          "description": "取引（収入・支出）の+更新の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -3973,7 +4326,9 @@
         }
       },
       "delete": {
-        "tags": ["Renews"],
+        "tags": [
+          "Renews"
+        ],
         "summary": "取引（収入・支出）の+更新の削除",
         "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の取引（収入・支出）の+更新を削除する</p>\n<h2 id=\"_3\">注意点</h2>\n<ul> <li>本APIでは+更新の削除のみ可能です。取引や支払行に対する削除はできません。</li> <li>renew_idにはrenewsのid(+更新ID)を指定してください。renewsのdetailsのid(+更新の明細行ID)を指定できません。</li>\n<li>月締めされている仕訳に紐づく＋更新行の編集・削除はできません。</li> <li>承認済み仕訳に紐づく＋更新行の編集・削除は管理者権限のユーザーのみ可能です。</li>\n<li>本APIで取引を更新すると、消費税の計算方法は必ず内税方式が選択されます。</li> </ul>\n",
         "operationId": "delete_deal_renew",
@@ -4068,7 +4423,9 @@
     },
     "/api/1/deals/{id}/payments": {
       "post": {
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "summary": "取引（収入・支出）の支払行の作成",
         "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の取引（収入・支出）の支払行を作成する</p>\n<h2 id=\"_2\">定義</h2>\n<ul>\n<li>\n<p>issue_date : 発生日</p>\n</li>\n<li>\n<p>due_date : 支払期日</p>\n</li>\n<li>\n<p>amount : 金額</p>\n</li>\n<li>\n<p>due_amount : 支払残額</p>\n</li>\n<li>\n<p>type</p>\n<ul>\n<li>income : 収入</li>\n<li>expense : 支出</li>\n</ul>\n</li>\n<li> <p>details : 取引の明細行</p> </li>\n<li> <p>renews : 取引の+更新行</p> </li>\n<li> <p>payments : 取引の支払行</p> </li>\n<li>\n<p>from_walletable_type</p>\n<ul>\n<li>bank_account : 銀行口座</li>\n<li>credit_card : クレジットカード</li>\n<li>wallet : 現金</li>\n<li>private_account_item : プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）</li>\n</ul>\n</li>\n</ul>",
         "operationId": "create_deal_payment",
@@ -4086,7 +4443,6 @@
           }
         ],
         "requestBody": {
-          "description": "取引（収入・支出）の支払行の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -4167,7 +4523,9 @@
     },
     "/api/1/deals/{id}/payments/{payment_id}": {
       "put": {
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "summary": "取引（収入・支出）の支払行の更新",
         "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の取引（収入・支出）の支払行を更新する</p>\n<h2 id=\"_2\">定義</h2>\n<ul>\n<li>\n<p>issue_date : 発生日</p>\n</li>\n<li>\n<p>due_date : 支払期日</p>\n</li>\n<li>\n<p>amount : 金額</p>\n</li>\n<li>\n<p>due_amount : 支払残額</p>\n</li>\n<li>\n<p>type</p>\n<ul>\n<li>income : 収入</li>\n<li>expense : 支出</li>\n</ul>\n</li>\n<li>\n<p>details : 取引の明細行</p>\n</li>\n<li>\n<p>renews : 取引の+更新行</p>\n</li>\n<li>\n<p>payments : 取引の支払行</p>\n</li>\n<li>\n<p>from_walletable_type</p>\n<ul>\n<li>bank_account : 銀行口座</li>\n<li>credit_card : クレジットカード</li>\n<li>wallet : 現金</li>\n<li>private_account_item : プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）</li>\n</ul>\n</li>\n</ul>",
         "operationId": "update_deal_payment",
@@ -4196,7 +4554,6 @@
           }
         ],
         "requestBody": {
-          "description": "取引（収入・支出）の支払行の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -4275,7 +4632,9 @@
         }
       },
       "delete": {
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "summary": "取引（収入・支出）の支払行の削除",
         "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の取引（収入・支出）の支払行を削除する</p>\n<h2 id=\"_2\">定義</h2>\n<ul>\n<li>\n<p>issue_date : 発生日</p>\n</li>\n<li>\n<p>due_date : 支払期日</p>\n</li>\n<li>\n<p>amount : 金額</p>\n</li>\n<li>\n<p>due_amount : 支払残額</p>\n</li>\n<li>\n<p>type</p>\n<ul>\n<li>income : 収入</li>\n<li>expense : 支出</li>\n</ul>\n</li>\n<li>\n<p>details : 取引の明細行</p>\n</li>\n</ul>",
         "operationId": "destroy_deal_payment",
@@ -4374,7 +4733,9 @@
     },
     "/api/1/manual_journals": {
       "get": {
-        "tags": ["ManualJournals"],
+        "tags": [
+          "ManualJournals"
+        ],
         "summary": "振替伝票一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の振替伝票一覧を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>\n<p>issue_date : 発生日</p>\n</li>\n\n<li>\n<p>adjustment : 決算整理仕訳フラグ（true: 決算整理仕訳, false: 日常仕訳）</p>\n</li>\n\n<li>\n<p>txn_number : 仕訳番号</p>\n</li>\n\n<li>\n<p>details : 振替伝票の貸借行</p>\n</li>\n\n<li>\n<p>entry_side : 貸借区分</p>\n\n<ul>\n<li>credit : 貸方</li>\n\n<li>debit : 借方</li>\n</ul>\n</li>\n\n<li>\n<p>amount : 金額</p>\n</li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n\n<ul>\n<li>振替伝票は売掛・買掛レポートには反映されません。債権・債務データの登録は取引(Deals)をお使いください。</li>\n<li>事業所の仕訳番号形式が有効な場合のみ、レスポンスで仕訳番号(txn_number)を返します。</li>\n<li>セグメントタグ情報は法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で利用可能です。利用可能なセグメントの数は、法人アドバンスプラン（および旧法人プロフェッショナルプラン）の場合は1つ、法人エンタープライズプランの場合は3つです。</li>\n<li>partner_codeを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。またpartner_codeとpartner_idは同時に指定することはできません。</li></ul>",
         "operationId": "get_manual_journals",
@@ -4412,7 +4773,10 @@
             "description": "貸借で絞込 (貸方: credit, 借方: debit)",
             "schema": {
               "type": "string",
-              "enum": ["credit", "debit"]
+              "enum": [
+                "credit",
+                "debit"
+              ]
             }
           },
           {
@@ -4535,7 +4899,7 @@
           {
             "name": "comment_important",
             "in": "query",
-            "description": "重要コメント付きの振替伝票を絞込",
+            "description": "お気に入りコメント付きの振替伝票を絞込",
             "schema": {
               "type": "boolean"
             }
@@ -4546,7 +4910,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -4587,7 +4954,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["manual_journals"],
+                  "required": [
+                    "manual_journals"
+                  ],
                   "properties": {
                     "manual_journals": {
                       "type": "array",
@@ -4643,12 +5012,13 @@
         }
       },
       "post": {
-        "tags": ["ManualJournals"],
+        "tags": [
+          "ManualJournals"
+        ],
         "summary": "振替伝票の作成",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の振替伝票を作成する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>\n<p>issue_date : 発生日</p>\n</li>\n\n<li>\n<p>adjustment : 決算整理仕訳フラグ（true: 決算整理仕訳, false: 日常仕訳）</p>\n</li>\n\n<li>\n<p>txn_number : 仕訳番号</p>\n</li>\n\n<li>\n<p>details : 振替伝票の貸借行</p>\n</li>\n\n<li>\n<p>entry_side : 貸借区分</p>\n\n<ul>\n<li>credit : 貸方</li>\n\n<li>debit : 借方</li>\n</ul>\n</li>\n\n<li>\n<p>amount : 金額</p>\n</li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n\n<ul>\n<li>振替伝票は売掛・買掛レポートには反映されません。債権・債務データの登録は取引(Deals)をお使いください。</li>\n<li>事業所の仕訳番号形式が有効な場合のみ、レスポンスで仕訳番号(txn_number)を返します。</li>\n<li>貸借合わせて100行まで仕訳行を登録できます。</li>\n<li>セグメントタグ情報は法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で利用可能です。利用可能なセグメントの数は、法人アドバンスプラン（および旧法人プロフェッショナルプラン）の場合は1つ、法人エンタープライズプランの場合は3つです。</li>\n<li>partner_codeを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。またpartner_codeとpartner_idは同時に指定することはできません。</li></ul>\n\n",
         "operationId": "create_manual_journal",
         "requestBody": {
-          "description": "振替伝票の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -4729,7 +5099,9 @@
     },
     "/api/1/manual_journals/{id}": {
       "get": {
-        "tags": ["ManualJournals"],
+        "tags": [
+          "ManualJournals"
+        ],
         "summary": "振替伝票の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の振替伝票を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul> <li> <p>issue_date : 発生日</p> </li>\n<li> <p>adjustment : 決算整理仕訳フラグ（true: 決算整理仕訳, false: 日常仕訳）</p> </li>\n<li> <p>txn_number : 仕訳番号</p> </li>\n<li> <p>details : 振替伝票の貸借行</p> </li>\n<li> <p>entry_side : 貸借区分</p>\n<ul> <li>credit : 貸方</li>\n<li>debit : 借方</li> </ul> </li>\n<li> <p>amount : 金額</p> </li> </ul>\n\n<h2 id=\"_3\">注意点</h2>\n\n<ul>\n<li>振替伝票は売掛・買掛レポートには反映されません。債権・債務データの登録は取引(Deals)をお使いください。</li>\n<li>事業所の仕訳番号形式が有効な場合のみ、レスポンスで仕訳番号(txn_number)を返します。</li>\n<li>セグメントタグ情報は法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で利用可能です。利用可能なセグメントの数は、法人アドバンスプラン（および旧法人プロフェッショナルプラン）の場合は1つ、法人エンタープライズプランの場合は3つです。</li>\n</ul>",
         "operationId": "get_manual_journal",
@@ -4820,7 +5192,9 @@
         }
       },
       "put": {
-        "tags": ["ManualJournals"],
+        "tags": [
+          "ManualJournals"
+        ],
         "summary": "振替伝票の更新",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の振替伝票を更新する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>\n<p>issue_date : 発生日</p>\n</li>\n\n<li>\n<p>adjustment : 決算整理仕訳フラグ（true: 決算整理仕訳, false: 日常仕訳）</p>\n</li>\n\n<li>\n<p>txn_number : 仕訳番号</p>\n</li>\n\n<li>\n<p>details : 振替伝票の貸借行</p>\n</li>\n\n<li>\n<p>entry_side : 貸借区分</p>\n\n<ul>\n<li>credit : 貸方</li>\n\n<li>debit : 借方</li>\n</ul>\n</li>\n\n<li>\n<p>amount : 金額</p>\n</li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n\n<ul>\n<li>振替伝票は売掛・買掛レポートには反映されません。債権・債務データの登録は取引(Deals)をお使いください。</li>\n\n<li>事業所の仕訳番号形式が有効な場合のみ、レスポンスで仕訳番号(txn_number)を返します。</li>\n<li>貸借合わせて100行まで仕訳行を登録できます。</li>\n\n<li>detailsに含まれない既存の貸借行は削除されます。更新後も残したい行は、必ず貸借行IDを指定してdetailsに含めてください。</li>\n\n<li>detailsに含まれる貸借行IDの指定がある行は、更新行として扱われ更新されます。</li>\n\n<li>detailsに含まれる貸借行IDの指定がない行は、新規行として扱われ追加されます。</li>\n<li>セグメントタグ情報は法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で利用可能です。利用可能なセグメントの数は、法人アドバンプスラン（および旧法人プロフェッショナルプラン）の場合は1つ、法人エンタープライズプランの場合は3つです。</li>\n<li>partner_codeを利用するには、事業所の設定から取引先コードの利用を有効にする必要があります。またpartner_codeとpartner_idは同時に指定することはできません。</li></ul>\n\n",
         "operationId": "update_manual_journal",
@@ -4837,7 +5211,6 @@
           }
         ],
         "requestBody": {
-          "description": "振替伝票の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -4916,7 +5289,9 @@
         }
       },
       "delete": {
-        "tags": ["ManualJournals"],
+        "tags": [
+          "ManualJournals"
+        ],
         "summary": "振替伝票の削除",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の振替伝票を削除する</p>",
         "operationId": "destroy_manual_journal",
@@ -5003,7 +5378,9 @@
     },
     "/api/1/users": {
       "get": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "事業所に所属するユーザー一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>事業所に所属するユーザー一覧を取得する</p>",
         "operationId": "get_users",
@@ -5038,7 +5415,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["users"],
+                  "required": [
+                    "users"
+                  ],
                   "properties": {
                     "users": {
                       "type": "array",
@@ -5106,7 +5485,9 @@
     },
     "/api/1/users/me": {
       "get": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "ログインユーザーの取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>ログインユーザーを取得する</p>",
         "operationId": "get_users_me",
@@ -5117,7 +5498,10 @@
             "description": "取得情報にユーザーが所属する事業所一覧を含める",
             "schema": {
               "type": "boolean",
-              "enum": [true, false]
+              "enum": [
+                true,
+                false
+              ]
             }
           },
           {
@@ -5126,7 +5510,10 @@
             "description": "取得情報に事業がアドバイザー事象所の場合は事業所毎の一意なプロフィールIDを含める",
             "schema": {
               "type": "boolean",
-              "enum": [true, false]
+              "enum": [
+                true,
+                false
+              ]
             }
           }
         ],
@@ -5194,12 +5581,13 @@
         }
       },
       "put": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "ログインユーザーの更新",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>ログインユーザーを更新する</p>",
         "operationId": "update_user",
         "requestBody": {
-          "description": "ログインユーザーの更新",
           "content": {
             "application/json": {
               "schema": {
@@ -5280,7 +5668,9 @@
     },
     "/api/1/users/capabilities": {
       "get": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "ログインユーザーの権限の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>ログインユーザーの権限を取得する</p>",
         "operationId": "get_users_capabilities",
@@ -5643,7 +6033,9 @@
     },
     "/api/1/companies": {
       "get": {
-        "tags": ["Companies"],
+        "tags": [
+          "Companies"
+        ],
         "summary": "事業所一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>ユーザーが所属する事業所一覧を取得する</p>",
         "operationId": "get_companies",
@@ -5703,7 +6095,9 @@
     },
     "/api/1/companies/{id}": {
       "get": {
-        "tags": ["Companies"],
+        "tags": [
+          "Companies"
+        ],
         "summary": "事業所の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>ユーザーが所属する事業所を取得する</p>",
         "operationId": "get_company",
@@ -5724,7 +6118,9 @@
             "description": "取得情報に勘定科目・税区分コード・品目・取引先・部門・メモタグ・口座の一覧を含める",
             "schema": {
               "type": "boolean",
-              "enum": [true]
+              "enum": [
+                true
+              ]
             }
           },
           {
@@ -5733,7 +6129,9 @@
             "description": "取得情報に勘定科目一覧を含める",
             "schema": {
               "type": "boolean",
-              "enum": [true]
+              "enum": [
+                true
+              ]
             }
           },
           {
@@ -5742,7 +6140,9 @@
             "description": "取得情報に税区分コード一覧を含める",
             "schema": {
               "type": "boolean",
-              "enum": [true]
+              "enum": [
+                true
+              ]
             }
           },
           {
@@ -5751,7 +6151,9 @@
             "description": "取得情報に品目一覧を含める",
             "schema": {
               "type": "boolean",
-              "enum": [true]
+              "enum": [
+                true
+              ]
             }
           },
           {
@@ -5760,7 +6162,9 @@
             "description": "取得情報に取引先一覧を含める",
             "schema": {
               "type": "boolean",
-              "enum": [true]
+              "enum": [
+                true
+              ]
             }
           },
           {
@@ -5769,7 +6173,9 @@
             "description": "取得情報に部門一覧を含める",
             "schema": {
               "type": "boolean",
-              "enum": [true]
+              "enum": [
+                true
+              ]
             }
           },
           {
@@ -5778,7 +6184,9 @@
             "description": "取得情報にメモタグ一覧を含める",
             "schema": {
               "type": "boolean",
-              "enum": [true]
+              "enum": [
+                true
+              ]
             }
           },
           {
@@ -5787,7 +6195,9 @@
             "description": "取得情報に口座一覧を含める",
             "schema": {
               "type": "boolean",
-              "enum": [true]
+              "enum": [
+                true
+              ]
             }
           }
         ],
@@ -5847,7 +6257,9 @@
     },
     "/api/1/items": {
       "get": {
-        "tags": ["Items"],
+        "tags": [
+          "Items"
+        ],
         "summary": "品目一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の品目一覧を取得する</p>\n<p>事業所の設定で品目コードを使用する設定にしている場合、レスポンスで品目コード(code)を返します</p>",
         "operationId": "get_items",
@@ -5909,7 +6321,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["items"],
+                  "required": [
+                    "items"
+                  ],
                   "properties": {
                     "items": {
                       "type": "array",
@@ -5965,12 +6379,13 @@
         }
       },
       "post": {
-        "tags": ["Items"],
+        "tags": [
+          "Items"
+        ],
         "summary": "品目の作成",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の品目を作成する</p>\n\n<p>codeを利用するには、事業所の設定で品目コードを使用する設定にする必要があります。</p>",
         "operationId": "create_item",
         "requestBody": {
-          "description": "品目の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -6041,7 +6456,9 @@
     },
     "/api/1/items/{id}": {
       "get": {
-        "tags": ["Items"],
+        "tags": [
+          "Items"
+        ],
         "summary": "品目の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の品目を取得する</p>\n<p>事業所の設定で品目コードを使用する設定にしている場合、レスポンスで品目コード(code)を返します</p>",
         "operationId": "get_item",
@@ -6133,8 +6550,10 @@
         }
       },
       "put": {
-        "tags": ["Items"],
-        "summary": "品目の更新",
+        "tags": [
+          "Items"
+        ],
+        "summary": "品目の更新（存在しない場合は作成）",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の品目を更新する</p>\n<p>codeを利用するには、事業所の設定で品目コードを使用する設定にする必要があります。</p>",
         "operationId": "update_item",
         "parameters": [
@@ -6151,7 +6570,6 @@
           }
         ],
         "requestBody": {
-          "description": "品目の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -6220,7 +6638,9 @@
         }
       },
       "delete": {
-        "tags": ["Items"],
+        "tags": [
+          "Items"
+        ],
         "summary": "品目の削除",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の品目を削除する</p>",
         "operationId": "destroy_item",
@@ -6306,9 +6726,145 @@
         }
       }
     },
+    "/api/1/items/code/upsert": {
+      "put": {
+        "tags": [
+          "Items"
+        ],
+        "summary": "品目の更新（作成）",
+        "description": "\n<h2 id=\"\">概要</h2>\n\n<p>品目コードをキーに、指定した品目の情報を更新（存在しない場合は作成）する</p>\n<p>codeを利用するには、事業所の設定で品目コードを使用する設定にする必要があります。</p>",
+        "operationId": "api/v1/items#upsert_by_code",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "code",
+                  "company_id",
+                  "item"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "maxLength": 20,
+                    "description": "品目コード",
+                    "example": "code001",
+                    "pattern": "^[0-9a-zA-Z_-]+$"
+                  },
+                  "company_id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "minimum": 1,
+                    "description": "事業所ID",
+                    "example": 1
+                  },
+                  "item": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "maxLength": 30,
+                        "description": "品目名 (30文字以内)",
+                        "example": "新しい品目"
+                      },
+                      "shortcut1": {
+                        "type": "string",
+                        "maxLength": 20,
+                        "description": "ショートカット１ (20文字以内)",
+                        "example": "NEWITEM"
+                      },
+                      "shortcut2": {
+                        "type": "string",
+                        "maxLength": 20,
+                        "description": "ショートカット２ (20文字以内)",
+                        "example": "202"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/paths/~1api~11~1items~1code~1upsert/put/requestBody/content/application~1json/schema"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/itemResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/itemResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequestError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/1/taxes/codes": {
       "get": {
-        "tags": ["Taxes"],
+        "tags": [
+          "Taxes"
+        ],
         "summary": "税区分一覧の取得（廃止予定）",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>税区分一覧を取得する</p>\n\n<h2 id=\"\">注意点</h2>\n\n<p>このAPIは廃止予定のため非推奨です。api/1/taxes/companies/{company_id}（指定した事業所の税区分一覧の取得）をご利用ください。</p>",
         "operationId": "get_tax_codes",
@@ -6319,7 +6875,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["taxes"],
+                  "required": [
+                    "taxes"
+                  ],
                   "properties": {
                     "taxes": {
                       "type": "array",
@@ -6377,7 +6935,9 @@
     },
     "/api/1/taxes/codes/{code}": {
       "get": {
-        "tags": ["Taxes"],
+        "tags": [
+          "Taxes"
+        ],
         "summary": "税区分の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>税区分を取得する</p>",
         "operationId": "get_tax_code",
@@ -6459,7 +7019,9 @@
     },
     "/api/1/taxes/companies/{company_id}": {
       "get": {
-        "tags": ["Taxes"],
+        "tags": [
+          "Taxes"
+        ],
         "summary": "指定した事業所の税区分一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の税区分一覧を取得する</p>",
         "operationId": "get_taxes_companies",
@@ -6513,13 +7075,21 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["taxes"],
+                  "required": [
+                    "taxes"
+                  ],
                   "properties": {
                     "taxes": {
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["available", "code", "display_category", "name", "name_ja"],
+                        "required": [
+                          "available",
+                          "code",
+                          "display_category",
+                          "name",
+                          "name_ja"
+                        ],
                         "properties": {
                           "code": {
                             "type": "integer",
@@ -6617,7 +7187,9 @@
     },
     "/api/1/walletables": {
       "get": {
-        "tags": ["Walletables"],
+        "tags": [
+          "Walletables"
+        ],
         "summary": "口座一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の口座一覧を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>type\n<ul>\n<li>bank_account : 銀行口座</li>\n\n<li>credit_card : クレジットカード</li>\n\n<li>wallet : その他の決済口座</li>\n</ul>\n</li>\n\n<li>walletable_balance : 登録残高</li>\n\n<li>last_balance : 同期残高</li>\n\n<li>last_synced_at : 最終同期成功日時</li>\n\n<li>sync_status : 同期ステータス</li>\n</ul>",
         "operationId": "get_walletables",
@@ -6639,7 +7211,11 @@
             "description": "口座種別（bank_account : 銀行口座, credit_card : クレジットカード, wallet : その他の決済口座）",
             "schema": {
               "type": "string",
-              "enum": ["bank_account", "credit_card", "wallet"]
+              "enum": [
+                "bank_account",
+                "credit_card",
+                "wallet"
+              ]
             }
           },
           {
@@ -6671,6 +7247,22 @@
               "default": false,
               "type": "boolean"
             }
+          },
+          {
+            "name": "start_update_date",
+            "in": "query",
+            "description": "更新日で絞込：開始日(yyyy-mm-dd)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "end_update_date",
+            "in": "query",
+            "description": "更新日で絞込：終了日(yyyy-mm-dd)",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -6680,7 +7272,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["walletables"],
+                  "required": [
+                    "walletables"
+                  ],
                   "properties": {
                     "walletables": {
                       "type": "array",
@@ -6746,12 +7340,13 @@
         }
       },
       "post": {
-        "tags": ["Walletables"],
+        "tags": [
+          "Walletables"
+        ],
         "summary": "口座の作成",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の口座を作成する</p>\n\n<h2 id=\"\">注意点</h2>\n<ul><li>同期に対応した口座はこのAPIでは作成できません</li></ul>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>\n<p>type</p>\n\n<ul>\n<li>bank_account : 銀行口座</li>\n\n<li>credit_card : クレジットカード</li>\n\n<li>wallet : その他の決済口座</li>\n</ul>\n</li>\n\n<li>\n<p>name : 口座名</p>\n</li>\n\n<li>\n<p>bank_id : 連携サービスID</p>\n</li>\n\n<li>\n<p>is_asset : type:wallet指定時に口座を資産口座とするか負債口座とするか（true: 資産口座 (デフォルト), false: 負債口座）</p>\n</li>\n</ul>",
         "operationId": "create_walletable",
         "requestBody": {
-          "description": "口座の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -6822,7 +7417,9 @@
     },
     "/api/1/walletables/{type}/{id}": {
       "get": {
-        "tags": ["Walletables"],
+        "tags": [
+          "Walletables"
+        ],
         "summary": "口座の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の口座を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>type\n<ul>\n<li>bank_account : 銀行口座</li>\n\n<li>credit_card : クレジットカード</li>\n\n<li>wallet : その他の決済口座</li>\n</ul>\n</li>\n\n<li>walletable_balance : 登録残高</li>\n\n<li>last_balance : 同期残高</li>\n\n<li>last_synced_at : 最終同期成功日時</li>\n\n<li>sync_status : 同期ステータス</li>\n</ul>",
         "operationId": "get_walletable",
@@ -6845,7 +7442,11 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["bank_account", "credit_card", "wallet"]
+              "enum": [
+                "bank_account",
+                "credit_card",
+                "wallet"
+              ]
             }
           },
           {
@@ -6887,7 +7488,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["walletable"],
+                  "required": [
+                    "walletable"
+                  ],
                   "properties": {
                     "walletable": {
                       "$ref": "#/components/schemas/walletable"
@@ -6960,7 +7563,9 @@
         }
       },
       "put": {
-        "tags": ["Walletables"],
+        "tags": [
+          "Walletables"
+        ],
         "summary": "口座の更新",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の口座を更新する</p>",
         "operationId": "update_walletable",
@@ -6982,12 +7587,15 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["bank_account", "credit_card", "wallet"]
+              "enum": [
+                "bank_account",
+                "credit_card",
+                "wallet"
+              ]
             }
           }
         ],
         "requestBody": {
-          "description": "口座の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -7009,7 +7617,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["walletable"],
+                  "required": [
+                    "walletable"
+                  ],
                   "properties": {
                     "walletable": {
                       "$ref": "#/components/schemas/walletableUpdateResponse"
@@ -7082,7 +7692,9 @@
         }
       },
       "delete": {
-        "tags": ["Walletables"],
+        "tags": [
+          "Walletables"
+        ],
         "summary": "口座の削除",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の口座を削除する</p>\n\n<h2 id=\"\">注意点</h2>\n<ul>\n<li>削除を実行するには、当該口座に関連する仕訳データを事前に削除する必要があります。</li>\n<li>当該口座に仕訳が残っていないか確認するには、レポートの「仕訳帳」等を参照し、必要に応じて、「取引」や「口座振替」も削除します。</li>\n\n</ul>",
         "operationId": "destroy_walletable",
@@ -7105,7 +7717,11 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["bank_account", "credit_card", "wallet"]
+              "enum": [
+                "bank_account",
+                "credit_card",
+                "wallet"
+              ]
             }
           },
           {
@@ -7180,7 +7796,9 @@
     },
     "/api/1/banks": {
       "get": {
-        "tags": ["Banks"],
+        "tags": [
+          "Banks"
+        ],
         "summary": "連携サービス一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>連携しているサービス一覧を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>type\n<ul>\n<li>bank_account : 銀行口座</li>\n\n<li>credit_card : クレジットカード</li>\n\n<li>wallet : その他の決済口座</li>\n</ul>\n</li>\n</ul>",
         "operationId": "get_banks",
@@ -7213,7 +7831,11 @@
             "description": "サービス種別",
             "schema": {
               "type": "string",
-              "enum": ["bank_account", "credit_card", "wallet"]
+              "enum": [
+                "bank_account",
+                "credit_card",
+                "wallet"
+              ]
             }
           }
         ],
@@ -7224,7 +7846,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["banks"],
+                  "required": [
+                    "banks"
+                  ],
                   "properties": {
                     "banks": {
                       "type": "array",
@@ -7282,7 +7906,9 @@
     },
     "/api/1/banks/{id}": {
       "get": {
-        "tags": ["Banks"],
+        "tags": [
+          "Banks"
+        ],
         "summary": "連携サービスの取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>連携しているサービスを取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>type\n<ul>\n<li>bank_account : 銀行口座</li>\n\n<li>credit_card : クレジットカード</li>\n\n<li>wallet : その他の決済口座</li>\n</ul>\n</li>\n</ul>",
         "operationId": "get_bank",
@@ -7365,7 +7991,9 @@
     },
     "/api/1/transfers": {
       "get": {
-        "tags": ["Transfers"],
+        "tags": [
+          "Transfers"
+        ],
         "summary": "取引（振替）一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の取引（振替）一覧を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>\n<p>amount : 振替金額</p>\n</li>\n\n<li>\n<p>from_walletable_type, to_walletable_type</p>\n\n<ul>\n<li>bank_account : 銀行口座</li>\n\n<li>credit_card : クレジットカード</li>\n\n<li>wallet : その他の決済口座</li>\n</ul>\n</li>\n</ul>",
         "operationId": "get_transfers",
@@ -7427,7 +8055,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["transfers"],
+                  "required": [
+                    "transfers"
+                  ],
                   "properties": {
                     "transfers": {
                       "type": "array",
@@ -7483,12 +8113,13 @@
         }
       },
       "post": {
-        "tags": ["Transfers"],
+        "tags": [
+          "Transfers"
+        ],
         "summary": "取引（振替）の作成",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の取引（振替）を作成する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>\n<p>amount : 振替金額</p>\n</li>\n\n<li>\n<p>from_walletable_type, to_walletable_type</p>\n\n<ul>\n<li>bank_account : 銀行口座</li>\n\n<li>credit_card : クレジットカード</li>\n\n<li>wallet : その他の決済口座</li>\n</ul>\n</li>\n</ul>",
         "operationId": "create_transfer",
         "requestBody": {
-          "description": "取引（振替）の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -7559,7 +8190,9 @@
     },
     "/api/1/transfers/{id}": {
       "get": {
-        "tags": ["Transfers"],
+        "tags": [
+          "Transfers"
+        ],
         "summary": "取引（振替）の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の取引（振替）を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>\n<p>amount : 振替金額</p>\n</li>\n\n<li>\n<p>from_walletable_type, to_walletable_type</p>\n\n<ul>\n<li>bank_account : 銀行口座</li>\n\n<li>credit_card : クレジットカード</li>\n\n<li>wallet : その他の決済口座</li>\n</ul>\n</li>\n</ul>",
         "operationId": "get_transfer",
@@ -7651,7 +8284,9 @@
         }
       },
       "put": {
-        "tags": ["Transfers"],
+        "tags": [
+          "Transfers"
+        ],
         "summary": "取引（振替）の更新",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の取引（振替）を更新する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>\n<p>amount : 振替金額</p>\n</li>\n\n<li>\n<p>from_walletable_type, to_walletable_type</p>\n\n<ul>\n<li>bank_account : 銀行口座</li>\n\n<li>credit_card : クレジットカード</li>\n\n<li>wallet : その他の決済口座</li>\n</ul>\n</li>\n</ul>",
         "operationId": "update_transfer",
@@ -7669,7 +8304,6 @@
           }
         ],
         "requestBody": {
-          "description": "取引（振替）の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -7748,7 +8382,9 @@
         }
       },
       "delete": {
-        "tags": ["Transfers"],
+        "tags": [
+          "Transfers"
+        ],
         "summary": "取引（振替）の削除",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の取引（振替）を削除する</p>",
         "operationId": "destroy_transfer",
@@ -7836,7 +8472,9 @@
     },
     "/api/1/wallet_txns": {
       "get": {
-        "tags": ["Wallet txns"],
+        "tags": [
+          "Wallet txns"
+        ],
         "summary": "口座明細一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の口座明細一覧を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>\n<p>amount : 明細金額</p>\n</li>\n\n<li>\n<p>due_amount : 取引登録待ち金額</p>\n</li>\n\n<li>\n<p>balance : 残高</p>\n</li>\n\n<li>\n<p>entry_side</p>\n\n<ul>\n<li>income : 入金</li>\n\n<li>expense : 出金</li>\n</ul>\n</li>\n\n<li>\n<p>walletable_type</p>\n\n<ul>\n<li>bank_account : 銀行口座</li>\n\n<li>credit_card : クレジットカード</li>\n\n<li>wallet : その他の決済口座</li>\n</ul>\n</li>\n</ul>",
         "operationId": "get_wallet_txns",
@@ -7858,7 +8496,11 @@
             "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet) walletable_type、walletable_idは同時に指定が必要です。",
             "schema": {
               "type": "string",
-              "enum": ["bank_account", "credit_card", "wallet"]
+              "enum": [
+                "bank_account",
+                "credit_card",
+                "wallet"
+              ]
             }
           },
           {
@@ -7893,7 +8535,10 @@
             "description": "入金／出金 (入金: income, 出金: expense)",
             "schema": {
               "type": "string",
-              "enum": ["income", "expense"]
+              "enum": [
+                "income",
+                "expense"
+              ]
             }
           },
           {
@@ -7926,7 +8571,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["wallet_txns"],
+                  "required": [
+                    "wallet_txns"
+                  ],
                   "properties": {
                     "wallet_txns": {
                       "type": "array",
@@ -7982,12 +8629,13 @@
         }
       },
       "post": {
-        "tags": ["Wallet txns"],
+        "tags": [
+          "Wallet txns"
+        ],
         "summary": "口座明細の作成",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の口座明細を作成する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>\n<p>amount : 明細金額</p>\n</li>\n\n<li>\n<p>due_amount : 取引登録待ち金額</p>\n</li>\n\n<li>\n<p>balance : 残高</p>\n</li>\n\n<li>\n<p>entry_side</p>\n\n<ul>\n<li>income : 入金</li>\n\n<li>expense : 出金</li>\n</ul>\n</li>\n\n<li>\n<p>walletable_type</p>\n\n<ul>\n<li>bank_account : 銀行口座</li>\n\n<li>credit_card : クレジットカード</li>\n\n<li>wallet : その他の決済口座</li>\n</ul>\n</li>\n</ul>",
         "operationId": "create_wallet_txn",
         "requestBody": {
-          "description": "口座明細の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -8058,7 +8706,9 @@
     },
     "/api/1/wallet_txns/{id}": {
       "get": {
-        "tags": ["Wallet txns"],
+        "tags": [
+          "Wallet txns"
+        ],
         "summary": "口座明細の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の口座明細を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>\n<p>amount : 明細金額</p>\n</li>\n\n<li>\n<p>due_amount : 取引登録待ち金額</p>\n</li>\n\n<li>\n<p>balance : 残高</p>\n</li>\n\n<li>\n<p>entry_side</p>\n\n<ul>\n<li>income : 入金</li>\n\n<li>expense : 出金</li>\n</ul>\n</li>\n\n<li>\n<p>walletable_type</p>\n\n<ul>\n<li>bank_account : 銀行口座</li>\n\n<li>credit_card : クレジットカード</li>\n\n<li>wallet : その他の決済口座</li>\n</ul>\n</li>\n</ul>",
         "operationId": "get_wallet_txn",
@@ -8150,7 +8800,9 @@
         }
       },
       "delete": {
-        "tags": ["Wallet txns"],
+        "tags": [
+          "Wallet txns"
+        ],
         "summary": "口座明細の削除",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の口座明細を削除する</p>\n\n<h2 id=\"\">注意点</h2>\n<ul>\n  <li>同期をして取得したデータが「明細」の場合は、削除および再取得はできません。</li>\n  <li>詳細は<a target=\"_blank\" href=\"https://support.freee.co.jp/hc/ja/articles/360015892332\">freeeヘルプセンター</a>をご確認ください。</li>\n</ul>",
         "operationId": "destroy_wallet_txn",
@@ -8238,7 +8890,9 @@
     },
     "/api/1/journals": {
       "get": {
-        "tags": ["Journals"],
+        "tags": [
+          "Journals"
+        ],
         "summary": "仕訳帳のダウンロード要求",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>ユーザーが所属する事業所の仕訳帳のダウンロードをリクエストします。</p>\n\n<p>生成されるファイルのファイル形式と出力項目に関しては、<a href=\"https://support.freee.co.jp/hc/ja/articles/204615564#other\">ヘルプページ</a>をご参照ください。</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n  <li>download_type\n    <ul>\n      <li>generic <a href=\"https://support.freee.co.jp/hc/ja/articles/204615564#2\">(旧CSV)</a></li>\n      <li>generic_v2 <a href=\"https://support.freee.co.jp/hc/ja/articles/204615564#h_01GEDXEY3SQP8Y7S58CM2H4CKH\">(新CSV（freee汎用形式）)</a></li>\n      <li>csv <a href=\"https://support.freee.co.jp/hc/ja/articles/204599604#2\">(弥生会計)</a></li>\n      <li>pdf <a href=\"https://support.freee.co.jp/hc/ja/articles/204615564#3\">(PDF)</a></li>\n    </ul>\n  </li>\n  <li>encoding : download_typeがgeneric, generic_v2の場合のみ有効で、指定しない場合はsjisになります。無効なdownload_typeのうちcsvの場合はsjisでファイル出力されるので、レスポンスでsjisがかえります。\n    <ul>\n      <li>sjis</li>\n      <li>utf-8</li>\n    </ul>\n  </li>\n  <li>visible_tags : download_typeがgeneric, csv, pdfの場合のみ有効です。指定しない場合は従来の仕様の仕訳帳が出力されます。\n    <ul>\n      <li>partner : 取引先タグ</li>\n      <li>item : 品目タグ</li>\n      <li>tag : メモタグ</li>\n      <li>section : 部門タグ</li>\n      <li>description : 備考欄</li>\n      <li>wallet_txn_description : 明細の備考欄</li>\n      <li>\n        segment_1_tag : セグメント１タグ<br>\n        segment_2_tag : セグメント２タグ<br>\n        segment_3_tag : セグメント３タグ<br><br>\n        <a href=\"https://support.freee.co.jp/hc/ja/articles/360020679611\" target=\"_blank\">セグメント（分析用タグ）の設定</a><br>\n      </li>\n      <li>all : 指定された場合は上記の設定をすべて有効として扱いますが、セグメント１タグ、セグメント２タグ、セグメント３タグは含みません。セグメントが必要な場合はallではなく、segment_1_tag, segment_2_tag, segment_3_tagを指定してください。</li>\n    </ul>\n  </li>\n  <li>visible_ids : download_typeがgenericの場合のみ有効です。\n    <ul>\n      <li>deal_id : 取引ID</li>\n      <li>transfer_id : 取引(振替)ID</li>\n      <li>manual_journal_id : 振替伝票ID</li>\n    </ul>\n  </li>\n\n  <li>id : 受け付けID</li>\n</ul>",
         "operationId": "get_journals",
@@ -8250,7 +8904,12 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["generic", "generic_v2", "csv", "pdf"]
+              "enum": [
+                "generic",
+                "generic_v2",
+                "csv",
+                "pdf"
+              ]
             }
           },
           {
@@ -8259,7 +8918,10 @@
             "description": "文字コード",
             "schema": {
               "type": "string",
-              "enum": ["sjis", "utf-8"]
+              "enum": [
+                "sjis",
+                "utf-8"
+              ]
             }
           },
           {
@@ -8308,7 +8970,11 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["deal_id", "transfer_id", "manual_journal_id"]
+                "enum": [
+                  "deal_id",
+                  "transfer_id",
+                  "manual_journal_id"
+                ]
               }
             }
           },
@@ -8385,7 +9051,9 @@
     },
     "/api/1/journals/reports/{id}/status": {
       "get": {
-        "tags": ["Journals"],
+        "tags": [
+          "Journals"
+        ],
         "summary": "仕訳帳のステータスの取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>仕訳帳のダウンロードリクエストのステータスを取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>\n<p>status</p>\n\n<ul>\n<li>enqueued : 実行待ち</li>\n\n<li>working : 実行中</li>\n\n<li>uploaded : 準備完了</li>\n</ul>\n</li>\n\n<li>\n<p>id : 受け付けID</p>\n</li>\n</ul>",
         "operationId": "get_journal_status",
@@ -8479,7 +9147,9 @@
     },
     "/api/1/journals/reports/{id}/download": {
       "get": {
-        "tags": ["Journals"],
+        "tags": [
+          "Journals"
+        ],
         "summary": "仕訳帳のダウンロード",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>仕訳帳をダウンロードする</p>\n\n<h2 id=\"_2\">定義</h2>\n\n<ul>\n<li>id : 受け付けID</li>\n</ul>",
         "operationId": "download_journal",
@@ -8579,7 +9249,9 @@
     },
     "/api/1/reports/trial_bs": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "貸借対照表の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の貸借対照表を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>opening_balance : 期首残高</p></li>\n  <li><p>debit_amount : 借方金額</p></li>\n  <li><p>credit_amount:  貸方金額</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n  <li><p>composition_ratio : 構成比</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_bs?company_id=1&amp;fiscal_year=2019&amp;breakdown_display_type=partner</p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_bs&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;breakdown_display_type&quot; : &quot;partner&quot;,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1000,\n        &quot;account_item_name&quot; : &quot;現金&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;流動資産&quot;,\n        &quot;opening_balance&quot; : 100000,\n        &quot;debit_amount&quot; : 50000,\n        &quot;credit_amount&quot; : 20000,\n        &quot;closing_balance&quot; : 130000,\n        &quot;composition_ratio&quot; : 0.25\n        &quot;partners&quot; : [{\n          &quot;id&quot; : 123,\n          &quot;name&quot; : &quot;freee&quot;,\n          &quot;opening_balance&quot; : 100000,\n          &quot;debit_amount&quot; : 50000,\n          &quot;credit_amount&quot; : 20000,\n          &quot;closing_balance&quot; : 130000,\n          &quot;composition_ratio&quot; : 0.25\n          },\n        ...\n        ]\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_bs",
@@ -8648,13 +9320,16 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない\n",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない\n",
             "schema": {
               "type": "string",
               "enum": [
@@ -8712,7 +9387,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -8721,7 +9399,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -8791,7 +9472,9 @@
     },
     "/api/1/reports/trial_bs_two_years": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "貸借対照表(前年比較)の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の貸借対照表(前年比較)を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>last_year_closing_balance:  前年度期末残高</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n  <li><p>year_on_year : 前年比</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_bs_two_years?company_id=1&amp;fiscal_year=2019</p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_bs_two_years&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1000,\n        &quot;account_item_name&quot; : &quot;現金&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;流動資産&quot;,\n        &quot;last_year_closing_balance&quot; : 25000,\n        &quot;closing_balance&quot; : 100000,\n        &quot;year_on_year&quot; : 0.85\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_bs_two_years",
@@ -8860,13 +9543,16 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
               "enum": [
@@ -8924,7 +9610,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -8933,7 +9622,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -9003,7 +9695,9 @@
     },
     "/api/1/reports/trial_bs_three_years": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "貸借対照表(３期間比較)の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の貸借対照表(３期間比較)を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul><li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>two_years_before_closing_balance:  前々年度期末残高</p></li>\n  <li><p>last_year_closing_balance:  前年度期末残高</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n  <li><p>year_on_year : 前年比</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_bs_three_years?company_id=1&amp;fiscal_year=2019</p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_bs_three_years&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1000,\n        &quot;account_item_name&quot; : &quot;現金&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;流動資産&quot;,\n        &quot;two_year_before_closing_balance&quot; : 50000,\n        &quot;last_year_closing_balance&quot; : 25000,\n        &quot;closing_balance&quot; : 100000,\n        &quot;year_on_year&quot; : 0.85\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_bs_three_years",
@@ -9072,13 +9766,16 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
               "enum": [
@@ -9136,7 +9833,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -9145,7 +9845,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -9215,7 +9918,9 @@
     },
     "/api/1/reports/trial_pl": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "損益計算書の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の損益計算書を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>opening_balance : 期首残高</p></li>\n  <li><p>debit_amount : 借方金額</p></li>\n  <li><p>credit_amount:  貸方金額</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n  <li><p>composition_ratio : 構成比</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>配賦仕訳の絞り込み（cost_allocation）は法人スタンダードプラン（および旧法人ベーシックプラン）以上で利用可能です。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_pl?company_id=1&amp;fiscal_year=2019&amp;breakdown_display_type=partner</p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_pl&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;breakdown_display_type&quot; : &quot;partner&quot;,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1500,\n        &quot;account_item_name&quot; : &quot;売上高&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;営業収益&quot;,\n        &quot;opening_balance&quot; : 100000,\n        &quot;debit_amount&quot; : 50000,\n        &quot;credit_amount&quot; : 20000,\n        &quot;closing_balance&quot; : 130000,\n        &quot;composition_ratio&quot; : 0.25\n        &quot;partners&quot; : [{\n          &quot;id&quot; : 123,\n          &quot;name&quot; : &quot;freee&quot;,\n          &quot;opening_balance&quot; : 100000,\n          &quot;debit_amount&quot; : 50000,\n          &quot;credit_amount&quot; : 20000,\n          &quot;closing_balance&quot; : 130000,\n          &quot;composition_ratio&quot; : 0.25\n          },\n        ...\n        ]\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_pl",
@@ -9284,13 +9989,16 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
               "enum": [
@@ -9348,7 +10056,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -9357,7 +10068,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -9366,7 +10080,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -9436,7 +10153,9 @@
     },
     "/api/1/reports/trial_pl_two_years": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "損益計算書(前年比較)の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の損益計算書(前年比較)を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>last_year_closing_balance:  前年度期末残高</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n  <li><p>year_on_year : 前年比</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>配賦仕訳の絞り込み（cost_allocation）は法人スタンダードプラン（および旧法人ベーシックプラン）以上で利用可能です。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n  <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n    <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_pl_two_years?company_id=1&amp;fiscal_year=2019</p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_pl_two_years&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1500,\n        &quot;account_item_name&quot; : &quot;売上高&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;営業収益&quot;,\n        &quot;last_year_closing_balance&quot; : 25000,\n        &quot;closing_balance&quot; : 100000,\n        &quot;year_on_year&quot; : 0.85\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_pl_two_years",
@@ -9505,13 +10224,16 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
               "enum": [
@@ -9569,7 +10291,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -9578,7 +10303,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -9587,7 +10315,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -9657,7 +10388,9 @@
     },
     "/api/1/reports/trial_pl_three_years": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "損益計算書(３期間比較)の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の損益計算書(３期間比較)を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>two_years_before_closing_balance:  前々年度期末残高</p></li>\n  <li><p>last_year_closing_balance:  前年度期末残高</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n  <li><p>year_on_year : 前年比</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>配賦仕訳の絞り込み（cost_allocation）は法人スタンダードプラン（および旧法人ベーシックプラン）以上で利用可能です。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_pl_three_years?company_id=1&fiscal_year=2019</p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_pl_three_years&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1500,\n        &quot;account_item_name&quot; : &quot;売上高&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;営業収益&quot;,\n        &quot;two_year_before_closing_balance&quot; : 50000,\n        &quot;last_year_closing_balance&quot; : 25000,\n        &quot;closing_balance&quot; : 100000,\n        &quot;year_on_year&quot; : 0.85\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_pl_three_years",
@@ -9726,13 +10459,16 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
               "enum": [
@@ -9790,7 +10526,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -9799,7 +10538,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -9808,7 +10550,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -9878,7 +10623,9 @@
     },
     "/api/1/reports/trial_pl_sections": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "損益計算書(部門比較)の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の損益計算書(部門比較)を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>配賦仕訳の絞り込み（cost_allocation）は法人スタンダードプラン（および旧法人ベーシックプラン）以上で利用可能です。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_pl_sections?company_id=1&amp;section_ids=1,2,3&amp;fiscal_year=2019</p></p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_pl_sections&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;section_ids&quot; : &quot;1,2,3&quot;,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1500,\n        &quot;account_item_name&quot; : &quot;売上高&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;営業収益&quot;,\n        &quot;closing_balance&quot; : 1000000,\n        &quot;sections&quot; : [{\n          &quot;id&quot;: 1\n          &quot;name&quot;: &quot;営業部&quot;,\n          &quot;closing_balance&quot; : 100000\n        },\n        {\n          &quot;id&quot;: 2\n          &quot;name&quot;: &quot;広報部&quot;,\n          &quot;closing_balance&quot; : 200000\n        },\n        {\n          &quot;id&quot;: 3\n          &quot;name&quot;: &quot;人事部&quot;,\n          &quot;closing_balance&quot; : 300000\n        },\n        ...\n        ]\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_pl_sections",
@@ -9956,13 +10703,16 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、セグメント の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、セグメント の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
               "enum": [
@@ -10009,7 +10759,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -10018,7 +10771,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -10027,7 +10783,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -10097,7 +10856,9 @@
     },
     "/api/1/reports/trial_pl_segment_1_tags": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "損益計算書(セグメント１比較)の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の損益計算書(セグメント１比較)を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>配賦仕訳の絞り込み（cost_allocation）は法人スタンダードプラン（および旧法人ベーシックプラン）以上で利用可能です。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_pl_segment_1_tags?company_id=1&amp;segment_1_tag_ids=1,2,3&amp;fiscal_year=2019</p></p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_pl_segment_1_tags&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;segment_1_tag_ids&quot; : &quot;1,2,3&quot;,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1500,\n        &quot;account_item_name&quot; : &quot;売上高&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;営業収益&quot;,\n        &quot;closing_balance&quot; : 1000000,\n        &quot;segment_1_tags&quot; : [{\n          &quot;id&quot;: 1\n          &quot;name&quot;: &quot;プロジェクトA&quot;,\n          &quot;closing_balance&quot; : 100000\n        },\n        {\n          &quot;id&quot;: 2\n          &quot;name&quot;: &quot;プロジェクトB&quot;,\n          &quot;closing_balance&quot; : 200000\n        },\n        {\n          &quot;id&quot;: 3\n          &quot;name&quot;: &quot;プロジェクトC&quot;,\n          &quot;closing_balance&quot; : 300000\n        },\n        ...\n        ]\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_pl_segment_1_tags",
@@ -10175,16 +10936,24 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門 の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門 の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
-              "enum": ["partner", "item", "section", "account_item"]
+              "enum": [
+                "partner",
+                "item",
+                "section",
+                "account_item"
+              ]
             }
           },
           {
@@ -10231,7 +11000,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -10240,7 +11012,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -10249,7 +11024,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -10319,7 +11097,9 @@
     },
     "/api/1/reports/trial_pl_segment_2_tags": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "損益計算書(セグメント２比較)の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の損益計算書(セグメント２比較)を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>配賦仕訳の絞り込み（cost_allocation）は法人スタンダードプラン（および旧法人ベーシックプラン）以上で利用可能です。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_pl_segment_2_tags?company_id=1&amp;segment_2_tag_ids=1,2,3&amp;fiscal_year=2019</p></p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_pl_segment_2_tags&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;segment_2_tag_ids&quot; : &quot;1,2,3&quot;,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1500,\n        &quot;account_item_name&quot; : &quot;売上高&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;営業収益&quot;,\n        &quot;closing_balance&quot; : 1000000,\n        &quot;segment_2_tags&quot; : [{\n          &quot;id&quot;: 1\n          &quot;name&quot;: &quot;プロジェクトA&quot;,\n          &quot;closing_balance&quot; : 100000\n        },\n        {\n          &quot;id&quot;: 2\n          &quot;name&quot;: &quot;プロジェクトB&quot;,\n          &quot;closing_balance&quot; : 200000\n        },\n        {\n          &quot;id&quot;: 3\n          &quot;name&quot;: &quot;プロジェクトC&quot;,\n          &quot;closing_balance&quot; : 300000\n        },\n        ...\n        ]\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_pl_segment_2_tags",
@@ -10397,16 +11177,24 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門 の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門 の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
-              "enum": ["partner", "item", "section", "account_item"]
+              "enum": [
+                "partner",
+                "item",
+                "section",
+                "account_item"
+              ]
             }
           },
           {
@@ -10453,7 +11241,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -10462,7 +11253,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -10471,7 +11265,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -10541,7 +11338,9 @@
     },
     "/api/1/reports/trial_pl_segment_3_tags": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "損益計算書(セグメント３比較)の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の損益計算書(セグメント３比較)を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>配賦仕訳の絞り込み（cost_allocation）は法人スタンダードプラン（および旧法人ベーシックプラン）以上で利用可能です。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_pl_segment_3_tags?company_id=1&amp;segment_3_tag_ids=1,2,3&amp;fiscal_year=2019</p></p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_pl_segment_3_tags&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;segment_3_tag_ids&quot; : &quot;1,2,3&quot;,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1500,\n        &quot;account_item_name&quot; : &quot;売上高&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;営業収益&quot;,\n        &quot;closing_balance&quot; : 1000000,\n        &quot;segment_3_tags&quot; : [{\n          &quot;id&quot;: 1\n          &quot;name&quot;: &quot;プロジェクトA&quot;,\n          &quot;closing_balance&quot; : 100000\n        },\n        {\n          &quot;id&quot;: 2\n          &quot;name&quot;: &quot;プロジェクトB&quot;,\n          &quot;closing_balance&quot; : 200000\n        },\n        {\n          &quot;id&quot;: 3\n          &quot;name&quot;: &quot;プロジェクトC&quot;,\n          &quot;closing_balance&quot; : 300000\n        },\n        ...\n        ]\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_pl_segment_3_tags",
@@ -10619,16 +11418,24 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門 の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門 の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
-              "enum": ["partner", "item", "section", "account_item"]
+              "enum": [
+                "partner",
+                "item",
+                "section",
+                "account_item"
+              ]
             }
           },
           {
@@ -10675,7 +11482,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -10684,7 +11494,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -10693,7 +11506,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -10763,7 +11579,9 @@
     },
     "/api/1/reports/trial_cr": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "製造原価報告書の取得",
         "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の製造原価報告書を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>opening_balance : 期首残高</p></li>\n  <li><p>debit_amount : 借方金額</p></li>\n  <li><p>credit_amount:  貸方金額</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n  <li><p>composition_ratio : 構成比</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>配賦仕訳の絞り込み（cost_allocation）は法人スタンダードプラン（および旧法人ベーシックプラン）以上で利用可能です。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_cr?company_id=1&amp;fiscal_year=2019&amp;breakdown_display_type=partner</p>\n</blockquote>\n<pre><code>{\n  &quot;trial_cr&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;breakdown_display_type&quot; : &quot;partner&quot;,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1500,\n        &quot;account_item_name&quot; : &quot;[製]期首材料棚卸高&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;期首原材料棚卸&quot;,\n        &quot;opening_balance&quot; : 100000,\n        &quot;debit_amount&quot; : 50000,\n        &quot;credit_amount&quot; : 20000,\n        &quot;closing_balance&quot; : 130000,\n        &quot;composition_ratio&quot; : 0.25\n        &quot;partners&quot; : [{\n          &quot;id&quot; : 123,\n          &quot;name&quot; : &quot;freee&quot;,\n          &quot;opening_balance&quot; : 100000,\n          &quot;debit_amount&quot; : 50000,\n          &quot;credit_amount&quot; : 20000,\n          &quot;closing_balance&quot; : 130000,\n          &quot;composition_ratio&quot; : 0.25\n          },\n        ...\n        ]\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_cr",
@@ -10832,13 +11650,16 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
               "enum": [
@@ -10896,7 +11717,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -10905,7 +11729,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -10914,7 +11741,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト), 全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -10984,7 +11814,9 @@
     },
     "/api/1/reports/trial_cr_two_years": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "製造原価報告書(前年比較)の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の製造原価報告書(前年比較)を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>last_year_closing_balance:  前年度期末残高</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n  <li><p>year_on_year : 前年比</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>配賦仕訳の絞り込み（cost_allocation）は法人スタンダードプラン（および旧法人ベーシックプラン）以上で利用可能です。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_cr_two_years?company_id=1&amp;fiscal_year=2019</p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_cr_two_years&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1500,\n        &quot;account_item_name&quot; : &quot;[製]期首材料棚卸高&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;期首原材料棚卸&quot;,\n        &quot;last_year_closing_balance&quot; : 25000,\n        &quot;closing_balance&quot; : 100000,\n        &quot;year_on_year&quot; : 0.85\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_cr_two_years",
@@ -11053,13 +11885,16 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
               "enum": [
@@ -11117,7 +11952,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -11126,7 +11964,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -11135,7 +11976,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト), 全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -11205,7 +12049,9 @@
     },
     "/api/1/reports/trial_cr_three_years": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "製造原価報告書(３期間比較)の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の製造原価報告書(３期間比較)を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>two_years_before_closing_balance:  前々年度期末残高</p></li>\n  <li><p>last_year_closing_balance:  前年度期末残高</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n  <li><p>year_on_year : 前年比</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>配賦仕訳の絞り込み（cost_allocation）は法人スタンダードプラン（および旧法人ベーシックプラン）以上で利用可能です。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_cr_three_years?company_id=1&fiscal_year=2019</p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_cr_three_years&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1500,\n        &quot;account_item_name&quot; : &quot;[製]期首材料棚卸高&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;期首原材料棚卸&quot;,\n        &quot;two_year_before_closing_balance&quot; : 50000,\n        &quot;last_year_closing_balance&quot; : 25000,\n        &quot;closing_balance&quot; : 100000,\n        &quot;year_on_year&quot; : 0.85\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_cr_three_years",
@@ -11274,13 +12120,16 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門、セグメント の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
               "enum": [
@@ -11338,7 +12187,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -11347,7 +12199,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -11356,7 +12211,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト), 全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -11426,7 +12284,9 @@
     },
     "/api/1/reports/trial_cr_sections": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "製造原価報告書(部門比較)の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の製造原価報告書(部門比較)を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>配賦仕訳の絞り込み（cost_allocation）は法人スタンダードプラン（および旧法人ベーシックプラン）以上で利用可能です。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_cr_sections?company_id=1&amp;section_ids=1,2,3&amp;fiscal_year=2019</p></p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_cr_sections&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;section_ids&quot; : &quot;1,2,3&quot;,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1500,\n        &quot;account_item_name&quot; : &quot;[製]期首材料棚卸高&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;期首原材料棚卸&quot;,\n        &quot;closing_balance&quot; : 1000000,\n        &quot;sections&quot; : [{\n          &quot;id&quot;: 1\n          &quot;name&quot;: &quot;営業部&quot;,\n          &quot;closing_balance&quot; : 100000\n        },\n        {\n          &quot;id&quot;: 2\n          &quot;name&quot;: &quot;広報部&quot;,\n          &quot;closing_balance&quot; : 200000\n        },\n        {\n          &quot;id&quot;: 3\n          &quot;name&quot;: &quot;人事部&quot;,\n          &quot;closing_balance&quot; : 300000\n        },\n        ...\n        ]\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_cr_sections",
@@ -11504,13 +12364,16 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、セグメント の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 勘定科目: account_item, セグメント１タグ: segment_1_tag, セグメント２タグ: segment_2_tag, セグメント３タグ: segment_3_tag） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、セグメント の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
               "enum": [
@@ -11557,7 +12420,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -11566,7 +12432,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -11575,7 +12444,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -11645,7 +12517,9 @@
     },
     "/api/1/reports/trial_cr_segment_1_tags": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "製造原価報告書(セグメント１比較)の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の製造原価報告書(セグメント１比較)を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_cr_segment_1_tags?company_id=1&amp;segment_1_tag_ids=1,2,3&amp;fiscal_year=2019</p></p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_cr_segment_1_tags&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;segment_1_tag_ids&quot; : &quot;1,2,3&quot;,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1500,\n        &quot;account_item_name&quot; : &quot;[製]期首材料棚卸高&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;期首原材料棚卸&quot;,\n        &quot;closing_balance&quot; : 1000000,\n        &quot;segment_1_tags&quot; : [{\n          &quot;id&quot;: 1\n          &quot;name&quot;: &quot;プロジェクトA&quot;,\n          &quot;closing_balance&quot; : 100000\n        },\n        {\n          &quot;id&quot;: 2\n          &quot;name&quot;: &quot;プロジェクトB&quot;,\n          &quot;closing_balance&quot; : 200000\n        },\n        {\n          &quot;id&quot;: 3\n          &quot;name&quot;: &quot;プロジェクトC&quot;,\n          &quot;closing_balance&quot; : 300000\n        },\n        ...\n        ]\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_cr_segment_1_tags",
@@ -11723,16 +12597,24 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門 の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門 の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
-              "enum": ["partner", "item", "section", "account_item"]
+              "enum": [
+                "partner",
+                "item",
+                "section",
+                "account_item"
+              ]
             }
           },
           {
@@ -11779,7 +12661,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -11788,7 +12673,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -11797,7 +12685,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -11867,7 +12758,9 @@
     },
     "/api/1/reports/trial_cr_segment_2_tags": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "製造原価報告書(セグメント２比較)の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の製造原価報告書(セグメント２比較)を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_cr_segment_2_tags?company_id=1&amp;segment_2_tag_ids=1,2,3&amp;fiscal_year=2019</p></p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_cr_segment_2_tags&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;segment_2_tag_ids&quot; : &quot;1,2,3&quot;,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1500,\n        &quot;account_item_name&quot; : &quot;[製]期首材料棚卸高&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;期首原材料棚卸&quot;,\n        &quot;closing_balance&quot; : 1000000,\n        &quot;segment_2_tags&quot; : [{\n          &quot;id&quot;: 1\n          &quot;name&quot;: &quot;プロジェクトA&quot;,\n          &quot;closing_balance&quot; : 100000\n        },\n        {\n          &quot;id&quot;: 2\n          &quot;name&quot;: &quot;プロジェクトB&quot;,\n          &quot;closing_balance&quot; : 200000\n        },\n        {\n          &quot;id&quot;: 3\n          &quot;name&quot;: &quot;プロジェクトC&quot;,\n          &quot;closing_balance&quot; : 300000\n        },\n        ...\n        ]\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_cr_segment_2_tags",
@@ -11945,16 +12838,24 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門 の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門 の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
-              "enum": ["partner", "item", "section", "account_item"]
+              "enum": [
+                "partner",
+                "item",
+                "section",
+                "account_item"
+              ]
             }
           },
           {
@@ -12001,7 +12902,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -12010,7 +12914,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -12019,7 +12926,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -12089,7 +12999,9 @@
     },
     "/api/1/reports/trial_cr_segment_3_tags": {
       "get": {
-        "tags": ["Trial balance"],
+        "tags": [
+          "Trial balance"
+        ],
         "summary": "製造原価報告書(セグメント３比較)の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n<p>指定した事業所の製造原価報告書(セグメント３比較)を取得する</p>\n\n<h2 id=\"_2\">定義</h2>\n<ul>\n  <li><p>created_at : 作成日時</p></li>\n  <li><p>account_item_name : 勘定科目名</p></li>\n  <li><p>hierarchy_level: 階層レベル</p></li>\n  <li><p>parent_account_category_name: 上位勘定科目カテゴリー名</p></li>\n  <li><p>closing_balance : 期末残高</p></li>\n</ul>\n\n<h2 id=\"_3\">注意点</h2>\n<ul>\n  <li>会計年度が指定されない場合、現在の会計年度がデフォルトとなります。</li>\n  <li>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</li>\n  <li>partner_codeとpartner_idは同時に指定することはできません。</li>\n  <li>start_date / end_date を指定した場合、以下を同時に指定することはできません。\n  <ul>\n    <li>fiscal_year</li>\n    <li>start_month</li>\n    <li>end_month</li>\n  </ul>\n  </li>\n  <li>0を指定すると未選択で絞り込めます\n  <ul>\n    <li>partner_idに0を指定して絞り込んだ場合\n    <ul>\n      <li>取引先が設定されていない取引、振替伝票の金額がレスポンスに返却されます</li>\n    </ul>\n    </li>\n  </ul>\n  </li>\n</ul>\n\n<h2 id=\"_4\">レスポンスの例</h2>\n\n<blockquote>\n<p>GET https://api.freee.co.jp/api/1/reports/trial_cr_segment_3_tags?company_id=1&amp;segment_3_tag_ids=1,2,3&amp;fiscal_year=2019</p></p>\n</blockquote>\n\n<pre><code>{\n  &quot;trial_cr_segment_3_tags&quot; :\n    {\n      &quot;company_id&quot; : 1,\n      &quot;segment_3_tag_ids&quot; : &quot;1,2,3&quot;,\n      &quot;fiscal_year&quot; : 2019,\n      &quot;created_at&quot; : &quot;2019-12-17 12:00:50&quot\n      &quot;balances&quot; : [{\n        &quot;account_item_id&quot; : 1500,\n        &quot;account_item_name&quot; : &quot;[製]期首材料棚卸高&quot;,\n        &quot;hierarchy_level&quot; : 2,\n        &quot;account_category_name&quot; : &quot;期首原材料棚卸&quot;,\n        &quot;closing_balance&quot; : 1000000,\n        &quot;segment_3_tags&quot; : [{\n          &quot;id&quot;: 1\n          &quot;name&quot;: &quot;プロジェクトA&quot;,\n          &quot;closing_balance&quot; : 100000\n        },\n        {\n          &quot;id&quot;: 2\n          &quot;name&quot;: &quot;プロジェクトB&quot;,\n          &quot;closing_balance&quot; : 200000\n        },\n        {\n          &quot;id&quot;: 3\n          &quot;name&quot;: &quot;プロジェクトC&quot;,\n          &quot;closing_balance&quot; : 300000\n        },\n        ...\n        ]\n      },\n      ...\n      ]\n    }\n}</code></pre>\n",
         "operationId": "get_trial_cr_segment_3_tags",
@@ -12167,16 +13079,24 @@
             "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）。指定されない場合、勘定科目: account_itemが指定されます。",
             "schema": {
               "type": "string",
-              "enum": ["account_item", "group"]
+              "enum": [
+                "account_item",
+                "group"
+              ]
             }
           },
           {
             "name": "breakdown_display_type",
             "in": "query",
-            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門 の各項目が単独で1,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が1,000以上、品目の登録数が999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
+            "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item） ※勘定科目はaccount_item_display_typeが「group」の時のみ指定できます。\n\n取引先、品目、部門 の各項目が単独で5,000以上登録されている場合は、breakdown_display_type で該当項目を指定するとエラーになります。\n\n例）取引先の登録数が5,000以上、品目の登録数が4,999以下の場合\n* breakdown_display_type: 取引先を指定 → エラーになる\n* breakdown_display_type: 品目を指定 → エラーにならない",
             "schema": {
               "type": "string",
-              "enum": ["partner", "item", "section", "account_item"]
+              "enum": [
+                "partner",
+                "item",
+                "section",
+                "account_item"
+              ]
             }
           },
           {
@@ -12223,7 +13143,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ: only, 決算整理仕訳以外: without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -12232,7 +13155,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             }
           },
           {
@@ -12241,7 +13167,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\nプレミアムプラン、法人アドバンスプラン（および旧法人プロフェッショナルプラン）以上で指定可能です。<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["without_in_progress", "all"]
+              "enum": [
+                "without_in_progress",
+                "all"
+              ]
             }
           }
         ],
@@ -12311,7 +13240,9 @@
     },
     "/api/1/reports/general_ledgers": {
       "get": {
-        "tags": ["General ledgers"],
+        "tags": [
+          "General ledgers"
+        ],
         "summary": "総勘定元帳一覧の取得（β版）",
         "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の総勘定元帳一覧を取得する</p>\n<br>\n※このAPIはβ版として提供しています。\n<ul>\n  <li>このAPIは法人アドバンスプラン（および旧法人プロフェッショナルプラン）・法人エンタープライズプランに加入している事業所のみが利用できます。</li>\n  <li>利用状況によって事前の告知なく提供プラン・コール数の上限を変更する可能性があります。</li>\n  <li>他エンドポイントと比べてレスポンスタイムが遅い場合があります。</li>\n</ul>",
         "operationId": "get_general_ledgers",
@@ -12453,7 +13384,10 @@
             "description": "決算整理仕訳で絞込（決算整理仕訳のみ：only, 決算整理仕訳以外：without）。指定されない場合、決算整理仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             },
             "example": "only"
           },
@@ -12463,7 +13397,10 @@
             "description": "配賦仕訳で絞込（配賦仕訳のみ：only,配賦仕訳以外：without）。指定されない場合、配賦仕訳を含む金額が返却されます。",
             "schema": {
               "type": "string",
-              "enum": ["only", "without"]
+              "enum": [
+                "only",
+                "without"
+              ]
             },
             "example": "only"
           },
@@ -12536,7 +13473,10 @@
             "description": "承認ステータスで絞込 (未承認を除く: without_in_progress (デフォルト)、全てのステータス: all)<br>\n事業所の設定から仕訳承認フローの利用を有効にした場合に指定可能です。\n",
             "schema": {
               "type": "string",
-              "enum": ["all", "without_in_progress"]
+              "enum": [
+                "all",
+                "without_in_progress"
+              ]
             },
             "example": "without_in_progress"
           }
@@ -12607,7 +13547,9 @@
     },
     "/api/1/receipts": {
       "get": {
-        "tags": ["Receipts"],
+        "tags": [
+          "Receipts"
+        ],
         "summary": "ファイルボックス（証憑ファイル）一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所のファイルボックス（証憑ファイル）一覧を取得する</p>",
         "operationId": "get_receipts",
@@ -12665,13 +13607,17 @@
             "description": "posted:コメントあり, raised:未解決, resolved:解決済",
             "schema": {
               "type": "string",
-              "enum": ["posted", "raised", "resolved"]
+              "enum": [
+                "posted",
+                "raised",
+                "resolved"
+              ]
             }
           },
           {
             "name": "comment_important",
             "in": "query",
-            "description": "trueの時、重要コメント付きが対象",
+            "description": "trueの時、お気に入りコメント付きが対象",
             "schema": {
               "type": "boolean"
             }
@@ -12721,7 +13667,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["receipts"],
+                  "required": [
+                    "receipts"
+                  ],
                   "properties": {
                     "receipts": {
                       "type": "array",
@@ -12777,9 +13725,11 @@
         }
       },
       "post": {
-        "tags": ["Receipts"],
+        "tags": [
+          "Receipts"
+        ],
         "summary": "ファイルボックス（証憑ファイル）のアップロード",
-        "description": "\n<h2 id=\"\">概要</h2>\n\n<p>ファイルボックス（証憑ファイル）をアップロードする</p>\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>リクエストヘッダーの Content-Type は、multipart/form-dataにのみ対応しています。</li>\n  <li>インボイス制度適格請求書発行事業者登録番号はOCR解析結果が採用されます。OCR解析結果を確認する場合は、Web画面にてご確認ください。上書きする場合は、ファイルボックス（証憑ファイル）の更新APIをご利用ください。</li>\n</ul>",
+        "description": "\n<h2 id=\"\">概要</h2>\n\n<p>ファイルボックス（証憑ファイル）をアップロードする</p>\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>リクエストヘッダーの Content-Type は、multipart/form-dataにのみ対応しています。</li>\n  <li>インボイス制度適格請求書発行事業者登録番号はOCR解析結果が採用されます。OCR解析結果を確認する場合は、Web画面にてご確認ください。上書きする場合は、ファイルボックス（証憑ファイル）の更新APIをご利用ください。</li>\n  <li>以下の制限を満たさない場合アップロードに失敗します。</li>\n  <ul>\n      <li>ファイルサイズの制限： 64MBまで</li>\n      <li>月間アップロード容量の制限： 月間合計10GBまで</li>\n      <li>1分間あたりのアップロード数制限： 300ファイルまで</li>\n      <li>プランによる月間アップロード数の制限： 以下のリンクからご確認ください</li>\n      <ul>\n          <li>\n              <a href=\"https://support.freee.co.jp/hc/ja/articles/213726523--%E5%80%8B%E4%BA%BA-freee%E4%BC%9A%E8%A8%88%E3%81%AE%E3%83%97%E3%83%A9%E3%83%B3%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6\" target=\"_blank\">【個人】freee会計のプランについて</a>\n          </li>\n          <li>\n              <a href=\"https://support.freee.co.jp/hc/ja/articles/27975180546713--%E6%B3%95%E4%BA%BA-freee%E4%BC%9A%E8%A8%88%E3%81%AE%E3%83%97%E3%83%A9%E3%83%B3%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6-2024%E5%B9%B47%E6%9C%88%E4%BB%A5%E9%99%8D\" target=\"_blank\">【法人】freee会計のプランについて（2024年7月以降）</a>\n          </li>\n      </ul>\n  </ul>\n</ul>",
         "operationId": "create_receipt",
         "requestBody": {
           "content": {
@@ -12847,7 +13797,9 @@
     },
     "/api/1/receipts/{id}": {
       "get": {
-        "tags": ["Receipts"],
+        "tags": [
+          "Receipts"
+        ],
         "summary": "ファイルボックス（証憑ファイル）の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所のファイルボックス（証憑ファイル）を取得する</p>",
         "operationId": "get_receipt",
@@ -12939,7 +13891,9 @@
         }
       },
       "put": {
-        "tags": ["Receipts"],
+        "tags": [
+          "Receipts"
+        ],
         "summary": "ファイルボックス（証憑ファイル）の更新",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>ファイルボックス（証憑ファイル）を更新する</p>\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>本APIでは、証憑ファイルの再アップロードはできません。</li>\n</ul>",
         "operationId": "update_receipt",
@@ -13035,7 +13989,9 @@
         }
       },
       "delete": {
-        "tags": ["Receipts"],
+        "tags": [
+          "Receipts"
+        ],
         "summary": "ファイルボックス（証憑ファイル）の削除",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>ファイルボックス（証憑ファイル）を削除する</p>",
         "operationId": "destroy_receipt",
@@ -13123,7 +14079,9 @@
     },
     "/api/1/receipts/{id}/download": {
       "get": {
-        "tags": ["Receipts"],
+        "tags": [
+          "Receipts"
+        ],
         "summary": "ファイルボックス（証憑ファイル）のダウンロード",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所のファイルボックス（証憑ファイル）をダウンロードする</p>",
         "operationId": "download_receipt",
@@ -13229,7 +14187,9 @@
     },
     "/api/1/expense_applications": {
       "get": {
-        "tags": ["Expense applications"],
+        "tags": [
+          "Expense applications"
+        ],
         "summary": "経費申請一覧の取得",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の経費申請一覧を取得する</p>\n\n<p>経費精算APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-expense-applications\" target=\"_blank\">freee会計経費精算APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>本APIでは、経費申請の一覧を取得することができます。</li>\n  <li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している経費申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n</ul>",
         "operationId": "get_expense_applications",
@@ -13451,12 +14411,13 @@
         }
       },
       "post": {
-        "tags": ["Expense applications"],
+        "tags": [
+          "Expense applications"
+        ],
         "summary": "経費申請の作成",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の経費申請を作成する</p>\n\n<p>経費精算APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-expense-applications\" target=\"_blank\">freee会計経費精算APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>\n    申請ステータス(下書き、申請中)の指定と変更、及び承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）は以下を参考にして行ってください。\n    <ul>\n      <li>\n        承認操作は申請ステータスが申請中、承認済み、却下のものだけが対象です。\n        <ul>\n          <li>\n            初回申請の場合\n            <ul><li>申請の作成（POST）</li></ul>\n          </li>\n          <li>\n            作成済みの申請の申請ステータス変更・更新する場合\n            <ul><li>申請の更新（PUT）</li></ul>\n          </li>\n          <li>\n            申請中、承認済み、却下の申請の承認操作を行う場合\n            <ul><li>承認操作の実行（POST）</li></ul>\n          </li>\n        </ul>\n      </li>\n      <li>申請の削除（DELETE）が可能なのは申請ステータスが下書き、差戻しの場合のみです</li>\n    </ul>\n  </li>\n  <li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している経費申請は本API経由で作成ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n  <li>申請時には、申請タイトル(title)に加え、項目行については金額(amount)、日付(transaction_date)、内容(description)が必須項目となります。申請時の業務効率化のため、API入力をお勧めします。</li>\n  <li>本APIは駅すぱあと連携 (出発駅と到着駅から金額を自動入力する機能)には非対応です。駅すぱあと連携を使用した経費申請は作成できません。</li>\n  <li>本APIは外貨には非対応です。外貨を利用する経費申請は作成できません。</li>\n</ul>",
         "operationId": "create_expense_application",
         "requestBody": {
-          "description": "経費申請の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -13527,7 +14488,9 @@
     },
     "/api/1/expense_applications/{id}": {
       "get": {
-        "tags": ["Expense applications"],
+        "tags": [
+          "Expense applications"
+        ],
         "summary": "経費申請詳細の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の経費申請を取得する</p>\n\n<p>経費精算APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-expense-applications\" target=\"_blank\">freee会計経費精算APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している経費申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n  <li>本APIは駅すぱあと連携 (出発駅と到着駅から金額を自動入力する機能)には非対応です。駅すぱあと連携を使用した経費申請は取得できません。</li>\n  <li>本APIは外貨には非対応です。外貨を利用する経費申請は取得できません。</li>\n</ul>",
         "operationId": "get_expense_application",
@@ -13619,7 +14582,9 @@
         }
       },
       "put": {
-        "tags": ["Expense applications"],
+        "tags": [
+          "Expense applications"
+        ],
         "summary": "経費申請の更新",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の経費申請を更新する</p>\n\n<p>経費精算APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-expense-applications\" target=\"_blank\">freee会計経費精算APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>本APIでは、経費申請を更新することができます。</li>\n  <li>本APIでは、status(申請ステータス): draft:下書き, feedback:差戻しのみ更新可能です。</li>\n  <li>\n    申請ステータス(下書き、申請中)の指定と変更、及び承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）は以下を参考にして行ってください。\n    <ul>\n      <li>\n        承認操作は申請ステータスが申請中、承認済み、却下のものだけが対象です。\n        <ul>\n          <li>\n            初回申請の場合\n            <ul><li>申請の作成（POST）</li></ul>\n          </li>\n          <li>\n            作成済みの申請の申請ステータス変更・更新する場合\n            <ul><li>申請の更新（PUT）</li></ul>\n          </li>\n          <li>\n            申請中、承認済み、却下の申請の承認操作を行う場合\n            <ul><li>承認操作の実行（POST）</li></ul>\n          </li>\n        </ul>\n      </li>\n      <li>申請の削除（DELETE）が可能なのは申請ステータスが下書き、差戻しの場合のみです</li>\n    </ul>\n  </li>\n  <li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している経費申請は本API経由で更新ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n  <li>申請時には、申請タイトル(title)に加え、項目行については金額(amount)、日付(transaction_date)、内容(description)が必須項目となります。申請時の業務効率化のため、API入力をお勧めします。</li>\n  <li>本APIは駅すぱあと連携 (出発駅と到着駅から金額を自動入力する機能)には非対応です。駅すぱあと連携を使用した経費申請は更新できません。</li>\n  <li>本APIは外貨には非対応です。外貨を利用する経費申請は更新できません。</li>\n</ul>",
         "operationId": "update_expense_application",
@@ -13637,7 +14602,6 @@
           }
         ],
         "requestBody": {
-          "description": "経費申請の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -13716,7 +14680,9 @@
         }
       },
       "delete": {
-        "tags": ["Expense applications"],
+        "tags": [
+          "Expense applications"
+        ],
         "summary": "経費申請の削除",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の経費申請を削除する</p>\n\n<p>経費精算APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-expense-applications\" target=\"_blank\">freee会計経費精算APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>\n    申請ステータス(下書き、申請中)の指定と変更、及び承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）は以下を参考にして行ってください。\n    <ul>\n      <li>\n        承認操作は申請ステータスが申請中、承認済み、却下のものだけが対象です。\n        <ul>\n          <li>\n            初回申請の場合\n            <ul><li>申請の作成（POST）</li></ul>\n          </li>\n          <li>\n            作成済みの申請の申請ステータス変更・更新する場合\n            <ul><li>申請の更新（PUT）</li></ul>\n          </li>\n          <li>\n            申請中、承認済み、却下の申請の承認操作を行う場合\n            <ul><li>承認操作の実行（POST）</li></ul>\n          </li>\n        </ul>\n      </li>\n      <li>申請の削除（DELETE）が可能なのは申請ステータスが下書き、差戻しの場合のみです</li>\n      <li>自分が申請者でない申請の削除が可能なのはユーザーの権限が管理者権限、且つ申請ステータスが差し戻しの場合のみです</li>\n    </ul>\n  </li>\n  <li>本APIは駅すぱあと連携 (出発駅と到着駅から金額を自動入力する機能)には非対応です。駅すぱあと連携を使用した経費申請は削除できません。</li>\n</ul>",
         "operationId": "destroy_expense_application",
@@ -13804,7 +14770,9 @@
     },
     "/api/1/expense_applications/{id}/actions": {
       "post": {
-        "tags": ["Expense applications"],
+        "tags": [
+          "Expense applications"
+        ],
         "summary": "経費申請の承認操作",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の経費申請の承認操作を行う</p>\n\n<p>経費精算APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-expense-applications\" target=\"_blank\">freee会計経費精算APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>本APIでは、経費申請の承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）を行うことができます。</li>\n  <li>\n    申請ステータス(下書き、申請中)の指定と変更、及び承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）は以下を参考にして行ってください。\n    <ul>\n      <li>\n        承認操作は申請ステータスが申請中、承認済み、却下のものだけが対象です。\n        <ul>\n          <li>\n            初回申請の場合\n            <ul><li>申請の作成（POST）</li></ul>\n          </li>\n          <li>\n            作成済みの申請の申請ステータス変更・更新する場合\n            <ul><li>申請の更新（PUT）</li></ul>\n          </li>\n          <li>\n            申請中、承認済み、却下の申請の承認操作を行う場合\n            <ul><li>承認操作の実行（POST）</li></ul>\n          </li>\n        </ul>\n      </li>\n      <li>申請の削除（DELETE）が可能なのは申請ステータスが下書き、差戻しの場合のみです</li>\n    </ul>\n  </li>\n  <li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している経費申請はAPI経由で承認ステータスの変更ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n  <li>本APIは駅すぱあと連携 (出発駅と到着駅から金額を自動入力する機能)には非対応です。駅すぱあと連携を使用した経費申請は承認操作できません。</li>\n</ul>",
         "operationId": "update_expense_application_action",
@@ -13822,7 +14790,6 @@
           }
         ],
         "requestBody": {
-          "description": "経費申請の承認操作",
           "content": {
             "application/json": {
               "schema": {
@@ -13903,7 +14870,9 @@
     },
     "/api/1/expense_applications/{id}/parent_approvable_requests": {
       "put": {
-        "tags": ["Expense applications"],
+        "tags": [
+          "Expense applications"
+        ],
         "summary": "経費申請に関連付ける各種申請の更新",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の経費申請に関連付ける各種申請の更新を行う</p>\n\n<p>経費精算APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-expense-applications\" target=\"_blank\">freee会計経費精算APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>本APIでは、経費申請に関連付ける各種申請を更新することができます。</li>\n  <li>本APIでは、status(申請ステータス): in_progress:申請中, approved:承認済みのみ更新可能です。</li>\n  <li>parent_idにnullを指定すると、現在設定されている各種申請との関連付けを解除できます。</li>\n  <li>\n    申請ステータスが申請中の経費申請に対して関連付ける各種申請を更新するためには、以下の全てに当てはまる必要があります。\n    <ul>\n      <li>現在の承認ステップで承認者として指定されている、または特権承認ができる</li>\n      <li>申請フォームの設定で、承認者による経費申請に関連付ける各種申請の更新が許可されている</li>\n    </ul>\n  </li>\n  <li>\n    申請ステータスが承認済みの経費申請に対して関連付ける各種申請を更新するためには、以下の全てに当てはまる必要があります。\n    <ul>\n      <li>経費精算に対する閲覧および編集の権限を持ち、自分の経費申請のみに限定する制限がかかっていない</li>\n      <li>申請フォームの設定で、管理者による経費申請に関連付ける各種申請の更新が許可されている</li>\n    </ul>\n  </li>\n  <li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している経費申請は本API経由で更新ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n  <li>本APIは駅すぱあと連携 (出発駅と到着駅から金額を自動入力する機能)には非対応です。駅すぱあと連携を使用した経費申請は関連付ける各種申請を更新できません。</li>\n  <li>申請フォームの設定はWeb画面よりご利用ください。</li>\n</ul>",
         "operationId": "update_expense_application_parent_approvable_requests",
@@ -13921,7 +14890,6 @@
           }
         ],
         "requestBody": {
-          "description": "経費申請に関連付ける各種申請の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -14002,7 +14970,9 @@
     },
     "/api/1/expense_application_line_templates": {
       "get": {
-        "tags": ["Expense application line templates"],
+        "tags": [
+          "Expense application line templates"
+        ],
         "summary": "経費科目一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の経費科目一覧を取得する</p>",
         "operationId": "get_expense_application_line_templates",
@@ -14048,7 +15018,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["expense_application_line_templates"],
+                  "required": [
+                    "expense_application_line_templates"
+                  ],
                   "properties": {
                     "expense_application_line_templates": {
                       "type": "array",
@@ -14104,11 +15076,12 @@
         }
       },
       "post": {
-        "tags": ["Expense application line templates"],
+        "tags": [
+          "Expense application line templates"
+        ],
         "summary": "経費科目の作成",
         "operationId": "create_expense_application_line_template",
         "requestBody": {
-          "description": "経費科目の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -14179,7 +15152,9 @@
     },
     "/api/1/expense_application_line_templates/{id}": {
       "get": {
-        "tags": ["Expense application line templates"],
+        "tags": [
+          "Expense application line templates"
+        ],
         "summary": "経費科目の取得",
         "operationId": "get_expense_application_line_template",
         "parameters": [
@@ -14270,7 +15245,9 @@
         }
       },
       "put": {
-        "tags": ["Expense application line templates"],
+        "tags": [
+          "Expense application line templates"
+        ],
         "summary": "経費科目の更新",
         "operationId": "update_expense_application_line_template",
         "parameters": [
@@ -14287,7 +15264,6 @@
           }
         ],
         "requestBody": {
-          "description": "経費科目の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -14366,7 +15342,9 @@
         }
       },
       "delete": {
-        "tags": ["Expense application line templates"],
+        "tags": [
+          "Expense application line templates"
+        ],
         "summary": "経費科目の削除",
         "operationId": "destroy_expense_application_line_template",
         "parameters": [
@@ -14453,7 +15431,9 @@
     },
     "/api/1/payment_requests": {
       "get": {
-        "tags": ["Payment requests"],
+        "tags": [
+          "Payment requests"
+        ],
         "summary": "支払依頼一覧の取得",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の支払依頼一覧を取得する</p>\n\n<p>支払依頼APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-payment-requests\" target=\"_blank\">freee会計支払依頼APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>本APIでは、支払依頼の一覧を取得することができます。</li>\n  <li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している支払依頼と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n</ul>",
         "operationId": "get_payment_requests",
@@ -14727,12 +15707,13 @@
         }
       },
       "post": {
-        "tags": ["Payment requests"],
+        "tags": [
+          "Payment requests"
+        ],
         "summary": "支払依頼の作成",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の支払依頼を作成する</p>\n\n<p>支払依頼APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-payment-requests\" target=\"_blank\">freee会計支払依頼APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>\n    申請ステータス(下書き、申請中)の指定と変更、及び承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）は以下を参考にして行ってください。\n    <ul>\n      <li>\n        承認操作は申請ステータスが申請中、承認済み、却下のものだけが対象です。\n        <ul>\n          <li>\n            初回申請の場合\n            <ul><li>申請の作成（POST）</li></ul>\n          </li>\n          <li>\n            作成済みの申請の申請ステータス変更・更新する場合\n            <ul><li>申請の更新（PUT）</li></ul>\n          </li>\n          <li>\n            申請中、承認済み、却下の申請の承認操作を行う場合\n            <ul><li>承認操作の実行（POST）</li></ul>\n          </li>\n        </ul>\n      </li>\n      <li>申請の削除（DELETE）が可能なのは申請ステータスが下書き、差戻しの場合のみです</li>\n    </ul>\n  </li>\n  <li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している支払依頼は本API経由で作成ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n  <li>本APIでは支払依頼の項目行一覧(payment_request_lines)は、最大100行までになります。</li>\n</ul>",
         "operationId": "create_payment_request",
         "requestBody": {
-          "description": "支払依頼の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -14803,7 +15784,9 @@
     },
     "/api/1/payment_requests/{id}": {
       "get": {
-        "tags": ["Payment requests"],
+        "tags": [
+          "Payment requests"
+        ],
         "summary": "支払依頼の取得",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の支払依頼を取得する</p>\n\n<p>支払依頼APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-payment-requests\" target=\"_blank\">freee会計支払依頼APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している支払依頼と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n</ul>",
         "operationId": "get_payment_request",
@@ -14895,7 +15878,9 @@
         }
       },
       "put": {
-        "tags": ["Payment requests"],
+        "tags": [
+          "Payment requests"
+        ],
         "summary": "支払依頼の更新",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の支払依頼を更新する</p>\n\n<p>支払依頼APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-payment-requests\" target=\"_blank\">freee会計支払依頼APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>本APIでは、支払依頼を更新することができます。</li>\n  <li>本APIでは、status(申請ステータス): draft:下書き, in_progress:申請中, feedback:差戻しのみ更新可能です。</li>\n  <li>\n    申請ステータス(下書き、申請中)の指定と変更、及び承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）は以下を参考にして行ってください。\n    <ul>\n      <li>\n        承認操作は申請ステータスが申請中、承認済み、却下のものだけが対象です。\n        <ul>\n          <li>\n            初回申請の場合\n            <ul><li>申請の作成（POST）</li></ul>\n          </li>\n          <li>\n            作成済みの申請の申請ステータス変更・更新する場合\n            <ul><li>申請の更新（PUT）</li></ul>\n          </li>\n          <li>\n            申請中、承認済み、却下の申請の承認操作を行う場合\n            <ul><li>承認操作の実行（POST）</li></ul>\n          </li>\n        </ul>\n      </li>\n      <li>申請の削除（DELETE）が可能なのは申請ステータスが下書き、差戻しの場合のみです</li>\n    </ul>\n  </li>\n  <li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している支払依頼は本API経由で更新ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n  <li>申請ステータスが申請中の場合には、申請タイトル(title)、申請日(application_date)、申請経路ID(approval_flow_route_id)、承認者のユーザーID(approver_id)は更新ができません。</li>\n  <li>本APIでは支払依頼の項目行一覧(payment_request_lines)は、最大100行までになります。</li>\n</ul>",
         "operationId": "update_payment_request",
@@ -14913,7 +15898,6 @@
           }
         ],
         "requestBody": {
-          "description": "支払依頼の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -14992,7 +15976,9 @@
         }
       },
       "delete": {
-        "tags": ["Payment requests"],
+        "tags": [
+          "Payment requests"
+        ],
         "summary": "支払依頼の削除",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の支払依頼を削除する</p>\n\n<p>支払依頼APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-payment-requests\" target=\"_blank\">freee会計支払依頼APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>本APIでは、支払依頼の承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）を行うことができます。</li>\n  <li>\n    申請ステータス(下書き、申請中)の指定と変更、及び承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）は以下を参考にして行ってください。\n    <ul>\n      <li>\n        承認操作は申請ステータスが申請中、承認済み、却下のものだけが対象です。\n        <ul>\n          <li>\n            初回申請の場合\n            <ul><li>申請の作成（POST）</li></ul>\n          </li>\n          <li>\n            作成済みの申請の申請ステータス変更・更新する場合\n            <ul><li>申請の更新（PUT）</li></ul>\n          </li>\n          <li>\n            申請中、承認済み、却下の申請の承認操作を行う場合\n            <ul><li>承認操作の実行（POST）</li></ul>\n          </li>\n        </ul>\n      </li>\n      <li>申請の削除（DELETE）が可能なのは申請ステータスが下書き、差戻しの場合のみです</li>\n    </ul>\n  </li>\n　<li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している支払依頼はAPI経由で承認ステータスの変更ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n</ul>",
         "operationId": "destroy_payment_request",
@@ -15080,7 +16066,9 @@
     },
     "/api/1/payment_requests/{id}/actions": {
       "post": {
-        "tags": ["Payment requests"],
+        "tags": [
+          "Payment requests"
+        ],
         "summary": "支払依頼の承認操作",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の支払依頼の承認操作を行う</p>\n\n<p>支払依頼APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-payment-requests\" target=\"_blank\">freee会計支払依頼APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>本APIでは、支払依頼の承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）を行うことができます。</li>\n  <li>\n    申請ステータス(下書き、申請中)の指定と変更、及び承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）は以下を参考にして行ってください。\n    <ul>\n      <li>\n        承認操作は申請ステータスが申請中、承認済み、却下のものだけが対象です。\n        <ul>\n          <li>\n            初回申請の場合\n            <ul><li>申請の作成（POST）</li></ul>\n          </li>\n          <li>\n            作成済みの申請の申請ステータス変更・更新する場合\n            <ul><li>申請の更新（PUT）</li></ul>\n          </li>\n          <li>\n            申請中、承認済み、却下の申請の承認操作を行う場合\n            <ul><li>承認操作の実行（POST）</li></ul>\n          </li>\n        </ul>\n      </li>\n      <li>申請の削除（DELETE）が可能なのは申請ステータスが下書き、差戻しの場合のみです</li>\n    </ul>\n  </li>\n　<li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している支払依頼はAPI経由で承認ステータスの変更ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n</ul>",
         "operationId": "update_payment_request_action",
@@ -15098,7 +16086,6 @@
           }
         ],
         "requestBody": {
-          "description": "支払依頼の承認操作",
           "content": {
             "application/json": {
               "schema": {
@@ -15179,7 +16166,9 @@
     },
     "/api/1/approval_requests": {
       "get": {
-        "tags": ["Approval requests"],
+        "tags": [
+          "Approval requests"
+        ],
         "summary": "各種申請一覧の取得",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の各種申請一覧を取得する</p>\n\n<p>各種申請APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-approval-requests\" target=\"_blank\">freee会計の各種申請APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>本APIでは、各種申請一覧を取得することができます。</li>\n  <li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している各種申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n  <li>\n    申請フォームの項目に契約書（freeeサイン連携）が利用されている各種申請については、API経由で参照は可能ですが、作成と更新ができません。\n  </li>\n</ul>",
         "operationId": "get_approval_requests",
@@ -15200,7 +16189,13 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["draft", "in_progress", "approved", "rejected", "feedback"]
+              "enum": [
+                "draft",
+                "in_progress",
+                "approved",
+                "rejected",
+                "feedback"
+              ]
             },
             "description": "申請ステータス(draft:下書き, in_progress:申請中, approved:承認済, rejected:却下, feedback:差戻し)\n承認者指定時には無効です。",
             "example": "draft"
@@ -15381,12 +16376,13 @@
         }
       },
       "post": {
-        "tags": ["Approval requests"],
+        "tags": [
+          "Approval requests"
+        ],
         "summary": "各種申請の作成",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の各種申請を作成する</p>\n\n<p>各種申請APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-approval-requests\" target=\"_blank\">freee会計の各種申請APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>本APIでは、各種申請を作成することができます。</li>\n  <li>\n    申請項目(request_items)については、申請フォームで設定された項目のIDとそれに対応する値を入力してください。\n    <ul>\n      <li>タイトル(title)：文字列(必須項目, 255文字まで, 改行なし) 例)予算申請</li>\n      <li>1行コメント(single_line)：文字列(255文字まで, 改行なし) 例)予算に関する申請</li>\n      <li>複数行コメント(multi_line)：文字列(1000文字まで, 改行あり)\n      <br>\n      &nbsp;&nbsp;例)<br>\n      &nbsp;&nbsp;予算に関する申請<br>\n      &nbsp;&nbsp;申請日 2019-12-17<br>\n      </li>\n      <li>プルダウン(select)： プルダウンの選択肢の名前(改行なし) 例)開発部</li>\n      <li>日付(date)： 日付形式 例)2019-12-17</li>\n      <li>金額(amount)： 数値(申請フォームで設定した上限・下限金額内の値, 改行なし) 例)10000</li>\n      <li>添付ファイル(receipt)： ファイルボックス（証憑ファイル）APIのID 例)1\n        <ul>\n          <li>ファイルボックスを参照できる権限が必要</li>\n          <li>自分のアップロードしたファイルのみ参照可能な権限のユーザーの場合、他ユーザーがアップロードしたファイルを指定できません</li>\n        </ul>\n      </li>\n      <li>部門ID(section)： 部門APIのID 例)1</li>\n        <ul>\n          <li>親部門は入力できません</li>\n          <li>ユーザーの所属するグループで利用不可な部門は入力できません</li>\n        </ul>\n      <li>取引先ID(partner)： 取引先APIのID 例)1</li>\n    </ul>\n  </li>\n  <li>申請項目に項目ID, 項目タイプの組み合わせが重複したものを入力できません</li>\n  <li>\n    申請ステータス(下書き、申請中)の指定と変更、及び承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）は以下を参考にして行ってください。\n    <ul>\n      <li>\n        承認操作は申請ステータスが申請中、承認済み、却下のものだけが対象です。\n        <ul>\n          <li>\n            初回申請の場合\n            <ul><li>申請の作成（POST）</li></ul>\n          </li>\n          <li>\n            作成済みの申請の申請ステータス変更・更新する場合\n            <ul><li>申請の更新（PUT）</li></ul>\n          </li>\n          <li>\n            申請中、承認済み、却下の申請の承認操作を行う場合\n            <ul><li>承認操作の実行（POST）</li></ul>\n          </li>\n        </ul>\n      </li>\n      <li>申請の削除（DELETE）が可能なのは申請ステータスが下書き、差戻しの場合のみです</li>\n    </ul>\n  </li>\n  <li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している各種申請は本API経由で作成ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n  <li>\n    申請フォームの項目に契約書（freeeサイン連携）が利用されている各種申請については、API経由で参照は可能ですが、作成と更新ができません。\n  </li>\n  <li>Web画面やAPIを通じて申請フォームが変更されると、本APIで使用する項目ID（request_itemsで指定するid）も変更されます。本API利用前に各種申請の取得APIを利用し、最新の申請フォームを取得することを推奨します。</li>\n  <li>申請中の申請を作成に成功した場合、申請者へメール、モバイルプッシュ、slack による通知をします\n    <ul>\n      <li>Webhook を有効にした事業所の場合は Webhook にも通知をします</li>\n    </ul>\n  </li>\n</ul>",
         "operationId": "create_approval_request",
         "requestBody": {
-          "description": "各種申請の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -15467,7 +16463,9 @@
     },
     "/api/1/approval_requests/{id}": {
       "get": {
-        "tags": ["Approval requests"],
+        "tags": [
+          "Approval requests"
+        ],
         "summary": "各種申請の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の各種申請を取得する</p>\n\n<p>各種申請APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-approval-requests\" target=\"_blank\">freee会計の各種申請APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している各種申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n  <li>\n    申請フォームの項目に契約書（freeeサイン連携）が利用されている各種申請については、API経由で参照は可能ですが、作成と更新ができません。\n  </li>\n</ul>",
         "operationId": "get_approval_request",
@@ -15559,7 +16557,9 @@
         }
       },
       "put": {
-        "tags": ["Approval requests"],
+        "tags": [
+          "Approval requests"
+        ],
         "summary": "各種申請の更新",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の各種申請を更新する</p>\n\n<p>各種申請APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-approval-requests\" target=\"_blank\">freee会計の各種申請APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>本APIでは、各種申請を更新することができます。</li>\n  <li>\n    申請項目(request_items)については、各種申請の取得APIで取得したrequest_items.idとそれに対応する値を入力してください。\n    <ul>\n      <li>タイトル(title)：文字列(必須項目, 255文字まで, 改行なし) 例)予算申請</li>\n      <li>1行コメント(single_line)：文字列(255文字まで, 改行なし) 例)予算に関する申請</li>\n      <li>複数行コメント(multi_line)：文字列(1000文字まで, 改行あり)\n      <br>\n      &nbsp;&nbsp;例)<br>\n      &nbsp;&nbsp;予算に関する申請<br>\n      &nbsp;&nbsp;申請日 2019-12-17<br>\n      </li>\n      <li>プルダウン(select)： プルダウンの選択肢の名前(改行なし) 例)開発部</li>\n      <li>日付(date)： 日付形式 例)2019-12-17</li>\n      <li>金額(amount)： 数値(申請フォームで設定した上限・下限金額内の値, 改行なし) 例)10000</li>\n      <li>添付ファイル(receipt)： ファイルボックス（証憑ファイル）APIのID 例)1\n        <ul>\n          <li>ファイルボックスを参照できる権限が必要</li>\n          <li>自分のアップロードしたファイルのみ参照可能な権限のユーザーの場合、他ユーザーがアップロードしたファイルを指定できません</li>\n        </ul>\n      </li>\n      <li>部門ID(section)： 部門APIのID 例)1</li>\n        <ul>\n          <li>親部門は入力できません</li>\n          <li>ユーザーの所属するグループで利用不可な部門は入力できません</li>\n        </ul>\n      <li>取引先ID(partner)： 取引先APIのID 例)1</li>\n    </ul>\n  </li>\n  <li>申請項目に項目ID, 項目タイプの組み合わせが重複したものを入力できません</li>\n  <li>本APIでは、status(申請ステータス): draft:下書き, feedback:差戻しのみ更新可能です。</li>\n  <li>\n    申請ステータス(下書き、申請中)の指定と変更、及び承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）は以下を参考にして行ってください。\n    <ul>\n      <li>\n        承認操作は申請ステータスが申請中、承認済み、却下のものだけが対象です。\n        <ul>\n          <li>\n            初回申請の場合\n            <ul><li>申請の作成（POST）</li></ul>\n          </li>\n          <li>\n            作成済みの申請の申請ステータス変更・更新する場合\n            <ul><li>申請の更新（PUT）</li></ul>\n          </li>\n          <li>\n            申請中、承認済み、却下の申請の承認操作を行う場合\n            <ul><li>承認操作の実行（POST）</li></ul>\n          </li>\n        </ul>\n      </li>\n      <li>申請の削除（DELETE）が可能なのは申請ステータスが下書き、差戻しの場合のみです</li>\n    </ul>\n  </li>\n  <li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している各種申請は本API経由で更新ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n  <li>\n    申請フォームの項目に契約書（freeeサイン連携）が利用されている各種申請については、API経由で参照は可能ですが、作成と更新ができません。\n  </li>\n  <li>Web画面やAPIを通じて申請フォームが変更されると、本APIで使用する項目ID（request_itemsで指定するid）も変更されます。本APIで使用する項目IDは申請作成時点の項目IDです。本API利用前に各種申請の取得APIを利用し、申請作成時点の項目IDを取得することを推奨します。</li>\n  <li>申請中の申請を作成に成功した場合、申請者へメール、モバイルプッシュ、slack による通知をします\n    <ul>\n      <li>申請を共有している場合、共有者へメール、slack による通知をします</li>\n      <li>Webhook を有効にした事業所の場合は Webhook にも通知をします</li>\n    </ul>\n  </li>\n</ul>",
         "operationId": "update_approval_request",
@@ -15577,7 +16577,6 @@
           }
         ],
         "requestBody": {
-          "description": "各種申請の更新",
           "content": {
             "application/json": {
               "schema": {
@@ -15656,7 +16655,9 @@
         }
       },
       "delete": {
-        "tags": ["Approval requests"],
+        "tags": [
+          "Approval requests"
+        ],
         "summary": "各種申請の削除",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の各種申請を削除する</p>\n\n<p>各種申請APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-approval-requests\" target=\"_blank\">freee会計の各種申請APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>\n    申請ステータス(下書き、申請中)の指定と変更、及び承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）は以下を参考にして行ってください。\n    <ul>\n      <li>\n        承認操作は申請ステータスが申請中、承認済み、却下のものだけが対象です。\n        <ul>\n          <li>\n            初回申請の場合\n            <ul><li>申請の作成（POST）</li></ul>\n          </li>\n          <li>\n            作成済みの申請の申請ステータス変更・更新する場合\n            <ul><li>申請の更新（PUT）</li></ul>\n          </li>\n          <li>\n            申請中、承認済み、却下の申請の承認操作を行う場合\n            <ul><li>承認操作の実行（POST）</li></ul>\n          </li>\n        </ul>\n      </li>\n      <li>申請の削除（DELETE）が可能なのは申請ステータスが下書き、差戻しの場合のみです</li>\n    </ul>\n  </li>\n</ul>",
         "operationId": "destroy_approval_request",
@@ -15744,7 +16745,9 @@
     },
     "/api/1/approval_requests/{id}/actions": {
       "post": {
-        "tags": ["Approval requests"],
+        "tags": [
+          "Approval requests"
+        ],
         "summary": "各種申請の承認操作",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の各種申請の承認操作を行う</p>\n\n<p>各種申請APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-approval-requests\" target=\"_blank\">freee会計の各種申請APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"_2\">注意点</h2>\n<ul>\n  <li>本APIでは、各種申請の承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）を行うことができます。</li>\n  <li>\n    申請ステータス(下書き、申請中)の指定と変更、及び承認操作（承認する、却下する、申請者へ差し戻す、特権承認する、承認済み・却下済みを取り消す）は以下を参考にして行ってください。\n    <ul>\n      <li>\n        承認操作は申請ステータスが申請中、承認済み、却下のものだけが対象です。\n        <ul>\n          <li>\n            初回申請の場合\n            <ul><li>申請の作成（POST）</li></ul>\n          </li>\n          <li>\n            作成済みの申請の申請ステータス変更・更新する場合\n            <ul><li>申請の更新（PUT）</li></ul>\n          </li>\n          <li>\n            申請中、承認済み、却下の申請の承認操作を行う場合\n            <ul><li>承認操作の実行（POST）</li></ul>\n          </li>\n        </ul>\n      </li>\n      <li>申請の削除（DELETE）が可能なのは申請ステータスが下書き、差戻しの場合のみです</li>\n    </ul>\n  </li>\n　<li>\n    申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している各種申請はAPI経由で承認ステータスの変更ができません。\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n  <li>\n    申請フォームの項目に契約書（freeeサイン連携）が利用されている各種申請については、API経由で参照は可能ですが、作成と更新ができません。\n  </li>\n</ul>",
         "operationId": "update_approval_request_action",
@@ -15762,7 +16765,6 @@
           }
         ],
         "requestBody": {
-          "description": "各種申請の承認操作",
           "content": {
             "application/json": {
               "schema": {
@@ -15843,7 +16845,9 @@
     },
     "/api/1/approval_requests/forms": {
       "get": {
-        "tags": ["Approval requests"],
+        "tags": [
+          "Approval requests"
+        ],
         "summary": "各種申請の申請フォーム一覧の取得",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の各種申請の申請フォーム一覧を取得する</p>\n\n<p>各種申請APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-approval-requests\" target=\"_blank\">freee会計の各種申請APIの使い方</a>をご参照ください</p>",
         "operationId": "get_approval_request_forms",
@@ -15926,7 +16930,9 @@
     },
     "/api/1/approval_requests/forms/{id}": {
       "get": {
-        "tags": ["Approval requests"],
+        "tags": [
+          "Approval requests"
+        ],
         "summary": "各種申請の申請フォームの取得",
         "description": "\n<h2 id=\"_1\">概要</h2>\n\n<p>指定した事業所の各種申請の申請フォームを取得する</p>\n\n<p>各種申請APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-approval-requests\" target=\"_blank\">freee会計の各種申請APIの使い方</a>をご参照ください</p>",
         "operationId": "get_approval_request_form",
@@ -16020,7 +17026,9 @@
     },
     "/api/1/approval_flow_routes": {
       "get": {
-        "tags": ["Approval flow routes"],
+        "tags": [
+          "Approval flow routes"
+        ],
         "summary": "申請経路一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の申請経路一覧を取得する</p>\n\n<p>各種申請APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-approval-requests\" target=\"_blank\">freee会計の各種申請APIの使い方</a>をご参照ください</p>\n<p>経費精算APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-expense-applications\" target=\"_blank\">freee会計の経費精算APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"\">注意点</h2>\n\n<ul>\n  <li>\n    <p>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</p>\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n</ul>",
         "operationId": "get_approval_flow_routes",
@@ -16137,7 +17145,9 @@
     },
     "/api/1/approval_flow_routes/{id}": {
       "get": {
-        "tags": ["Approval flow routes"],
+        "tags": [
+          "Approval flow routes"
+        ],
         "summary": "申請経路の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所の申請経路を取得する</p>\n\n<p>各種申請APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-approval-requests\" target=\"_blank\">freee会計の各種申請APIの使い方</a>をご参照ください</p>\n<p>経費精算APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/accounting-expense-applications\" target=\"_blank\">freee会計の経費精算APIの使い方</a>をご参照ください</p>\n\n<h2 id=\"\">注意点</h2>\n\n<ul>\n  <li>\n    <p>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</p>\n    <ul>\n      <li>役職指定（申請者の所属部門）</li>\n      <li>役職指定（申請時に部門指定）</li>\n      <li>部門および役職指定</li>\n    </ul>\n  </li>\n</ul>",
         "operationId": "get_approval_flow_route",
@@ -16229,7 +17239,9 @@
     },
     "/api/1/segments/{segment_id}/tags": {
       "get": {
-        "tags": ["Segment tags"],
+        "tags": [
+          "Segment tags"
+        ],
         "summary": "セグメントタグ一覧の取得",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所のセグメントタグ一覧を取得する</p>\n\n<h2 id=\"\">注意点</h2>\n\n<ul>\n  <li>事業所の設定でセグメントタグコードを使用する設定にしている場合、レスポンスでセグメントタグコード(code)を返します</li>\n</ul>",
         "operationId": "get_segment_tags",
@@ -16278,6 +17290,22 @@
               "minimum": 1,
               "maximum": 500
             }
+          },
+          {
+            "name": "start_update_date",
+            "in": "query",
+            "description": "更新日で絞込：開始日(yyyy-mm-dd)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "end_update_date",
+            "in": "query",
+            "description": "更新日で絞込：終了日(yyyy-mm-dd)",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -16287,7 +17315,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["segment_tags"],
+                  "required": [
+                    "segment_tags"
+                  ],
                   "properties": {
                     "segment_tags": {
                       "type": "array",
@@ -16343,7 +17373,9 @@
         }
       },
       "post": {
-        "tags": ["Segment tags"],
+        "tags": [
+          "Segment tags"
+        ],
         "summary": "セグメントタグの作成",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所のセグメントタグを作成する</p>\n\n<h2 id=\"\">注意点</h2>\n\n<ul>\n  <li>codeを利用するには、事業所の設定でセグメントタグコードを使用する設定にする必要があります。</li>\n</ul>",
         "operationId": "create_segment_tag",
@@ -16362,7 +17394,6 @@
           }
         ],
         "requestBody": {
-          "description": "セグメントタグの作成",
           "content": {
             "application/json": {
               "schema": {
@@ -16433,7 +17464,9 @@
     },
     "/api/1/segments/{segment_id}/tags/{id}": {
       "put": {
-        "tags": ["Segment tags"],
+        "tags": [
+          "Segment tags"
+        ],
         "summary": "セグメントタグの更新",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所のセグメントタグを更新する</p>\n\n<h2 id=\"\">注意点</h2>\n\n<ul>\n  <li>codeを利用するには、事業所の設定でセグメントタグコードを使用する設定にする必要があります。</li>\n</ul>",
         "operationId": "update_segment_tag",
@@ -16463,7 +17496,6 @@
           }
         ],
         "requestBody": {
-          "description": "セグメントタグの作成",
           "content": {
             "application/json": {
               "schema": {
@@ -16532,7 +17564,9 @@
         }
       },
       "delete": {
-        "tags": ["Segment tags"],
+        "tags": [
+          "Segment tags"
+        ],
         "summary": "セグメントタグの削除",
         "description": "\n<h2 id=\"\">概要</h2>\n\n<p>指定した事業所のセグメントタグを削除する</p>",
         "operationId": "destroy_segments_tag",
@@ -16620,9 +17654,165 @@
         }
       }
     },
+    "/api/1/segments/{segment_id}/tags/code/upsert": {
+      "put": {
+        "tags": [
+          "Segment tags"
+        ],
+        "summary": "セグメントタグの更新（作成）",
+        "description": "\n  <h2 id=\"\">概要</h2>\n\n  <p>セグメントタグコードをキーに、指定したセグメントタグの情報を更新（存在しない場合は作成）する</p>\n\n  <h2 id=\"\">注意点</h2>\n\n  <ul>\n    <li>codeを利用するには、事業所の設定でセグメントタグコードを使用する設定にする必要があります。</li>\n  </ul>",
+        "operationId": "upsert_segment_tag",
+        "parameters": [
+          {
+            "name": "segment_id",
+            "in": "path",
+            "description": "セグメントID（1,2,3のいずれか）\n該当プラン以外で参照した場合にはエラーとなります。\n",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 3
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "company_id",
+                  "code",
+                  "segment_tag"
+                ],
+                "properties": {
+                  "company_id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "minimum": 1,
+                    "description": "事業所ID",
+                    "example": 1
+                  },
+                  "code": {
+                    "type": "string",
+                    "maxLength": 20,
+                    "description": "セグメントタグコード",
+                    "example": "code001",
+                    "pattern": "^[0-9a-zA-Z_-]+$"
+                  },
+                  "segment_tag": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "maxLength": 100,
+                        "type": "string",
+                        "description": "セグメントタグ名 (100文字以内)",
+                        "example": "プロジェクトA"
+                      },
+                      "description": {
+                        "maxLength": 30,
+                        "type": "string",
+                        "description": "備考 (30文字以内)",
+                        "example": "備考"
+                      },
+                      "shortcut1": {
+                        "type": "string",
+                        "maxLength": 20,
+                        "description": "ショートカット１ (20文字以内)",
+                        "example": "A"
+                      },
+                      "shortcut2": {
+                        "type": "string",
+                        "maxLength": 20,
+                        "description": "ショートカット２ (20文字以内)",
+                        "example": "123"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/paths/~1api~11~1segments~1%7Bsegment_id%7D~1tags~1code~1upsert/put/requestBody/content/application~1json/schema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/segmentTagResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/segmentTagResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequestError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/1/fixed_assets": {
       "get": {
-        "tags": ["Fixed assets"],
+        "tags": [
+          "Fixed assets"
+        ],
         "summary": "固定資産一覧の取得",
         "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の固定資産一覧を取得する</p>\n\n<h2 id=\"\">定義</h2>\n<ul>\n  <li>このAPIは法人エンタープライズに加入している事業所のみが利用できます。</li>\n  <li><p>target_date : 表示したい会計期間の開始年月日。開始年月日以外を指定した場合は、その日付が含まれる会計期間が対象となります。</p></li>\n  <li><p>depreciation_amount : 本年分の償却費合計</p></li>\n  <li><p>depreciation_method : 償却方法</p></li>\n  <li><p>depreciation_account_item_id : 減価償却に使う勘定科目</p></li>\n  <li><p>acquisition_cost : 取得価額</p></li>\n  <li><p>opening_balance : 期首残高</p></li>\n  <li><p>undepreciated_balance : 未償却残高。土地などの償却しない固定資産はnullが返ります。</p></li>\n  <li><p>opening_accumulated_depreciation : 期首減価償却累計額</p></li>\n  <li><p>closing_accumulated_depreciation : 期末減価償却累計額</p></li>\n</ul>\n<h2 id=\"\">注意点</h2>\n<ul>\n  <li><p>up_to_dateがfalseの場合、残高の集計が完了していません。最新の集計結果を確認したい場合は、時間を空けて再度取得する必要があります。</p></li>\n</ul>",
         "operationId": "get_fixed_assets",
@@ -16731,12 +17921,13 @@
     },
     "/api/1/account_groups": {
       "post": {
-        "tags": ["Account groups"],
+        "tags": [
+          "Account groups"
+        ],
         "summary": "決算書表示名の作成",
         "description": "\n<h2 id=\"_1\">概要</h2>\n<p>指定した事業所の決算書表示名を作成する</p>",
         "operationId": "create_account_group",
         "requestBody": {
-          "description": "決算書表示名の作成",
           "content": {
             "application/json": {
               "schema": {
@@ -16814,7 +18005,13 @@
   "components": {
     "schemas": {
       "paymentParams": {
-        "required": ["amount", "company_id", "date", "from_walletable_id", "from_walletable_type"],
+        "required": [
+          "amount",
+          "company_id",
+          "date",
+          "from_walletable_id",
+          "from_walletable_type"
+        ],
         "type": "object",
         "properties": {
           "company_id": {
@@ -16831,9 +18028,14 @@
           },
           "from_walletable_type": {
             "type": "string",
-            "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet, プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）: private_account_item)：payments指定時は必須",
+            "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet, プライベート資金: private_account_item)：payments指定時は必須",
             "example": "bank_account",
-            "enum": ["bank_account", "credit_card", "wallet", "private_account_item"]
+            "enum": [
+              "bank_account",
+              "credit_card",
+              "wallet",
+              "private_account_item"
+            ]
           },
           "from_walletable_id": {
             "type": "integer",
@@ -16853,7 +18055,12 @@
         }
       },
       "dealCreateParams": {
-        "required": ["company_id", "details", "issue_date", "type"],
+        "required": [
+          "company_id",
+          "details",
+          "issue_date",
+          "type"
+        ],
         "type": "object",
         "properties": {
           "issue_date": {
@@ -16865,7 +18072,10 @@
             "type": "string",
             "description": "収支区分 (収入: income, 支出: expense)",
             "example": "income",
-            "enum": ["income", "expense"]
+            "enum": [
+              "income",
+              "expense"
+            ]
           },
           "company_id": {
             "type": "integer",
@@ -16899,7 +18109,10 @@
           "details": {
             "type": "array",
             "items": {
-              "required": ["tax_code", "account_item_id", "amount"],
+              "required": [
+                "tax_code",
+                "amount"
+              ],
               "type": "object",
               "properties": {
                 "tax_code": {
@@ -16917,6 +18130,11 @@
                   "description": "勘定科目ID",
                   "example": 1
                 },
+                "account_item_code": {
+                  "type": "string",
+                  "description": "勘定科目コード",
+                  "example": "code001"
+                },
                 "amount": {
                   "type": "integer",
                   "format": "int64",
@@ -16932,12 +18150,22 @@
                   "description": "品目ID",
                   "example": 1
                 },
+                "item_code": {
+                  "type": "string",
+                  "description": "品目コード",
+                  "example": "code001"
+                },
                 "section_id": {
                   "type": "integer",
                   "format": "int64",
                   "minimum": 1,
                   "description": "部門ID",
                   "example": 1
+                },
+                "section_code": {
+                  "type": "string",
+                  "description": "部門コード",
+                  "example": "code001"
                 },
                 "tag_ids": {
                   "type": "array",
@@ -16956,6 +18184,11 @@
                   "description": "セグメント１タグID",
                   "example": 1
                 },
+                "segment_1_tag_code": {
+                  "type": "string",
+                  "description": "セグメント１タグコード",
+                  "example": "code001"
+                },
                 "segment_2_tag_id": {
                   "type": "integer",
                   "format": "int64",
@@ -16963,12 +18196,22 @@
                   "description": "セグメント２タグID",
                   "example": 1
                 },
+                "segment_2_tag_code": {
+                  "type": "string",
+                  "description": "セグメント２タグコード",
+                  "example": "code001"
+                },
                 "segment_3_tag_id": {
                   "type": "integer",
                   "format": "int64",
                   "minimum": 1,
                   "description": "セグメント３タグID",
                   "example": 1
+                },
+                "segment_3_tag_code": {
+                  "type": "string",
+                  "description": "セグメント３タグコード",
+                  "example": "code001"
                 },
                 "description": {
                   "type": "string",
@@ -16988,7 +18231,12 @@
             "type": "array",
             "description": "支払行一覧（配列）：未指定の場合、未決済の取引を作成します。",
             "items": {
-              "required": ["amount", "date", "from_walletable_id", "from_walletable_type"],
+              "required": [
+                "amount",
+                "date",
+                "from_walletable_id",
+                "from_walletable_type"
+              ],
               "type": "object",
               "properties": {
                 "amount": {
@@ -17008,9 +18256,14 @@
                 },
                 "from_walletable_type": {
                   "type": "string",
-                  "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet, プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）: private_account_item)：payments指定時は必須",
+                  "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet, プライベート資金: private_account_item)：payments指定時は必須",
                   "example": "bank_account",
-                  "enum": ["bank_account", "credit_card", "wallet", "private_account_item"]
+                  "enum": [
+                    "bank_account",
+                    "credit_card",
+                    "wallet",
+                    "private_account_item"
+                  ]
                 },
                 "date": {
                   "type": "string",
@@ -17033,7 +18286,12 @@
         }
       },
       "dealUpdateParams": {
-        "required": ["company_id", "details", "issue_date", "type"],
+        "required": [
+          "company_id",
+          "details",
+          "issue_date",
+          "type"
+        ],
         "type": "object",
         "properties": {
           "issue_date": {
@@ -17045,7 +18303,10 @@
             "type": "string",
             "description": "収支区分 (収入: income, 支出: expense)",
             "example": "income",
-            "enum": ["income", "expense"]
+            "enum": [
+              "income",
+              "expense"
+            ]
           },
           "company_id": {
             "type": "integer",
@@ -17079,7 +18340,11 @@
           "details": {
             "type": "array",
             "items": {
-              "required": ["tax_code", "account_item_id", "amount"],
+              "required": [
+                "tax_code",
+                "account_item_id",
+                "amount"
+              ],
               "type": "object",
               "properties": {
                 "id": {
@@ -17185,7 +18450,11 @@
         }
       },
       "manualJournalCreateParams": {
-        "required": ["company_id", "details", "issue_date"],
+        "required": [
+          "company_id",
+          "details",
+          "issue_date"
+        ],
         "type": "object",
         "properties": {
           "company_id": {
@@ -17208,14 +18477,22 @@
           "details": {
             "type": "array",
             "items": {
-              "required": ["account_item_id", "amount", "entry_side", "tax_code"],
+              "required": [
+                "account_item_id",
+                "amount",
+                "entry_side",
+                "tax_code"
+              ],
               "type": "object",
               "properties": {
                 "entry_side": {
                   "type": "string",
                   "description": "貸借（貸方: credit, 借方: debit）",
                   "example": "debit",
-                  "enum": ["debit", "credit"]
+                  "enum": [
+                    "debit",
+                    "credit"
+                  ]
                 },
                 "tax_code": {
                   "type": "integer",
@@ -17325,7 +18602,11 @@
         }
       },
       "manualJournalUpdateParams": {
-        "required": ["company_id", "details", "issue_date"],
+        "required": [
+          "company_id",
+          "details",
+          "issue_date"
+        ],
         "type": "object",
         "properties": {
           "company_id": {
@@ -17348,7 +18629,12 @@
           "details": {
             "type": "array",
             "items": {
-              "required": ["account_item_id", "amount", "entry_side", "tax_code"],
+              "required": [
+                "account_item_id",
+                "amount",
+                "entry_side",
+                "tax_code"
+              ],
               "type": "object",
               "properties": {
                 "id": {
@@ -17362,7 +18648,10 @@
                   "type": "string",
                   "description": "貸借（貸方: credit, 借方: debit）",
                   "example": "debit",
-                  "enum": ["debit", "credit"]
+                  "enum": [
+                    "debit",
+                    "credit"
+                  ]
                 },
                 "tax_code": {
                   "type": "integer",
@@ -17473,7 +18762,10 @@
       },
       "itemParams": {
         "type": "object",
-        "required": ["company_id", "name"],
+        "required": [
+          "company_id",
+          "name"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -17511,7 +18803,11 @@
       },
       "walletableCreateParams": {
         "type": "object",
-        "required": ["company_id", "name", "type"],
+        "required": [
+          "company_id",
+          "name",
+          "type"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -17523,7 +18819,11 @@
             "type": "string",
             "description": "口座種別（bank_account : 銀行口座, credit_card : クレジットカード, wallet : その他の決済口座）",
             "example": "bank_account",
-            "enum": ["bank_account", "credit_card", "wallet"]
+            "enum": [
+              "bank_account",
+              "credit_card",
+              "wallet"
+            ]
           },
           "company_id": {
             "type": "integer",
@@ -17536,6 +18836,7 @@
             "type": "integer",
             "format": "int64",
             "minimum": 1,
+            "nullable": true,
             "description": "連携サービスID（typeにbank_account、credit_cardを指定する場合は必須）",
             "example": 1
           },
@@ -17548,7 +18849,10 @@
       },
       "walletableUpdateParams": {
         "type": "object",
-        "required": ["company_id", "name"],
+        "required": [
+          "company_id",
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -17567,7 +18871,12 @@
       },
       "walletableUpdateResponse": {
         "type": "object",
-        "required": ["bank_id", "id", "name", "type"],
+        "required": [
+          "bank_id",
+          "id",
+          "name",
+          "type"
+        ],
         "properties": {
           "id": {
             "type": "integer",
@@ -17594,7 +18903,11 @@
             "type": "string",
             "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)",
             "example": "bank_account",
-            "enum": ["bank_account", "credit_card", "wallet"]
+            "enum": [
+              "bank_account",
+              "credit_card",
+              "wallet"
+            ]
           },
           "last_balance": {
             "type": "integer",
@@ -17633,7 +18946,11 @@
             "type": "string",
             "description": "振替先口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)",
             "example": "bank_account",
-            "enum": ["bank_account", "credit_card", "wallet"]
+            "enum": [
+              "bank_account",
+              "credit_card",
+              "wallet"
+            ]
           },
           "from_walletable_id": {
             "type": "integer",
@@ -17646,7 +18963,11 @@
             "type": "string",
             "description": "振替元口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)",
             "example": "credit_card",
-            "enum": ["bank_account", "credit_card", "wallet"]
+            "enum": [
+              "bank_account",
+              "credit_card",
+              "wallet"
+            ]
           },
           "amount": {
             "type": "integer",
@@ -17690,7 +19011,10 @@
             "type": "string",
             "description": "入金／出金 (入金: income, 出金: expense)",
             "example": "income",
-            "enum": ["income", "expense"]
+            "enum": [
+              "income",
+              "expense"
+            ]
           },
           "description": {
             "type": "string",
@@ -17716,7 +19040,11 @@
             "type": "string",
             "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)",
             "example": "bank_account",
-            "enum": ["bank_account", "credit_card", "wallet"]
+            "enum": [
+              "bank_account",
+              "credit_card",
+              "wallet"
+            ]
           },
           "date": {
             "type": "string",
@@ -17742,7 +19070,10 @@
       },
       "expenseApplicationCreateParams": {
         "type": "object",
-        "required": ["company_id", "title"],
+        "required": [
+          "company_id",
+          "title"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -17790,7 +19121,9 @@
             "description": "経費申請の申請行一覧（配列）",
             "items": {
               "type": "object",
-              "required": ["transaction_date"],
+              "required": [
+                "transaction_date"
+              ],
               "properties": {
                 "receipt_id": {
                   "type": "integer",
@@ -17898,7 +19231,10 @@
       },
       "expenseApplicationUpdateParams": {
         "type": "object",
-        "required": ["company_id", "title"],
+        "required": [
+          "company_id",
+          "title"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -17946,7 +19282,9 @@
             "description": "経費申請の申請行一覧（配列）",
             "items": {
               "type": "object",
-              "required": ["transaction_date"],
+              "required": [
+                "transaction_date"
+              ],
               "properties": {
                 "id": {
                   "type": "integer",
@@ -18069,7 +19407,12 @@
       },
       "expenseApplicationActionCreateParams": {
         "type": "object",
-        "required": ["company_id", "approval_action", "target_step_id", "target_round"],
+        "required": [
+          "company_id",
+          "approval_action",
+          "target_step_id",
+          "target_round"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -18082,7 +19425,14 @@
             "type": "string",
             "description": "操作(approve: 承認する、force_approve: 特権承認する、cancel: 申請を取り消す、reject: 却下する、feedback: 申請者へ差し戻す、force_feedback: 承認済み・却下済みを取り消す)",
             "example": "approve",
-            "enum": ["approve", "force_approve", "cancel", "reject", "feedback", "force_feedback"]
+            "enum": [
+              "approve",
+              "force_approve",
+              "cancel",
+              "reject",
+              "feedback",
+              "force_feedback"
+            ]
           },
           "target_step_id": {
             "type": "integer",
@@ -18111,7 +19461,10 @@
       },
       "expenseApplicationParentApprovableRequestUpdateParams": {
         "type": "object",
-        "required": ["company_id", "parent_id"],
+        "required": [
+          "company_id",
+          "parent_id"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -18168,13 +19521,19 @@
             "description": "支払依頼の項目行一覧（配列）",
             "items": {
               "type": "object",
-              "required": ["amount"],
+              "required": [
+                "amount"
+              ],
               "properties": {
                 "line_type": {
                   "type": "string",
                   "description": "'行の種類 (deal_line: 支払依頼の通常取引行, negative_line: 支払依頼の控除・マイナス行, withholding_tax: 源泉所得税行)'<br>\n'デフォルトは deal_line: 支払依頼の通常取引行 です'\n",
                   "example": "deal_line",
-                  "enum": ["deal_line", "negative_line", "withholding_tax"]
+                  "enum": [
+                    "deal_line",
+                    "negative_line",
+                    "withholding_tax"
+                  ]
                 },
                 "description": {
                   "type": "string",
@@ -18222,7 +19581,11 @@
                 "tag_ids": {
                   "type": "array",
                   "description": "メモタグID",
-                  "example": [1, 2, 3],
+                  "example": [
+                    1,
+                    2,
+                    3
+                  ],
                   "items": {
                     "type": "integer",
                     "format": "int64",
@@ -18385,12 +19748,22 @@
             "type": "string",
             "description": "'口座種別(ordinary: 普通、checking: 当座、earmarked: 納税準備預金、savings: 貯蓄、other: その他)'<br>\n'支払先指定時には無効'<br>\n'デフォルトは ordinary: 普通 です'\n",
             "example": "ordinary",
-            "enum": ["ordinary", "checking", "earmarked", "savings", "other"]
+            "enum": [
+              "ordinary",
+              "checking",
+              "earmarked",
+              "savings",
+              "other"
+            ]
           },
           "qualified_invoice_status": {
             "type": "string",
             "description": "適格請求書発行事業者（qualified: 該当する、not_qualified: 該当しない、unspecified: 未選択）\n- 支払依頼をインボイス要件をみたす申請として扱うかどうかを表します。\n- qualified_invoice_statusキーをリクエストに含めない場合、unspecifiedが適用されます。\n- issue_dateが2023年9月30日以前の場合、unspecified以外利用できません。\n- インボイス経過措置の税区分の設定が使用する設定になっていない場合、unspecified以外利用できません。\n",
-            "enum": ["qualified", "not_qualified", "unspecified"],
+            "enum": [
+              "qualified",
+              "not_qualified",
+              "unspecified"
+            ],
             "example": "qualified"
           }
         }
@@ -18432,7 +19805,9 @@
             "description": "支払依頼の項目行一覧（配列）",
             "items": {
               "type": "object",
-              "required": ["amount"],
+              "required": [
+                "amount"
+              ],
               "properties": {
                 "id": {
                   "type": "integer",
@@ -18445,7 +19820,11 @@
                   "type": "string",
                   "description": "'行の種類 (deal_line: 支払依頼の通常取引行, negative_line: 支払依頼の控除・マイナス行, withholding_tax: 源泉所得税行)'<br>\n'デフォルトは deal_line: 支払依頼の通常取引行 です'\n",
                   "example": "deal_line",
-                  "enum": ["deal_line", "negative_line", "withholding_tax"]
+                  "enum": [
+                    "deal_line",
+                    "negative_line",
+                    "withholding_tax"
+                  ]
                 },
                 "description": {
                   "type": "string",
@@ -18493,7 +19872,11 @@
                 "tag_ids": {
                   "type": "array",
                   "description": "メモタグID",
-                  "example": [1, 2, 3],
+                  "example": [
+                    1,
+                    2,
+                    3
+                  ],
                   "items": {
                     "type": "integer",
                     "format": "int64",
@@ -18648,18 +20031,31 @@
             "type": "string",
             "description": "'口座種別(ordinary: 普通、checking: 当座、earmarked: 納税準備預金、savings: 貯蓄、other: その他)'<br>\n'支払先指定時には無効'<br>\n'デフォルトは ordinary: 普通 です'\n",
             "example": "ordinary",
-            "enum": ["ordinary", "checking", "earmarked", "savings", "other"]
+            "enum": [
+              "ordinary",
+              "checking",
+              "earmarked",
+              "savings",
+              "other"
+            ]
           },
           "qualified_invoice_status": {
             "type": "string",
             "description": "適格請求書発行事業者（qualified: 該当する、not_qualified: 該当しない、unspecified: 未選択）\n- 支払依頼をインボイス要件をみたす申請として扱うかどうかを表します。\n- qualified_invoice_statusキーをリクエストに含めない場合、unspecifiedが適用されます。\n- issue_dateが2023年9月30日以前の場合、unspecified以外利用できません。\n- インボイス経過措置の税区分の設定が使用する設定になっていない場合、unspecified以外利用できません。\n",
-            "enum": ["qualified", "not_qualified", "unspecified"],
+            "enum": [
+              "qualified",
+              "not_qualified",
+              "unspecified"
+            ],
             "example": "qualified"
           }
         }
       },
       "partnerCreateParams": {
-        "required": ["company_id", "name"],
+        "required": [
+          "company_id",
+          "name"
+        ],
         "type": "object",
         "properties": {
           "company_id": {
@@ -18697,14 +20093,20 @@
             "format": "int64",
             "description": "事業所種別（null: 未設定、1: 法人、2: 個人）",
             "example": 1,
-            "enum": [1, 2],
+            "enum": [
+              1,
+              2
+            ],
             "nullable": true
           },
           "country_code": {
             "type": "string",
             "description": "地域（JP: 国内、ZZ:国外）、指定しない場合JPになります。",
             "example": "JP",
-            "enum": ["JP", "ZZ"]
+            "enum": [
+              "JP",
+              "ZZ"
+            ]
           },
           "long_name": {
             "type": "string",
@@ -18752,7 +20154,10 @@
             "type": "string",
             "description": "振込手数料負担（一括振込ファイル用）: (振込元(当方): payer, 振込先(先方): payee)、指定しない場合payerになります。",
             "example": "payer",
-            "enum": ["payer", "payee"]
+            "enum": [
+              "payer",
+              "payee"
+            ]
           },
           "qualified_invoice_issuer": {
             "type": "boolean",
@@ -18807,7 +20212,11 @@
                 "type": "string",
                 "description": "請求書送付方法(email:メール、posting:郵送、email_and_posting:メールと郵送、null:設定しない)",
                 "example": "posting",
-                "enum": ["email", "posting", "email_and_posting"],
+                "enum": [
+                  "email",
+                  "posting",
+                  "email_and_posting"
+                ],
                 "nullable": true
               }
             }
@@ -18927,7 +20336,10 @@
         }
       },
       "partnerUpdateParams": {
-        "required": ["company_id", "name"],
+        "required": [
+          "company_id",
+          "name"
+        ],
         "type": "object",
         "properties": {
           "company_id": {
@@ -18965,14 +20377,20 @@
             "format": "int64",
             "description": "事業所種別（null: 未設定、1: 法人、2: 個人）",
             "example": 1,
-            "enum": [1, 2],
+            "enum": [
+              1,
+              2
+            ],
             "nullable": true
           },
           "country_code": {
             "type": "string",
             "description": "地域（JP: 国内、ZZ:国外）、指定しない場合JPになります。",
             "example": "JP",
-            "enum": ["JP", "ZZ"]
+            "enum": [
+              "JP",
+              "ZZ"
+            ]
           },
           "long_name": {
             "type": "string",
@@ -19020,7 +20438,10 @@
             "type": "string",
             "description": "振込手数料負担（一括振込ファイル用）: (振込元(当方): payer, 振込先(先方): payee)、指定しない場合payerになります。",
             "example": "payer",
-            "enum": ["payer", "payee"]
+            "enum": [
+              "payer",
+              "payee"
+            ]
           },
           "qualified_invoice_issuer": {
             "type": "boolean",
@@ -19074,7 +20495,11 @@
                 "type": "string",
                 "description": "請求書送付方法(email:メール、posting:郵送、email_and_posting:メールと郵送、null:設定しない)",
                 "example": "posting",
-                "enum": ["email", "posting", "email_and_posting"],
+                "enum": [
+                  "email",
+                  "posting",
+                  "email_and_posting"
+                ],
                 "nullable": true
               }
             }
@@ -19198,7 +20623,10 @@
       },
       "receiptCreateParams": {
         "type": "object",
-        "required": ["company_id", "receipt"],
+        "required": [
+          "company_id",
+          "receipt"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -19232,8 +20660,8 @@
           "receipt_metadatum_amount": {
             "type": "integer",
             "format": "int64",
-            "minimum": -9223372036854775808,
-            "maximum": 9223372036854775807,
+            "minimum": -999999999999,
+            "maximum": 999999999999,
             "nullable": true,
             "description": "金額",
             "example": 5250
@@ -19241,20 +20669,30 @@
           "qualified_invoice": {
             "type": "string",
             "description": "適格請求書等（qualified: 該当する、not_qualified: 該当しない、unselected: 未選択）",
-            "enum": ["qualified", "not_qualified", "unselected"],
+            "enum": [
+              "qualified",
+              "not_qualified",
+              "unselected"
+            ],
             "example": "qualified"
           },
           "document_type": {
             "type": "string",
             "description": "書類の種類（receipt: 領収書、invoice: 請求書、other: その他）",
-            "enum": ["receipt", "invoice", "other"],
+            "enum": [
+              "receipt",
+              "invoice",
+              "other"
+            ],
             "example": "receipt"
           }
         }
       },
       "receiptUpdateParams": {
         "type": "object",
-        "required": ["company_id"],
+        "required": [
+          "company_id"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -19288,8 +20726,8 @@
               "amount": {
                 "type": "integer",
                 "format": "int64",
-                "minimum": -9223372036854775808,
-                "maximum": 9223372036854775807,
+                "minimum": -999999999999,
+                "maximum": 999999999999,
                 "nullable": true,
                 "description": "金額",
                 "example": 5250
@@ -19299,7 +20737,11 @@
           "qualified_invoice": {
             "type": "string",
             "description": "適格請求書等（qualified: 該当する、not_qualified: 該当しない、unselected: 未選択）",
-            "enum": ["qualified", "not_qualified", "unselected"],
+            "enum": [
+              "qualified",
+              "not_qualified",
+              "unselected"
+            ],
             "example": "qualified"
           },
           "invoice_registration_number": {
@@ -19313,14 +20755,21 @@
           "document_type": {
             "type": "string",
             "description": "書類の種類（receipt: 領収書、invoice: 請求書、other: その他）",
-            "enum": ["receipt", "invoice", "other"],
+            "enum": [
+              "receipt",
+              "invoice",
+              "other"
+            ],
             "example": "receipt"
           }
         }
       },
       "accountItemCreateParams": {
         "type": "object",
-        "required": ["account_item", "company_id"],
+        "required": [
+          "account_item",
+          "company_id"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -19450,7 +20899,9 @@
       },
       "accountItemsResponse": {
         "type": "object",
-        "required": ["account_items"],
+        "required": [
+          "account_items"
+        ],
         "properties": {
           "account_items": {
             "type": "array",
@@ -19587,6 +21038,11 @@
                   "description": "支出取引相手勘定科目ID",
                   "example": 1,
                   "nullable": true
+                },
+                "update_date": {
+                  "type": "string",
+                  "description": "更新日(yyyy-mm-dd)",
+                  "example": "2020-06-15"
                 }
               }
             }
@@ -19595,7 +21051,9 @@
       },
       "accountItemResponse": {
         "type": "object",
-        "required": ["account_item"],
+        "required": [
+          "account_item"
+        ],
         "properties": {
           "account_item": {
             "type": "object",
@@ -19695,7 +21153,10 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["id", "name"],
+                  "required": [
+                    "id",
+                    "name"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -19716,7 +21177,10 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["id", "name"],
+                  "required": [
+                    "id",
+                    "name"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -19794,7 +21258,10 @@
       },
       "accountItemUpdateParams": {
         "type": "object",
-        "required": ["account_item", "company_id"],
+        "required": [
+          "account_item",
+          "company_id"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -19922,7 +21389,9 @@
       },
       "bank": {
         "type": "object",
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "properties": {
           "id": {
             "type": "integer",
@@ -19940,7 +21409,11 @@
             "type": "string",
             "description": "連携サービス種別: (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)",
             "example": "bank_account",
-            "enum": ["bank_account", "credit_card", "wallet"]
+            "enum": [
+              "bank_account",
+              "credit_card",
+              "wallet"
+            ]
           },
           "name_kana": {
             "type": "string",
@@ -19952,7 +21425,9 @@
       },
       "bankResponse": {
         "type": "object",
-        "required": ["bank"],
+        "required": [
+          "bank"
+        ],
         "properties": {
           "bank": {
             "$ref": "#/components/schemas/bank"
@@ -19960,11 +21435,16 @@
         }
       },
       "journalsResponse": {
-        "required": ["journals"],
+        "required": [
+          "journals"
+        ],
         "type": "object",
         "properties": {
           "journals": {
-            "required": ["company_id", "id"],
+            "required": [
+              "company_id",
+              "id"
+            ],
             "type": "object",
             "properties": {
               "id": {
@@ -19993,14 +21473,22 @@
                 "type": "string",
                 "description": "ダウンロード形式",
                 "example": "csv",
-                "enum": ["generic", "generic_v2", "csv", "pdf"]
+                "enum": [
+                  "generic",
+                  "generic_v2",
+                  "csv",
+                  "pdf"
+                ]
               },
               "encoding": {
                 "type": "string",
                 "description": "文字コード",
                 "example": "sjis",
                 "nullable": true,
-                "enum": ["sjis", "utf-8"]
+                "enum": [
+                  "sjis",
+                  "utf-8"
+                ]
               },
               "start_date": {
                 "type": "string",
@@ -20038,7 +21526,11 @@
                   "type": "string",
                   "description": "追加出力するID項目",
                   "example": "deal_id",
-                  "enum": ["deal_id", "transfer_id", "manual_journal_id"]
+                  "enum": [
+                    "deal_id",
+                    "transfer_id",
+                    "manual_journal_id"
+                  ]
                 }
               },
               "status_url": {
@@ -20056,13 +21548,19 @@
                 "description": "集計が最新でない場合の要因情報",
                 "items": {
                   "type": "object",
-                  "required": ["code", "message"],
+                  "required": [
+                    "code",
+                    "message"
+                  ],
                   "properties": {
                     "code": {
                       "type": "string",
                       "description": "コード",
                       "example": "depreciation_creating",
-                      "enum": ["depreciation_creating", "depreciation_create_error"]
+                      "enum": [
+                        "depreciation_creating",
+                        "depreciation_create_error"
+                      ]
                     },
                     "message": {
                       "type": "string",
@@ -20078,11 +21576,20 @@
       },
       "journalStatusResponse": {
         "type": "object",
-        "required": ["journals"],
+        "required": [
+          "journals"
+        ],
         "properties": {
           "journals": {
             "type": "object",
-            "required": ["company_id", "download_type", "end_date", "id", "start_date", "status"],
+            "required": [
+              "company_id",
+              "download_type",
+              "end_date",
+              "id",
+              "start_date",
+              "status"
+            ],
             "properties": {
               "id": {
                 "type": "integer",
@@ -20102,20 +21609,33 @@
                 "type": "string",
                 "description": "ダウンロード形式",
                 "example": "csv",
-                "enum": ["generic", "generic_v2", "csv", "pdf"]
+                "enum": [
+                  "generic",
+                  "generic_v2",
+                  "csv",
+                  "pdf"
+                ]
               },
               "encoding": {
                 "type": "string",
                 "description": "文字コード",
                 "example": "sjis",
                 "nullable": true,
-                "enum": ["sjis", "utf-8"]
+                "enum": [
+                  "sjis",
+                  "utf-8"
+                ]
               },
               "status": {
                 "type": "string",
                 "description": "ダウンロードリクエストのステータス",
-                "example": "csv",
-                "enum": ["enqueued", "working", "uploaded", "failed"]
+                "example": "enqueued",
+                "enum": [
+                  "enqueued",
+                  "working",
+                  "uploaded",
+                  "failed"
+                ]
               },
               "start_date": {
                 "type": "string",
@@ -20153,7 +21673,11 @@
                   "type": "string",
                   "description": "追加出力するID項目",
                   "example": "deal_id",
-                  "enum": ["deal_id", "transfer_id", "manual_journal_id"]
+                  "enum": [
+                    "deal_id",
+                    "transfer_id",
+                    "manual_journal_id"
+                  ]
                 }
               },
               "download_url": {
@@ -20167,11 +21691,17 @@
       },
       "trialBsResponse": {
         "type": "object",
-        "required": ["trial_bs", "up_to_date"],
+        "required": [
+          "trial_bs",
+          "up_to_date"
+        ],
         "properties": {
           "trial_bs": {
             "type": "object",
-            "required": ["balances", "company_id"],
+            "required": [
+              "balances",
+              "company_id"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -20215,7 +21745,10 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
@@ -20260,13 +21793,19 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -20300,7 +21839,9 @@
                       "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -20351,7 +21892,9 @@
                       "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -20402,7 +21945,9 @@
                       "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -20453,7 +21998,9 @@
                       "description": "breakdown_display_type:segment_1_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -20504,7 +22051,9 @@
                       "description": "breakdown_display_type:segment_2_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -20555,7 +22104,9 @@
                       "description": "breakdown_display_type:segment_3_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -20666,13 +22217,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -20686,11 +22243,17 @@
       },
       "trialBsTwoYearsResponse": {
         "type": "object",
-        "required": ["trial_bs_two_years", "up_to_date"],
+        "required": [
+          "trial_bs_two_years",
+          "up_to_date"
+        ],
         "properties": {
           "trial_bs_two_years": {
             "type": "object",
-            "required": ["balances", "company_id"],
+            "required": [
+              "balances",
+              "company_id"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -20734,7 +22297,10 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
@@ -20779,13 +22345,19 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -20819,7 +22391,9 @@
                       "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -20858,7 +22432,9 @@
                       "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -20897,7 +22473,9 @@
                       "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -20936,7 +22514,9 @@
                       "description": "breakdown_display_type:segment_1_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -20975,7 +22555,9 @@
                       "description": "breakdown_display_type:segment_2_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -21014,7 +22596,9 @@
                       "description": "breakdown_display_type:segment_3_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -21101,13 +22685,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -21120,12 +22710,18 @@
         }
       },
       "trialBsThreeYearsResponse": {
-        "required": ["trial_bs_three_years", "up_to_date"],
+        "required": [
+          "trial_bs_three_years",
+          "up_to_date"
+        ],
         "type": "object",
         "properties": {
           "trial_bs_three_years": {
             "type": "object",
-            "required": ["balances", "company_id"],
+            "required": [
+              "balances",
+              "company_id"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -21169,7 +22765,10 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
@@ -21214,13 +22813,19 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -21254,7 +22859,9 @@
                       "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -21299,7 +22906,9 @@
                       "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -21344,7 +22953,9 @@
                       "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -21389,7 +23000,9 @@
                       "description": "breakdown_display_type:segment_1_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -21434,7 +23047,9 @@
                       "description": "breakdown_display_type:segment_2_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -21479,7 +23094,9 @@
                       "description": "breakdown_display_type:segment_3_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -21578,13 +23195,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -21598,10 +23221,16 @@
       },
       "trialPlResponse": {
         "type": "object",
-        "required": ["trial_pl", "up_to_date"],
+        "required": [
+          "trial_pl",
+          "up_to_date"
+        ],
         "properties": {
           "trial_pl": {
-            "required": ["balances", "company_id"],
+            "required": [
+              "balances",
+              "company_id"
+            ],
             "type": "object",
             "properties": {
               "company_id": {
@@ -21646,7 +23275,10 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
@@ -21691,19 +23323,28 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "cost_allocation": {
                 "type": "string",
                 "description": "配賦仕訳のみ：only,配賦仕訳以外：without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -21737,7 +23378,9 @@
                       "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -21788,7 +23431,9 @@
                       "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -21839,7 +23484,9 @@
                       "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -21890,7 +23537,9 @@
                       "description": "breakdown_display_type:segment_1_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -21941,7 +23590,9 @@
                       "description": "breakdown_display_type:segment_2_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -21992,7 +23643,9 @@
                       "description": "breakdown_display_type:segment_3_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -22103,13 +23756,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -22123,11 +23782,17 @@
       },
       "trialPlTwoYearsResponse": {
         "type": "object",
-        "required": ["trial_pl_two_years", "up_to_date"],
+        "required": [
+          "trial_pl_two_years",
+          "up_to_date"
+        ],
         "properties": {
           "trial_pl_two_years": {
             "type": "object",
-            "required": ["balances", "company_id"],
+            "required": [
+              "balances",
+              "company_id"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -22171,7 +23836,10 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
@@ -22216,19 +23884,28 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "cost_allocation": {
                 "type": "string",
                 "description": "配賦仕訳のみ：only,配賦仕訳以外：without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -22262,7 +23939,9 @@
                       "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -22301,7 +23980,9 @@
                       "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -22340,7 +24021,9 @@
                       "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -22379,7 +24062,9 @@
                       "description": "breakdown_display_type:segment_1_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -22418,7 +24103,9 @@
                       "description": "breakdown_display_type:segment_2_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -22457,7 +24144,9 @@
                       "description": "breakdown_display_type:segment_3_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -22544,13 +24233,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -22564,11 +24259,17 @@
       },
       "trialPlThreeYearsResponse": {
         "type": "object",
-        "required": ["trial_pl_three_years", "up_to_date"],
+        "required": [
+          "trial_pl_three_years",
+          "up_to_date"
+        ],
         "properties": {
           "trial_pl_three_years": {
             "type": "object",
-            "required": ["balances", "company_id"],
+            "required": [
+              "balances",
+              "company_id"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -22612,7 +24313,10 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
@@ -22657,19 +24361,28 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "cost_allocation": {
                 "type": "string",
                 "description": "配賦仕訳のみ：only,配賦仕訳以外：without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -22703,7 +24416,9 @@
                       "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -22748,7 +24463,9 @@
                       "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -22793,7 +24510,9 @@
                       "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -22838,7 +24557,9 @@
                       "description": "breakdown_display_type:segment_1_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -22883,7 +24604,9 @@
                       "description": "breakdown_display_type:segment_2_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -22928,7 +24651,9 @@
                       "description": "breakdown_display_type:segment_3_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -23027,13 +24752,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -23047,11 +24778,18 @@
       },
       "trialPlSectionsResponse": {
         "type": "object",
-        "required": ["trial_pl_sections", "up_to_date"],
+        "required": [
+          "trial_pl_sections",
+          "up_to_date"
+        ],
         "properties": {
           "trial_pl_sections": {
             "type": "object",
-            "required": ["balances", "company_id", "section_ids"],
+            "required": [
+              "balances",
+              "company_id",
+              "section_ids"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -23100,7 +24838,10 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
@@ -23137,19 +24878,28 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "cost_allocation": {
                 "type": "string",
                 "description": "配賦仕訳のみ：only,配賦仕訳以外：without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -23183,7 +24933,9 @@
                       "description": "部門",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -23208,7 +24960,9 @@
                             "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -23236,7 +24990,9 @@
                             "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -23264,7 +25020,9 @@
                             "description": "breakdown_display_type:segment_1_tag, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -23292,7 +25050,9 @@
                             "description": "breakdown_display_type:segment_2_tag, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -23320,7 +25080,9 @@
                             "description": "breakdown_display_type:segment_3_tag, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -23388,13 +25150,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -23408,11 +25176,18 @@
       },
       "trialPlSegment_1TagsResponse": {
         "type": "object",
-        "required": ["trial_pl_segment_1_tags", "up_to_date"],
+        "required": [
+          "trial_pl_segment_1_tags",
+          "up_to_date"
+        ],
         "properties": {
           "trial_pl_segment_1_tags": {
             "type": "object",
-            "required": ["balances", "company_id", "segment_1_tag_ids"],
+            "required": [
+              "balances",
+              "company_id",
+              "segment_1_tag_ids"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -23461,12 +25236,20 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
                 "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item）(条件に指定した時のみ含まれる）",
-                "enum": ["partner", "item", "section", "account_item"]
+                "enum": [
+                  "partner",
+                  "item",
+                  "section",
+                  "account_item"
+                ]
               },
               "partner_id": {
                 "type": "integer",
@@ -23498,19 +25281,28 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "cost_allocation": {
                 "type": "string",
                 "description": "配賦仕訳のみ：only,配賦仕訳以外：without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -23544,7 +25336,9 @@
                       "description": "セグメント１タグ",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -23569,7 +25363,9 @@
                             "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -23597,7 +25393,9 @@
                             "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -23625,7 +25423,9 @@
                             "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -23693,13 +25493,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -23713,11 +25519,18 @@
       },
       "trialPlSegment_2TagsResponse": {
         "type": "object",
-        "required": ["trial_pl_segment_2_tags", "up_to_date"],
+        "required": [
+          "trial_pl_segment_2_tags",
+          "up_to_date"
+        ],
         "properties": {
           "trial_pl_segment_2_tags": {
             "type": "object",
-            "required": ["balances", "company_id", "segment_2_tag_ids"],
+            "required": [
+              "balances",
+              "company_id",
+              "segment_2_tag_ids"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -23766,12 +25579,20 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
                 "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item）(条件に指定した時のみ含まれる）",
-                "enum": ["partner", "item", "section", "account_item"]
+                "enum": [
+                  "partner",
+                  "item",
+                  "section",
+                  "account_item"
+                ]
               },
               "partner_id": {
                 "type": "integer",
@@ -23803,19 +25624,28 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "cost_allocation": {
                 "type": "string",
                 "description": "配賦仕訳のみ：only,配賦仕訳以外：without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -23849,7 +25679,9 @@
                       "description": "セグメント２タグ",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -23874,7 +25706,9 @@
                             "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -23902,7 +25736,9 @@
                             "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -23930,7 +25766,9 @@
                             "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -23998,13 +25836,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -24018,11 +25862,18 @@
       },
       "trialPlSegment_3TagsResponse": {
         "type": "object",
-        "required": ["trial_pl_segment_3_tags", "up_to_date"],
+        "required": [
+          "trial_pl_segment_3_tags",
+          "up_to_date"
+        ],
         "properties": {
           "trial_pl_segment_3_tags": {
             "type": "object",
-            "required": ["balances", "company_id", "segment_3_tag_ids"],
+            "required": [
+              "balances",
+              "company_id",
+              "segment_3_tag_ids"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -24071,12 +25922,20 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
                 "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item）(条件に指定した時のみ含まれる）",
-                "enum": ["partner", "item", "section", "account_item"]
+                "enum": [
+                  "partner",
+                  "item",
+                  "section",
+                  "account_item"
+                ]
               },
               "partner_id": {
                 "type": "integer",
@@ -24108,19 +25967,28 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "cost_allocation": {
                 "type": "string",
                 "description": "配賦仕訳のみ：only,配賦仕訳以外：without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -24154,7 +26022,9 @@
                       "description": "セグメント３タグ",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -24179,7 +26049,9 @@
                             "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -24207,7 +26079,9 @@
                             "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -24235,7 +26109,9 @@
                             "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -24303,13 +26179,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -24323,10 +26205,16 @@
       },
       "trialCrResponse": {
         "type": "object",
-        "required": ["trial_cr", "up_to_date"],
+        "required": [
+          "trial_cr",
+          "up_to_date"
+        ],
         "properties": {
           "trial_cr": {
-            "required": ["balances", "company_id"],
+            "required": [
+              "balances",
+              "company_id"
+            ],
             "type": "object",
             "properties": {
               "company_id": {
@@ -24371,7 +26259,10 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
@@ -24416,19 +26307,28 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "cost_allocation": {
                 "type": "string",
                 "description": "配賦仕訳のみ：only,配賦仕訳以外：without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -24462,7 +26362,9 @@
                       "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -24513,7 +26415,9 @@
                       "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -24564,7 +26468,9 @@
                       "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -24615,7 +26521,9 @@
                       "description": "breakdown_display_type:segment_1_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -24666,7 +26574,9 @@
                       "description": "breakdown_display_type:segment_2_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -24717,7 +26627,9 @@
                       "description": "breakdown_display_type:segment_3_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -24828,13 +26740,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -24848,11 +26766,17 @@
       },
       "trialCrTwoYearsResponse": {
         "type": "object",
-        "required": ["trial_cr_two_years", "up_to_date"],
+        "required": [
+          "trial_cr_two_years",
+          "up_to_date"
+        ],
         "properties": {
           "trial_cr_two_years": {
             "type": "object",
-            "required": ["balances", "company_id"],
+            "required": [
+              "balances",
+              "company_id"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -24896,7 +26820,10 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
@@ -24940,19 +26867,28 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "cost_allocation": {
                 "type": "string",
                 "description": "配賦仕訳のみ：only,配賦仕訳以外：without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -24986,7 +26922,9 @@
                       "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -25025,7 +26963,9 @@
                       "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -25064,7 +27004,9 @@
                       "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -25103,7 +27045,9 @@
                       "description": "breakdown_display_type:segment_1_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -25142,7 +27086,9 @@
                       "description": "breakdown_display_type:segment_2_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -25181,7 +27127,9 @@
                       "description": "breakdown_display_type:segment_3_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -25268,13 +27216,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -25288,11 +27242,17 @@
       },
       "trialCrThreeYearsResponse": {
         "type": "object",
-        "required": ["trial_cr_three_years", "up_to_date"],
+        "required": [
+          "trial_cr_three_years",
+          "up_to_date"
+        ],
         "properties": {
           "trial_cr_three_years": {
             "type": "object",
-            "required": ["balances", "company_id"],
+            "required": [
+              "balances",
+              "company_id"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -25336,7 +27296,10 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
@@ -25381,19 +27344,28 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "cost_allocation": {
                 "type": "string",
                 "description": "配賦仕訳のみ：only,配賦仕訳以外：without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -25427,7 +27399,9 @@
                       "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -25472,7 +27446,9 @@
                       "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -25517,7 +27493,9 @@
                       "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -25562,7 +27540,9 @@
                       "description": "breakdown_display_type:segment_1_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -25607,7 +27587,9 @@
                       "description": "breakdown_display_type:segment_2_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -25652,7 +27634,9 @@
                       "description": "breakdown_display_type:segment_3_tag, account_item_display_type:account_item指定時のみ含まれる",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -25751,13 +27735,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -25771,11 +27761,18 @@
       },
       "trialCrSectionsResponse": {
         "type": "object",
-        "required": ["trial_cr_sections", "up_to_date"],
+        "required": [
+          "trial_cr_sections",
+          "up_to_date"
+        ],
         "properties": {
           "trial_cr_sections": {
             "type": "object",
-            "required": ["balances", "company_id", "section_ids"],
+            "required": [
+              "balances",
+              "company_id",
+              "section_ids"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -25824,7 +27821,10 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
@@ -25861,19 +27861,28 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "cost_allocation": {
                 "type": "string",
                 "description": "配賦仕訳のみ：only,配賦仕訳以外：without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -25907,7 +27916,9 @@
                       "description": "部門",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -25932,7 +27943,9 @@
                             "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -25960,7 +27973,9 @@
                             "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -25988,7 +28003,9 @@
                             "description": "breakdown_display_type:segment_1_tag, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -26016,7 +28033,9 @@
                             "description": "breakdown_display_type:segment_2_tag, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -26044,7 +28063,9 @@
                             "description": "breakdown_display_type:segment_3_tag, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -26112,13 +28133,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -26132,11 +28159,18 @@
       },
       "trialCrSegment_1TagsResponse": {
         "type": "object",
-        "required": ["trial_cr_segment_1_tags", "up_to_date"],
+        "required": [
+          "trial_cr_segment_1_tags",
+          "up_to_date"
+        ],
         "properties": {
           "trial_cr_segment_1_tags": {
             "type": "object",
-            "required": ["balances", "company_id", "segment_1_tag_ids"],
+            "required": [
+              "balances",
+              "company_id",
+              "segment_1_tag_ids"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -26185,12 +28219,20 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
                 "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item）(条件に指定した時のみ含まれる）",
-                "enum": ["partner", "item", "section", "account_item"]
+                "enum": [
+                  "partner",
+                  "item",
+                  "section",
+                  "account_item"
+                ]
               },
               "partner_id": {
                 "type": "integer",
@@ -26222,19 +28264,28 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "cost_allocation": {
                 "type": "string",
                 "description": "配賦仕訳のみ：only,配賦仕訳以外：without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -26268,7 +28319,9 @@
                       "description": "セグメント１タグ",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -26293,7 +28346,9 @@
                             "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -26321,7 +28376,9 @@
                             "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -26349,7 +28406,9 @@
                             "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -26417,13 +28476,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -26437,11 +28502,18 @@
       },
       "trialCrSegment_2TagsResponse": {
         "type": "object",
-        "required": ["trial_cr_segment_2_tags", "up_to_date"],
+        "required": [
+          "trial_cr_segment_2_tags",
+          "up_to_date"
+        ],
         "properties": {
           "trial_cr_segment_2_tags": {
             "type": "object",
-            "required": ["balances", "company_id", "segment_2_tag_ids"],
+            "required": [
+              "balances",
+              "company_id",
+              "segment_2_tag_ids"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -26490,12 +28562,20 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
                 "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item）(条件に指定した時のみ含まれる）",
-                "enum": ["partner", "item", "section", "account_item"]
+                "enum": [
+                  "partner",
+                  "item",
+                  "section",
+                  "account_item"
+                ]
               },
               "partner_id": {
                 "type": "integer",
@@ -26527,19 +28607,28 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "cost_allocation": {
                 "type": "string",
                 "description": "配賦仕訳のみ：only,配賦仕訳以外：without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -26573,7 +28662,9 @@
                       "description": "セグメント２タグ",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -26598,7 +28689,9 @@
                             "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -26626,7 +28719,9 @@
                             "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -26654,7 +28749,9 @@
                             "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -26722,13 +28819,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -26742,11 +28845,18 @@
       },
       "trialCrSegment_3TagsResponse": {
         "type": "object",
-        "required": ["trial_cr_segment_3_tags", "up_to_date"],
+        "required": [
+          "trial_cr_segment_3_tags",
+          "up_to_date"
+        ],
         "properties": {
           "trial_cr_segment_3_tags": {
             "type": "object",
-            "required": ["balances", "company_id", "segment_3_tag_ids"],
+            "required": [
+              "balances",
+              "company_id",
+              "segment_3_tag_ids"
+            ],
             "properties": {
               "company_id": {
                 "type": "integer",
@@ -26795,12 +28905,20 @@
               "account_item_display_type": {
                 "type": "string",
                 "description": "勘定科目の表示（勘定科目: account_item, 決算書表示:group）(条件に指定した時のみ含まれる）",
-                "enum": ["account_item", "group"]
+                "enum": [
+                  "account_item",
+                  "group"
+                ]
               },
               "breakdown_display_type": {
                 "type": "string",
                 "description": "内訳の表示（取引先: partner, 品目: item, 部門: section, 勘定科目: account_item）(条件に指定した時のみ含まれる）",
-                "enum": ["partner", "item", "section", "account_item"]
+                "enum": [
+                  "partner",
+                  "item",
+                  "section",
+                  "account_item"
+                ]
               },
               "partner_id": {
                 "type": "integer",
@@ -26832,19 +28950,28 @@
                 "type": "string",
                 "description": "決算整理仕訳のみ: only, 決算整理仕訳以外: without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "cost_allocation": {
                 "type": "string",
                 "description": "配賦仕訳のみ：only,配賦仕訳以外：without(条件に指定した時のみ含まれる）",
                 "example": "only",
-                "enum": ["only", "without"]
+                "enum": [
+                  "only",
+                  "without"
+                ]
               },
               "approval_flow_status": {
                 "type": "string",
                 "description": "未承認を除く: without_in_progress (デフォルト), 全てのステータス: all(条件に指定した時のみ含まれる）",
                 "example": "without_in_progress",
-                "enum": ["without_in_progress", "all"]
+                "enum": [
+                  "without_in_progress",
+                  "all"
+                ]
               },
               "created_at": {
                 "type": "string",
@@ -26878,7 +29005,9 @@
                       "description": "セグメント３タグ",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -26903,7 +29032,9 @@
                             "description": "breakdown_display_type:partner, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -26931,7 +29062,9 @@
                             "description": "breakdown_display_type:item, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -26959,7 +29092,9 @@
                             "description": "breakdown_display_type:section, account_item_display_type:account_item指定時のみ含まれる",
                             "items": {
                               "type": "object",
-                              "required": ["id"],
+                              "required": [
+                                "id"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -27027,13 +29162,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -27047,7 +29188,10 @@
       },
       "sectionParams": {
         "type": "object",
-        "required": ["company_id", "name"],
+        "required": [
+          "company_id",
+          "name"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -27098,7 +29242,12 @@
       },
       "section": {
         "type": "object",
-        "required": ["company_id", "id", "name", "available"],
+        "required": [
+          "company_id",
+          "id",
+          "name",
+          "available"
+        ],
         "properties": {
           "id": {
             "type": "integer",
@@ -27168,12 +29317,19 @@
             "description": "<a target=\"_blank\" href=\"https://support.freee.co.jp/hc/ja/articles/209093566\">親部門ID</a>\n<br>\n※ parent_id が null のときは第一階層の親部門です。\n",
             "example": 1,
             "nullable": true
+          },
+          "update_date": {
+            "type": "string",
+            "description": "更新日(yyyy-mm-dd)",
+            "example": "2020-06-15"
           }
         }
       },
       "sectionResponse": {
         "type": "object",
-        "required": ["section"],
+        "required": [
+          "section"
+        ],
         "properties": {
           "section": {
             "$ref": "#/components/schemas/section"
@@ -27182,11 +29338,20 @@
       },
       "dealCreateResponse": {
         "type": "object",
-        "required": ["deal"],
+        "required": [
+          "deal"
+        ],
         "properties": {
           "deal": {
             "type": "object",
-            "required": ["amount", "company_id", "id", "issue_date", "partner_id", "status"],
+            "required": [
+              "amount",
+              "company_id",
+              "id",
+              "issue_date",
+              "partner_id",
+              "status"
+            ],
             "properties": {
               "id": {
                 "type": "integer",
@@ -27230,7 +29395,10 @@
                 "type": "string",
                 "description": "収支区分 (収入: income, 支出: expense)",
                 "example": "expense",
-                "enum": ["income", "expense"]
+                "enum": [
+                  "income",
+                  "expense"
+                ]
               },
               "partner_id": {
                 "type": "integer",
@@ -27255,7 +29423,10 @@
                 "type": "string",
                 "description": "決済状況 (未決済: unsettled, 完了: settled)",
                 "example": "settled",
-                "enum": ["unsettled", "settled"]
+                "enum": [
+                  "unsettled",
+                  "settled"
+                ]
               },
               "deal_origin_name": {
                 "type": "string",
@@ -27267,7 +29438,14 @@
                 "description": "取引の明細行",
                 "items": {
                   "type": "object",
-                  "required": ["account_item_id", "amount", "entry_side", "id", "tax_code", "vat"],
+                  "required": [
+                    "account_item_id",
+                    "amount",
+                    "entry_side",
+                    "id",
+                    "tax_code",
+                    "vat"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -27282,6 +29460,12 @@
                       "minimum": 1,
                       "description": "勘定科目ID",
                       "example": 803
+                    },
+                    "account_item_code": {
+                      "type": "string",
+                      "description": "勘定科目コード",
+                      "example": "code001",
+                      "nullable": true
                     },
                     "tax_code": {
                       "type": "integer",
@@ -27299,6 +29483,12 @@
                       "example": 501,
                       "nullable": true
                     },
+                    "item_code": {
+                      "type": "string",
+                      "description": "品目コード",
+                      "example": "code001",
+                      "nullable": true
+                    },
                     "section_id": {
                       "type": "integer",
                       "format": "int64",
@@ -27307,10 +29497,20 @@
                       "example": 1,
                       "nullable": true
                     },
+                    "section_code": {
+                      "type": "string",
+                      "description": "部門コード",
+                      "example": "code001",
+                      "nullable": true
+                    },
                     "tag_ids": {
                       "type": "array",
                       "description": "メモタグID",
-                      "example": [1, 2, 3],
+                      "example": [
+                        1,
+                        2,
+                        3
+                      ],
                       "items": {
                         "type": "integer",
                         "format": "int64",
@@ -27325,6 +29525,12 @@
                       "example": 1,
                       "nullable": true
                     },
+                    "segment_1_tag_code": {
+                      "type": "string",
+                      "description": "セグメント１タグコード",
+                      "example": "code001",
+                      "nullable": true
+                    },
                     "segment_2_tag_id": {
                       "type": "integer",
                       "format": "int64",
@@ -27333,12 +29539,24 @@
                       "example": 1,
                       "nullable": true
                     },
+                    "segment_2_tag_code": {
+                      "type": "string",
+                      "description": "セグメント２タグコード",
+                      "example": "code001",
+                      "nullable": true
+                    },
                     "segment_3_tag_id": {
                       "type": "integer",
                       "format": "int64",
                       "minimum": 1,
                       "description": "セグメント３タグID",
                       "example": 1,
+                      "nullable": true
+                    },
+                    "segment_3_tag_code": {
+                      "type": "string",
+                      "description": "セグメント３タグコード",
+                      "example": "code001",
                       "nullable": true
                     },
                     "amount": {
@@ -27364,7 +29582,10 @@
                       "type": "string",
                       "description": "貸借（貸方: credit, 借方: debit）",
                       "example": "debit",
-                      "enum": ["credit", "debit"]
+                      "enum": [
+                        "credit",
+                        "debit"
+                      ]
                     }
                   }
                 }
@@ -27374,7 +29595,11 @@
                 "description": "取引の支払行",
                 "items": {
                   "type": "object",
-                  "required": ["amount", "date", "id"],
+                  "required": [
+                    "amount",
+                    "date",
+                    "id"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -27390,9 +29615,14 @@
                     },
                     "from_walletable_type": {
                       "type": "string",
-                      "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet, プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）: private_account_item)",
+                      "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet, プライベート資金: private_account_item)",
                       "example": "bank_account",
-                      "enum": ["bank_account", "credit_card", "wallet", "private_account_item"]
+                      "enum": [
+                        "bank_account",
+                        "credit_card",
+                        "wallet",
+                        "private_account_item"
+                      ]
                     },
                     "from_walletable_id": {
                       "type": "integer",
@@ -27417,7 +29647,14 @@
                 "description": "ファイルボックス（証憑ファイル）",
                 "items": {
                   "type": "object",
-                  "required": ["created_at", "id", "mime_type", "origin", "status", "user"],
+                  "required": [
+                    "created_at",
+                    "id",
+                    "mime_type",
+                    "origin",
+                    "status",
+                    "user"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -27430,7 +29667,11 @@
                       "type": "string",
                       "description": "ステータス(confirmed:確認済み、deleted:削除済み、ignored:無視)",
                       "example": "confirmed",
-                      "enum": ["confirmed", "deleted", "ignored"]
+                      "enum": [
+                        "confirmed",
+                        "deleted",
+                        "ignored"
+                      ]
                     },
                     "description": {
                       "type": "string",
@@ -27470,7 +29711,10 @@
                       "example": "2019-12-17T18:30:24+09:00"
                     },
                     "user": {
-                      "required": ["email", "id"],
+                      "required": [
+                        "email",
+                        "id"
+                      ],
                       "type": "object",
                       "properties": {
                         "id": {
@@ -27529,7 +29773,14 @@
       },
       "deal": {
         "type": "object",
-        "required": ["amount", "company_id", "id", "issue_date", "partner_id", "status"],
+        "required": [
+          "amount",
+          "company_id",
+          "id",
+          "issue_date",
+          "partner_id",
+          "status"
+        ],
         "properties": {
           "id": {
             "type": "integer",
@@ -27573,7 +29824,10 @@
             "type": "string",
             "description": "収支区分 (収入: income, 支出: expense)",
             "example": "expense",
-            "enum": ["income", "expense"]
+            "enum": [
+              "income",
+              "expense"
+            ]
           },
           "partner_id": {
             "type": "integer",
@@ -27597,7 +29851,10 @@
             "type": "string",
             "description": "決済状況 (未決済: unsettled, 完了: settled)",
             "example": "settled",
-            "enum": ["unsettled", "settled"]
+            "enum": [
+              "unsettled",
+              "settled"
+            ]
           },
           "deal_origin_name": {
             "type": "string",
@@ -27609,7 +29866,14 @@
             "description": "取引の明細行",
             "items": {
               "type": "object",
-              "required": ["account_item_id", "amount", "entry_side", "id", "tax_code", "vat"],
+              "required": [
+                "account_item_id",
+                "amount",
+                "entry_side",
+                "id",
+                "tax_code",
+                "vat"
+              ],
               "properties": {
                 "id": {
                   "type": "integer",
@@ -27648,7 +29912,11 @@
                 "tag_ids": {
                   "type": "array",
                   "description": "メモタグID",
-                  "example": [1, 2, 3],
+                  "example": [
+                    1,
+                    2,
+                    3
+                  ],
                   "items": {
                     "type": "integer",
                     "format": "int64"
@@ -27698,7 +29966,10 @@
                   "type": "string",
                   "description": "貸借（貸方: credit, 借方: debit）",
                   "example": "debit",
-                  "enum": ["credit", "debit"]
+                  "enum": [
+                    "credit",
+                    "debit"
+                  ]
                 }
               }
             }
@@ -27708,7 +29979,13 @@
             "description": "取引の+更新行",
             "items": {
               "type": "object",
-              "required": ["details", "id", "renew_target_id", "renew_target_type", "update_date"],
+              "required": [
+                "details",
+                "id",
+                "renew_target_id",
+                "renew_target_type",
+                "update_date"
+              ],
               "properties": {
                 "id": {
                   "type": "integer",
@@ -27731,7 +30008,11 @@
                   "type": "string",
                   "description": "+更新の対象行タイプ",
                   "example": "detail",
-                  "enum": ["detail", "accrual", "renew"]
+                  "enum": [
+                    "detail",
+                    "accrual",
+                    "renew"
+                  ]
                 },
                 "details": {
                   "type": "array",
@@ -27758,7 +30039,10 @@
                         "type": "string",
                         "description": "貸借(貸方: credit, 借方: debit)",
                         "example": "debit",
-                        "enum": ["credit", "debit"]
+                        "enum": [
+                          "credit",
+                          "debit"
+                        ]
                       },
                       "account_item_id": {
                         "type": "integer",
@@ -27849,7 +30133,11 @@
             "description": "取引の支払行",
             "items": {
               "type": "object",
-              "required": ["amount", "date", "id"],
+              "required": [
+                "amount",
+                "date",
+                "id"
+              ],
               "properties": {
                 "id": {
                   "type": "integer",
@@ -27864,9 +30152,14 @@
                 },
                 "from_walletable_type": {
                   "type": "string",
-                  "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet, プライベート資金（法人の場合は役員借入金もしくは役員借入金、個人の場合は事業主貸もしくは事業主借）: private_account_item)",
+                  "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet, プライベート資金: private_account_item)",
                   "example": "bank_account",
-                  "enum": ["bank_account", "credit_card", "wallet", "private_account_item"]
+                  "enum": [
+                    "bank_account",
+                    "credit_card",
+                    "wallet",
+                    "private_account_item"
+                  ]
                 },
                 "from_walletable_id": {
                   "type": "integer",
@@ -27890,7 +30183,15 @@
             "description": "ファイルボックス（証憑ファイル）",
             "items": {
               "type": "object",
-              "required": ["created_at", "file_src", "id", "mime_type", "origin", "status", "user"],
+              "required": [
+                "created_at",
+                "file_src",
+                "id",
+                "mime_type",
+                "origin",
+                "status",
+                "user"
+              ],
               "properties": {
                 "id": {
                   "type": "integer",
@@ -27902,7 +30203,11 @@
                   "type": "string",
                   "description": "ステータス(confirmed:確認済み、deleted:削除済み、ignored:無視)",
                   "example": "confirmed",
-                  "enum": ["confirmed", "deleted", "ignored"]
+                  "enum": [
+                    "confirmed",
+                    "deleted",
+                    "ignored"
+                  ]
                 },
                 "description": {
                   "type": "string",
@@ -27948,7 +30253,10 @@
                   "deprecated": true
                 },
                 "user": {
-                  "required": ["email", "id"],
+                  "required": [
+                    "email",
+                    "id"
+                  ],
                   "type": "object",
                   "properties": {
                     "id": {
@@ -28004,7 +30312,9 @@
       },
       "dealResponse": {
         "type": "object",
-        "required": ["deal"],
+        "required": [
+          "deal"
+        ],
         "properties": {
           "deal": {
             "$ref": "#/components/schemas/deal"
@@ -28017,20 +30327,32 @@
           "account_categories": {
             "type": "array",
             "items": {
-              "required": ["account_items", "balance", "org_code", "role", "title"],
+              "required": [
+                "account_items",
+                "balance",
+                "org_code",
+                "role",
+                "title"
+              ],
               "type": "object",
               "properties": {
                 "balance": {
                   "type": "string",
                   "description": "収支",
                   "example": "expense",
-                  "enum": ["expense", "income"]
+                  "enum": [
+                    "expense",
+                    "income"
+                  ]
                 },
                 "org_code": {
                   "type": "string",
                   "description": "事業形態（個人事業主: personal、法人: corporate）",
                   "example": "personal",
-                  "enum": ["personal", "corporate"]
+                  "enum": [
+                    "personal",
+                    "corporate"
+                  ]
                 },
                 "role": {
                   "type": "string",
@@ -28051,7 +30373,9 @@
                   "type": "array",
                   "description": "勘定科目の一覧",
                   "items": {
-                    "required": ["id"],
+                    "required": [
+                      "id"
+                    ],
                     "type": "object",
                     "properties": {
                       "id": {
@@ -28311,7 +30635,13 @@
             "type": "array",
             "description": "決算書表示名（小カテゴリー）",
             "items": {
-              "required": ["account_category_id", "account_structure_id", "id", "index", "name"],
+              "required": [
+                "account_category_id",
+                "account_structure_id",
+                "id",
+                "index",
+                "name"
+              ],
               "type": "object",
               "properties": {
                 "id": {
@@ -28370,7 +30700,13 @@
         }
       },
       "item": {
-        "required": ["company_id", "id", "name", "update_date", "available"],
+        "required": [
+          "company_id",
+          "id",
+          "name",
+          "update_date",
+          "available"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -28425,7 +30761,9 @@
         }
       },
       "itemResponse": {
-        "required": ["item"],
+        "required": [
+          "item"
+        ],
         "type": "object",
         "properties": {
           "item": {
@@ -28435,7 +30773,14 @@
       },
       "manual_journal": {
         "type": "object",
-        "required": ["adjustment", "company_id", "details", "id", "issue_date", "txn_number"],
+        "required": [
+          "adjustment",
+          "company_id",
+          "details",
+          "id",
+          "issue_date",
+          "txn_number"
+        ],
         "properties": {
           "id": {
             "type": "integer",
@@ -28502,7 +30847,10 @@
                   "type": "string",
                   "description": "貸借(貸方: credit, 借方: debit)",
                   "example": "credit",
-                  "enum": ["credit", "debit"]
+                  "enum": [
+                    "credit",
+                    "debit"
+                  ]
                 },
                 "account_item_id": {
                   "type": "integer",
@@ -28659,7 +31007,11 @@
           "receipt_ids": {
             "type": "array",
             "description": "ファイルボックス（証憑ファイル）ID",
-            "example": [1, 2, 3],
+            "example": [
+              1,
+              2,
+              3
+            ],
             "items": {
               "type": "integer",
               "format": "int64",
@@ -28670,7 +31022,9 @@
       },
       "manualJournalResponse": {
         "type": "object",
-        "required": ["manual_journal"],
+        "required": [
+          "manual_journal"
+        ],
         "properties": {
           "manual_journal": {
             "$ref": "#/components/schemas/manual_journal"
@@ -28678,7 +31032,10 @@
         }
       },
       "tagParams": {
-        "required": ["company_id", "name"],
+        "required": [
+          "company_id",
+          "name"
+        ],
         "type": "object",
         "properties": {
           "company_id": {
@@ -28710,7 +31067,12 @@
       },
       "tag": {
         "type": "object",
-        "required": ["company_id", "id", "name", "update_date"],
+        "required": [
+          "company_id",
+          "id",
+          "name",
+          "update_date"
+        ],
         "properties": {
           "id": {
             "type": "integer",
@@ -28755,7 +31117,9 @@
       },
       "tagResponse": {
         "type": "object",
-        "required": ["tag"],
+        "required": [
+          "tag"
+        ],
         "properties": {
           "tag": {
             "$ref": "#/components/schemas/tag"
@@ -28764,13 +31128,22 @@
       },
       "companyIndexResponse": {
         "type": "object",
-        "required": ["companies"],
+        "required": [
+          "companies"
+        ],
         "properties": {
           "companies": {
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["company_number", "display_name", "id", "name", "name_kana", "role"],
+              "required": [
+                "company_number",
+                "display_name",
+                "id",
+                "name",
+                "name_kana",
+                "role"
+              ],
               "properties": {
                 "id": {
                   "type": "integer",
@@ -28799,14 +31172,20 @@
                 },
                 "company_number": {
                   "type": "string",
-                  "description": "事業所番号（ハイフン無し）",
-                  "example": "1234567890"
+                  "description": "事業所番号（ハイフン無し)(半角英数字10桁)",
+                  "example": "97e576421b"
                 },
                 "role": {
                   "type": "string",
                   "description": "ユーザーの権限\n\n* admin - 管理者\n* simple_accounting - 一般（経理）\n* read_only - 取引登録のみ\n* self_only - 閲覧のみ\n* workflow - 申請・承認",
                   "example": "admin",
-                  "enum": ["admin", "simple_accounting", "self_only", "read_only", "workflow"]
+                  "enum": [
+                    "admin",
+                    "simple_accounting",
+                    "self_only",
+                    "read_only",
+                    "workflow"
+                  ]
                 }
               }
             }
@@ -28815,7 +31194,9 @@
       },
       "companyResponse": {
         "type": "object",
-        "required": ["company"],
+        "required": [
+          "company"
+        ],
         "properties": {
           "company": {
             "type": "object",
@@ -28909,7 +31290,11 @@
                 "type": "string",
                 "description": "仕訳番号形式（not_used: 使用しない、digits: 数字（例：5091824）、alnum: 英数字（例：59J0P））",
                 "example": "not_used",
-                "enum": ["not_used", "digits", "alnum"]
+                "enum": [
+                  "not_used",
+                  "digits",
+                  "alnum"
+                ]
               },
               "default_wallet_account_id": {
                 "type": "integer",
@@ -28940,14 +31325,20 @@
               },
               "company_number": {
                 "type": "string",
-                "description": "事業所番号（ハイフン無し）",
-                "example": "1234567890"
+                "description": "事業所番号（ハイフン無し)(半角英数字10桁)",
+                "example": "97e576421b"
               },
               "role": {
                 "type": "string",
                 "description": "ユーザーの権限\n\n* admin - 管理者\n* simple_accounting - 一般（経理）\n* read_only - 取引登録のみ\n* self_only - 閲覧のみ\n* workflow - 申請・承認",
                 "example": "admin",
-                "enum": ["admin", "simple_accounting", "self_only", "read_only", "workflow"]
+                "enum": [
+                  "admin",
+                  "simple_accounting",
+                  "self_only",
+                  "read_only",
+                  "workflow"
+                ]
               },
               "phone1": {
                 "type": "string",
@@ -29189,7 +31580,10 @@
                 "type": "string",
                 "description": "仕訳承認フロー（enable: 有効、 disable: 無効）",
                 "example": "disabled",
-                "enum": ["enable", "disable"]
+                "enum": [
+                  "enable",
+                  "disable"
+                ]
               },
               "fiscal_years": {
                 "type": "array",
@@ -29201,7 +31595,11 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["id", "name", "categories"],
+                  "required": [
+                    "id",
+                    "name",
+                    "categories"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -29237,7 +31635,11 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["code", "name", "name_ja"],
+                  "required": [
+                    "code",
+                    "name",
+                    "name_ja"
+                  ],
                   "properties": {
                     "code": {
                       "type": "integer",
@@ -29264,7 +31666,10 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["id", "name"],
+                  "required": [
+                    "id",
+                    "name"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -29298,7 +31703,10 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["id", "name"],
+                  "required": [
+                    "id",
+                    "name"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -29339,7 +31747,10 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["id", "name"],
+                  "required": [
+                    "id",
+                    "name"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -29390,7 +31801,10 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["id", "name"],
+                  "required": [
+                    "id",
+                    "name"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -29426,7 +31840,11 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["id", "name", "type"],
+                  "required": [
+                    "id",
+                    "name",
+                    "type"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -29445,7 +31863,11 @@
                       "type": "string",
                       "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)",
                       "example": "bank_account",
-                      "enum": ["bank_account", "credit_card", "wallet"]
+                      "enum": [
+                        "bank_account",
+                        "credit_card",
+                        "wallet"
+                      ]
                     }
                   }
                 }
@@ -29486,7 +31908,10 @@
           "errors": {
             "type": "array",
             "items": {
-              "required": ["messages", "type"],
+              "required": [
+                "messages",
+                "type"
+              ],
               "type": "object",
               "properties": {
                 "messages": {
@@ -29499,7 +31924,11 @@
                 "type": {
                   "type": "string",
                   "example": "validation",
-                  "enum": ["status", "validation", "error"]
+                  "enum": [
+                    "status",
+                    "validation",
+                    "error"
+                  ]
                 }
               }
             }
@@ -29516,7 +31945,10 @@
           "errors": {
             "type": "array",
             "items": {
-              "required": ["messages", "type"],
+              "required": [
+                "messages",
+                "type"
+              ],
               "type": "object",
               "properties": {
                 "messages": {
@@ -29529,7 +31961,11 @@
                 "type": {
                   "type": "string",
                   "example": "validation",
-                  "enum": ["status", "validation", "error"]
+                  "enum": [
+                    "status",
+                    "validation",
+                    "error"
+                  ]
                 }
               }
             }
@@ -29546,7 +31982,10 @@
           "errors": {
             "type": "array",
             "items": {
-              "required": ["messages", "type"],
+              "required": [
+                "messages",
+                "type"
+              ],
               "type": "object",
               "properties": {
                 "messages": {
@@ -29559,7 +31998,11 @@
                 "type": {
                   "type": "string",
                   "example": "validation",
-                  "enum": ["status", "validation", "error"]
+                  "enum": [
+                    "status",
+                    "validation",
+                    "error"
+                  ]
                 }
               }
             }
@@ -29568,14 +32011,21 @@
       },
       "tooManyRequestsError": {
         "type": "object",
-        "required": ["status_code", "meta"],
+        "required": [
+          "status_code",
+          "meta"
+        ],
         "properties": {
           "status_code": {
             "type": "integer",
             "example": 429
           },
           "meta": {
-            "required": ["limit", "remaining", "reset"],
+            "required": [
+              "limit",
+              "remaining",
+              "reset"
+            ],
             "type": "object",
             "properties": {
               "limit": {
@@ -29612,7 +32062,10 @@
           "errors": {
             "type": "array",
             "items": {
-              "required": ["messages", "type"],
+              "required": [
+                "messages",
+                "type"
+              ],
               "type": "object",
               "properties": {
                 "messages": {
@@ -29625,7 +32078,11 @@
                 "type": {
                   "type": "string",
                   "example": "status",
-                  "enum": ["status", "validation", "error"]
+                  "enum": [
+                    "status",
+                    "validation",
+                    "error"
+                  ]
                 }
               }
             }
@@ -29634,7 +32091,10 @@
       },
       "serviceUnavailableError": {
         "type": "object",
-        "required": ["status_code", "errors"],
+        "required": [
+          "status_code",
+          "errors"
+        ],
         "properties": {
           "status_code": {
             "type": "integer",
@@ -29643,7 +32103,10 @@
           "errors": {
             "type": "array",
             "items": {
-              "required": ["messages", "type"],
+              "required": [
+                "messages",
+                "type"
+              ],
               "type": "object",
               "properties": {
                 "messages": {
@@ -29656,7 +32119,10 @@
                 "type": {
                   "type": "string",
                   "example": "error",
-                  "enum": ["status", "error"]
+                  "enum": [
+                    "status",
+                    "error"
+                  ]
                 }
               }
             }
@@ -29664,14 +32130,23 @@
         }
       },
       "partnersResponse": {
-        "required": ["partners"],
+        "required": [
+          "partners"
+        ],
         "type": "object",
         "properties": {
           "partners": {
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["code", "company_id", "id", "name", "update_date", "available"],
+              "required": [
+                "code",
+                "company_id",
+                "id",
+                "name",
+                "update_date",
+                "available"
+              ],
               "properties": {
                 "id": {
                   "type": "integer",
@@ -29785,7 +32260,10 @@
                   "type": "string",
                   "description": "振込手数料負担（一括振込ファイル用）: (振込元(当方): payer, 振込先(先方): payee)",
                   "example": "payer",
-                  "enum": ["payer", "payee"]
+                  "enum": [
+                    "payer",
+                    "payee"
+                  ]
                 },
                 "qualified_invoice_issuer": {
                   "type": "boolean",
@@ -29837,7 +32315,11 @@
                       "type": "string",
                       "description": "請求書送付方法(email:メール、posting:郵送、email_and_posting:メールと郵送、null:設定しない)",
                       "example": "posting",
-                      "enum": ["email", "posting", "email_and_posting"],
+                      "enum": [
+                        "email",
+                        "posting",
+                        "email_and_posting"
+                      ],
                       "nullable": true
                     }
                   }
@@ -29885,7 +32367,13 @@
                       "type": "string",
                       "description": "口座種別(ordinary:普通、checking:当座、earmarked:納税準備預金、savings:貯蓄、other:その他)",
                       "example": "ordinary",
-                      "enum": ["ordinary", "checking", "earmarked", "savings", "other"],
+                      "enum": [
+                        "ordinary",
+                        "checking",
+                        "earmarked",
+                        "savings",
+                        "other"
+                      ],
                       "nullable": true
                     },
                     "account_number": {
@@ -29914,12 +32402,21 @@
         }
       },
       "partnerResponse": {
-        "required": ["partner"],
+        "required": [
+          "partner"
+        ],
         "type": "object",
         "properties": {
           "partner": {
             "type": "object",
-            "required": ["code", "company_id", "id", "name", "update_date", "available"],
+            "required": [
+              "code",
+              "company_id",
+              "id",
+              "name",
+              "update_date",
+              "available"
+            ],
             "properties": {
               "id": {
                 "type": "integer",
@@ -30033,7 +32530,10 @@
                 "type": "string",
                 "description": "振込手数料負担（一括振込ファイル用）: (振込元(当方): payer, 振込先(先方): payee)",
                 "example": "payer",
-                "enum": ["payer", "payee"]
+                "enum": [
+                  "payer",
+                  "payee"
+                ]
               },
               "qualified_invoice_issuer": {
                 "type": "boolean",
@@ -30085,7 +32585,11 @@
                     "type": "string",
                     "description": "請求書送付方法(email:メール、posting:郵送、email_and_posting:メールと郵送、null:設定しない)",
                     "example": "posting",
-                    "enum": ["email", "posting", "email_and_posting"],
+                    "enum": [
+                      "email",
+                      "posting",
+                      "email_and_posting"
+                    ],
                     "nullable": true
                   }
                 }
@@ -30133,7 +32637,13 @@
                     "type": "string",
                     "description": "口座種別(ordinary:普通、checking:当座、earmarked:納税準備預金、savings:貯蓄、other:その他)",
                     "example": "ordinary",
-                    "enum": ["ordinary", "checking", "earmarked", "savings", "other"],
+                    "enum": [
+                      "ordinary",
+                      "checking",
+                      "earmarked",
+                      "savings",
+                      "other"
+                    ],
                     "nullable": true
                   },
                   "account_number": {
@@ -30226,7 +32736,11 @@
       },
       "tax": {
         "type": "object",
-        "required": ["code", "name", "name_ja"],
+        "required": [
+          "code",
+          "name",
+          "name_ja"
+        ],
         "properties": {
           "code": {
             "type": "integer",
@@ -30250,7 +32764,9 @@
       },
       "taxResponse": {
         "type": "object",
-        "required": ["tax"],
+        "required": [
+          "tax"
+        ],
         "properties": {
           "tax": {
             "$ref": "#/components/schemas/tax"
@@ -30259,7 +32775,12 @@
       },
       "walletable": {
         "type": "object",
-        "required": ["bank_id", "id", "name", "type"],
+        "required": [
+          "bank_id",
+          "id",
+          "name",
+          "type"
+        ],
         "properties": {
           "id": {
             "type": "integer",
@@ -30284,9 +32805,13 @@
           },
           "type": {
             "type": "string",
-            "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)",
+            "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, その他の決済口座: wallet)",
             "example": "bank_account",
-            "enum": ["bank_account", "credit_card", "wallet"]
+            "enum": [
+              "bank_account",
+              "credit_card",
+              "wallet"
+            ]
           },
           "last_synced_at": {
             "type": "string",
@@ -30318,16 +32843,28 @@
             "format": "int64",
             "description": "登録残高",
             "example": 1340261
+          },
+          "update_date": {
+            "type": "string",
+            "description": "更新日(yyyy-mm-dd)",
+            "example": "2020-06-15"
           }
         }
       },
       "walletableCreateResponse": {
         "type": "object",
-        "required": ["walletable"],
+        "required": [
+          "walletable"
+        ],
         "properties": {
           "walletable": {
             "type": "object",
-            "required": ["bank_id", "id", "name", "type"],
+            "required": [
+              "bank_id",
+              "id",
+              "name",
+              "type"
+            ],
             "properties": {
               "id": {
                 "type": "integer",
@@ -30352,7 +32889,11 @@
                 "type": "string",
                 "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)",
                 "example": "bank_account",
-                "enum": ["bank_account", "credit_card", "wallet"]
+                "enum": [
+                  "bank_account",
+                  "credit_card",
+                  "wallet"
+                ]
               }
             }
           }
@@ -30419,13 +32960,20 @@
             "type": "string",
             "description": "入金／出金 (入金: income, 出金: expense)",
             "example": "income",
-            "enum": ["income", "expense"]
+            "enum": [
+              "income",
+              "expense"
+            ]
           },
           "walletable_type": {
             "type": "string",
             "description": "口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)",
             "example": "bank_account",
-            "enum": ["bank_account", "credit_card", "wallet"]
+            "enum": [
+              "bank_account",
+              "credit_card",
+              "wallet"
+            ]
           },
           "walletable_id": {
             "type": "integer",
@@ -30455,7 +33003,9 @@
       },
       "walletTxnResponse": {
         "type": "object",
-        "required": ["wallet_txn"],
+        "required": [
+          "wallet_txn"
+        ],
         "properties": {
           "wallet_txn": {
             "$ref": "#/components/schemas/wallet_txn"
@@ -30507,7 +33057,11 @@
             "type": "string",
             "description": "振替元口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)",
             "example": "credit_card",
-            "enum": ["bank_account", "wallet", "credit_card"],
+            "enum": [
+              "bank_account",
+              "wallet",
+              "credit_card"
+            ],
             "nullable": true
           },
           "from_walletable_id": {
@@ -30521,7 +33075,11 @@
             "type": "string",
             "description": "振替先口座区分 (銀行口座: bank_account, クレジットカード: credit_card, 現金: wallet)",
             "example": "bank_account",
-            "enum": ["bank_account", "wallet", "credit_card"],
+            "enum": [
+              "bank_account",
+              "wallet",
+              "credit_card"
+            ],
             "nullable": true
           },
           "to_walletable_id": {
@@ -30541,7 +33099,9 @@
       },
       "transferResponse": {
         "type": "object",
-        "required": ["transfer"],
+        "required": [
+          "transfer"
+        ],
         "properties": {
           "transfer": {
             "$ref": "#/components/schemas/transfer"
@@ -30585,7 +33145,10 @@
       },
       "user": {
         "type": "object",
-        "required": ["email", "id"],
+        "required": [
+          "email",
+          "id"
+        ],
         "properties": {
           "id": {
             "type": "integer",
@@ -30641,11 +33204,16 @@
       },
       "meResponse": {
         "type": "object",
-        "required": ["user"],
+        "required": [
+          "user"
+        ],
         "properties": {
           "user": {
             "type": "object",
-            "required": ["email", "id"],
+            "required": [
+              "email",
+              "id"
+            ],
             "properties": {
               "id": {
                 "type": "integer",
@@ -30693,7 +33261,12 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["display_name", "id", "role", "use_custom_role"],
+                  "required": [
+                    "display_name",
+                    "id",
+                    "role",
+                    "use_custom_role"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -30711,7 +33284,13 @@
                       "type": "string",
                       "description": "ユーザーの権限\n<ul>\n<li>admin: 管理者</li>\n<li>simple_accounting: 一般</li>\n<li>self_only: 取引登録のみ</li>\n<li>read_only: 閲覧のみ</li>\n<li>workflow: 申請・承認</li>\n</ul>",
                       "example": "admin",
-                      "enum": ["admin", "simple_accounting", "self_only", "read_only", "workflow"]
+                      "enum": [
+                        "admin",
+                        "simple_accounting",
+                        "self_only",
+                        "read_only",
+                        "workflow"
+                      ]
                     },
                     "use_custom_role": {
                       "type": "boolean",
@@ -30879,7 +33458,10 @@
           "allowed_target": {
             "type": "string",
             "description": "「自分のみ」がonになっている場合はself_only、offになっている場合はallになります。",
-            "enum": ["self_only", "all"]
+            "enum": [
+              "self_only",
+              "all"
+            ]
           }
         }
       },
@@ -30976,7 +33558,14 @@
       },
       "receipt": {
         "type": "object",
-        "required": ["created_at", "id", "mime_type", "origin", "status", "user"],
+        "required": [
+          "created_at",
+          "id",
+          "mime_type",
+          "origin",
+          "status",
+          "user"
+        ],
         "properties": {
           "id": {
             "type": "integer",
@@ -30989,7 +33578,11 @@
             "type": "string",
             "description": "ステータス(confirmed:確認済み、deleted:削除済み、ignored:無視)",
             "example": "confirmed",
-            "enum": ["confirmed", "deleted", "ignored"]
+            "enum": [
+              "confirmed",
+              "deleted",
+              "ignored"
+            ]
           },
           "description": {
             "type": "string",
@@ -31025,7 +33618,10 @@
           },
           "user": {
             "type": "object",
-            "required": ["email", "id"],
+            "required": [
+              "email",
+              "id"
+            ],
             "properties": {
               "id": {
                 "type": "integer",
@@ -31076,7 +33672,11 @@
           "qualified_invoice": {
             "type": "string",
             "description": "適格請求書等（qualified: 該当する、not_qualified: 該当しない、unselected: 未選択、null: OCR解析結果が保存されている時等）",
-            "enum": ["qualified", "not_qualified", "unselected"],
+            "enum": [
+              "qualified",
+              "not_qualified",
+              "unselected"
+            ],
             "example": "qualified",
             "nullable": true
           },
@@ -31092,7 +33692,11 @@
           "document_type": {
             "type": "string",
             "description": "書類の種類（receipt: 領収書、invoice: 請求書、other: その他、null: OCR解析結果が保存されている時等）",
-            "enum": ["receipt", "invoice", "other"],
+            "enum": [
+              "receipt",
+              "invoice",
+              "other"
+            ],
             "example": "receipt",
             "nullable": true
           }
@@ -31100,7 +33704,9 @@
       },
       "receiptResponse": {
         "type": "object",
-        "required": ["receipt"],
+        "required": [
+          "receipt"
+        ],
         "properties": {
           "receipt": {
             "$ref": "#/components/schemas/receipt"
@@ -31192,7 +33798,9 @@
       },
       "expenseApplicationsIndexResponse": {
         "type": "object",
-        "required": ["expense_applications"],
+        "required": [
+          "expense_applications"
+        ],
         "properties": {
           "expense_applications": {
             "type": "array",
@@ -31249,7 +33857,13 @@
                   "type": "string",
                   "description": "申請ステータス(draft:下書き, in_progress:申請中, approved:承認済, rejected:却下, feedback:差戻し)",
                   "example": "draft",
-                  "enum": ["draft", "in_progress", "approved", "rejected", "feedback"]
+                  "enum": [
+                    "draft",
+                    "in_progress",
+                    "approved",
+                    "rejected",
+                    "feedback"
+                  ]
                 },
                 "section_id": {
                   "type": "integer",
@@ -31274,7 +33888,9 @@
                   "description": "経費申請の申請行一覧（配列）",
                   "items": {
                     "type": "object",
-                    "required": ["id"],
+                    "required": [
+                      "id"
+                    ],
                     "properties": {
                       "id": {
                         "type": "integer",
@@ -31312,7 +33928,9 @@
                         "description": "明細行一覧（配列）",
                         "items": {
                           "type": "object",
-                          "required": ["id"],
+                          "required": [
+                            "id"
+                          ],
                           "properties": {
                             "id": {
                               "type": "integer",
@@ -31361,7 +33979,10 @@
                   "type": "string",
                   "description": "取引ステータス (申請ステータス:statusがapprovedで、取引が存在する時のみdeal_statusが表示されます settled:精算済み, unsettled:清算待ち)",
                   "example": "settled",
-                  "enum": ["settled", "unsettled"],
+                  "enum": [
+                    "settled",
+                    "unsettled"
+                  ],
                   "nullable": true
                 },
                 "applicant_id": {
@@ -31423,7 +34044,9 @@
       },
       "expenseApplicationResponse": {
         "type": "object",
-        "required": ["expense_application"],
+        "required": [
+          "expense_application"
+        ],
         "properties": {
           "expense_application": {
             "type": "object",
@@ -31485,7 +34108,13 @@
                 "type": "string",
                 "description": "申請ステータス(draft:下書き, in_progress:申請中, approved:承認済, rejected:却下, feedback:差戻し)",
                 "example": "draft",
-                "enum": ["draft", "in_progress", "approved", "rejected", "feedback"]
+                "enum": [
+                  "draft",
+                  "in_progress",
+                  "approved",
+                  "rejected",
+                  "feedback"
+                ]
               },
               "section_id": {
                 "type": "integer",
@@ -31510,7 +34139,9 @@
                 "description": "経費申請の申請行一覧（配列）",
                 "items": {
                   "type": "object",
-                  "required": ["id"],
+                  "required": [
+                    "id"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -31548,7 +34179,9 @@
                       "description": "明細行一覧（配列）",
                       "items": {
                         "type": "object",
-                        "required": ["id"],
+                        "required": [
+                          "id"
+                        ],
                         "properties": {
                           "id": {
                             "type": "integer",
@@ -31597,7 +34230,10 @@
                 "type": "string",
                 "description": "取引ステータス (申請ステータス:statusがapprovedで、取引が存在する時のみdeal_statusが表示されます settled:精算済み, unsettled:清算待ち)",
                 "example": "settled",
-                "enum": ["settled", "unsettled"],
+                "enum": [
+                  "settled",
+                  "unsettled"
+                ],
                 "nullable": true
               },
               "applicant_id": {
@@ -31612,7 +34248,13 @@
                 "description": "承認者（配列）\n  承認ステップのresource_typeがunspecified (指定なし)の場合はapproversはレスポンスに含まれません。\n  しかし、resource_typeがunspecifiedの承認ステップにおいて誰かが承認・却下・差し戻しのいずれかのアクションを取った後は、\n  approversはレスポンスに含まれるようになります。\n  その場合approversにはアクションを行ったステップのIDとアクションを行ったユーザーのIDが含まれます。",
                 "items": {
                   "type": "object",
-                  "required": ["step_id", "user_id", "status", "is_force_action", "resource_type"],
+                  "required": [
+                    "step_id",
+                    "user_id",
+                    "status",
+                    "is_force_action",
+                    "resource_type"
+                  ],
                   "properties": {
                     "step_id": {
                       "type": "integer",
@@ -31633,7 +34275,12 @@
                       "type": "string",
                       "description": "承認者の承認状態\n* `initial` - 初期状態\n* `approved` - 承認済\n* `rejected` - 却下\n* `feedback` - 差戻し",
                       "example": "initial",
-                      "enum": ["initial", "approved", "rejected", "feedback"]
+                      "enum": [
+                        "initial",
+                        "approved",
+                        "rejected",
+                        "feedback"
+                      ]
                     },
                     "is_force_action": {
                       "type": "boolean",
@@ -31674,7 +34321,11 @@
                 "description": "経費申請のコメント一覧（配列）",
                 "items": {
                   "type": "object",
-                  "required": ["comment", "user_id", "posted_at"],
+                  "required": [
+                    "comment",
+                    "user_id",
+                    "posted_at"
+                  ],
                   "properties": {
                     "comment": {
                       "type": "string",
@@ -31701,12 +34352,23 @@
                 "description": "経費申請の承認履歴（配列）",
                 "items": {
                   "type": "object",
-                  "required": ["action", "user_id", "updated_at"],
+                  "required": [
+                    "action",
+                    "user_id",
+                    "updated_at"
+                  ],
                   "properties": {
                     "action": {
                       "type": "string",
                       "description": "操作(apply: 申請, approve: 承認, force_approve: 特権承認, cancel: 取消, reject: 却下, feedback: 差戻し)",
-                      "enum": ["apply", "approve", "force_approve", "cancel", "reject", "feedback"],
+                      "enum": [
+                        "apply",
+                        "approve",
+                        "force_approve",
+                        "cancel",
+                        "reject",
+                        "feedback"
+                      ],
                       "example": "approve"
                     },
                     "user_id": {
@@ -31778,7 +34440,12 @@
       },
       "expense_application_line_template": {
         "type": "object",
-        "required": ["account_item_name", "id", "name", "tax_name"],
+        "required": [
+          "account_item_name",
+          "id",
+          "name",
+          "tax_name"
+        ],
         "properties": {
           "id": {
             "type": "integer",
@@ -31836,7 +34503,9 @@
       },
       "expenseApplicationLineTemplateResponse": {
         "type": "object",
-        "required": ["expense_application_line_template"],
+        "required": [
+          "expense_application_line_template"
+        ],
         "properties": {
           "expense_application_line_template": {
             "$ref": "#/components/schemas/expense_application_line_template"
@@ -31845,7 +34514,9 @@
       },
       "paymentRequestResponse": {
         "type": "object",
-        "required": ["payment_request"],
+        "required": [
+          "payment_request"
+        ],
         "properties": {
           "payment_request": {
             "type": "object",
@@ -31925,7 +34596,13 @@
                 "type": "string",
                 "description": "申請ステータス(draft:下書き, in_progress:申請中, approved:承認済, rejected:却下, feedback:差戻し)",
                 "example": "draft",
-                "enum": ["draft", "in_progress", "approved", "rejected", "feedback"]
+                "enum": [
+                  "draft",
+                  "in_progress",
+                  "approved",
+                  "rejected",
+                  "feedback"
+                ]
               },
               "payment_request_lines": {
                 "type": "array",
@@ -31955,7 +34632,11 @@
                       "type": "string",
                       "description": "'行の種類 (deal_line: 支払依頼の通常取引行, negative_line: 支払依頼の控除・マイナス行, withholding_tax: 源泉所得税行)'\n",
                       "example": "deal_line",
-                      "enum": ["deal_line", "negative_line", "withholding_tax"]
+                      "enum": [
+                        "deal_line",
+                        "negative_line",
+                        "withholding_tax"
+                      ]
                     },
                     "description": {
                       "type": "string",
@@ -32006,7 +34687,11 @@
                     "tag_ids": {
                       "type": "array",
                       "description": "メモタグID",
-                      "example": [1, 2, 3],
+                      "example": [
+                        1,
+                        2,
+                        3
+                      ],
                       "items": {
                         "type": "integer",
                         "format": "int64",
@@ -32052,7 +34737,10 @@
                 "type": "string",
                 "description": "取引ステータス (申請ステータス:statusがapprovedで、取引が存在する時のみdeal_statusが表示されます settled:支払済み, unsettled:支払待ち)",
                 "example": "settled",
-                "enum": ["settled", "unsettled"],
+                "enum": [
+                  "settled",
+                  "unsettled"
+                ],
                 "nullable": true
               },
               "applicant_id": {
@@ -32067,7 +34755,13 @@
                 "description": "承認者（配列）\n  承認ステップのresource_typeがunspecified (指定なし)の場合はapproversはレスポンスに含まれません。\n  しかし、resource_typeがunspecifiedの承認ステップにおいて誰かが承認・却下・差し戻しのいずれかのアクションを取った後は、\n  approversはレスポンスに含まれるようになります。\n  その場合approversにはアクションを行ったステップのIDとアクションを行ったユーザーのIDが含まれます。",
                 "items": {
                   "type": "object",
-                  "required": ["step_id", "user_id", "status", "is_force_action", "resource_type"],
+                  "required": [
+                    "step_id",
+                    "user_id",
+                    "status",
+                    "is_force_action",
+                    "resource_type"
+                  ],
                   "properties": {
                     "step_id": {
                       "type": "integer",
@@ -32088,7 +34782,12 @@
                       "type": "string",
                       "description": "承認者の承認状態\n* `initial` - 初期状態\n* `approved` - 承認済\n* `rejected` - 却下\n* `feedback` - 差戻し",
                       "example": "initial",
-                      "enum": ["initial", "approved", "rejected", "feedback"]
+                      "enum": [
+                        "initial",
+                        "approved",
+                        "rejected",
+                        "feedback"
+                      ]
                     },
                     "is_force_action": {
                       "type": "boolean",
@@ -32129,7 +34828,11 @@
                 "description": "支払依頼のコメント一覧（配列）",
                 "items": {
                   "type": "object",
-                  "required": ["comment", "user_id", "posted_at"],
+                  "required": [
+                    "comment",
+                    "user_id",
+                    "posted_at"
+                  ],
                   "properties": {
                     "comment": {
                       "type": "string",
@@ -32156,12 +34859,23 @@
                 "description": "支払依頼の承認履歴（配列）",
                 "items": {
                   "type": "object",
-                  "required": ["action", "user_id", "updated_at"],
+                  "required": [
+                    "action",
+                    "user_id",
+                    "updated_at"
+                  ],
                   "properties": {
                     "action": {
                       "type": "string",
                       "description": "操作(apply: 申請, approve: 承認, force_approve: 特権承認, cancel: 取消, reject: 却下, feedback: 差戻し)",
-                      "enum": ["apply", "approve", "force_approve", "cancel", "reject", "feedback"],
+                      "enum": [
+                        "apply",
+                        "approve",
+                        "force_approve",
+                        "cancel",
+                        "reject",
+                        "feedback"
+                      ],
                       "example": "approve"
                     },
                     "user_id": {
@@ -32203,7 +34917,11 @@
               "receipt_ids": {
                 "type": "array",
                 "description": "ファイルボックス（証憑ファイル）ID",
-                "example": [1, 2, 3],
+                "example": [
+                  1,
+                  2,
+                  3
+                ],
                 "items": {
                   "type": "integer",
                   "format": "int64",
@@ -32287,7 +35005,13 @@
                 "type": "string",
                 "description": "口座種別(ordinary:普通、checking:当座、earmarked:納税準備預金、savings:貯蓄、other:その他)",
                 "example": "ordinary",
-                "enum": ["ordinary", "checking", "earmarked", "savings", "other"]
+                "enum": [
+                  "ordinary",
+                  "checking",
+                  "earmarked",
+                  "savings",
+                  "other"
+                ]
               },
               "account_number": {
                 "type": "string",
@@ -32302,7 +35026,11 @@
               "qualified_invoice_status": {
                 "type": "string",
                 "description": "適格請求書発行事業者（qualified: 該当する、not_qualified: 該当しない、unspecified: 未選択）\n- 支払依頼をインボイス要件をみたす申請として扱うかどうかを表します。\n",
-                "enum": ["qualified", "not_qualified", "unspecified"],
+                "enum": [
+                  "qualified",
+                  "not_qualified",
+                  "unspecified"
+                ],
                 "example": "qualified"
               }
             }
@@ -32311,7 +35039,9 @@
       },
       "paymentRequestsIndexResponse": {
         "type": "object",
-        "required": ["payment_requests"],
+        "required": [
+          "payment_requests"
+        ],
         "properties": {
           "payment_requests": {
             "type": "array",
@@ -32372,7 +35102,13 @@
                   "type": "string",
                   "description": "申請ステータス(draft:下書き, in_progress:申請中, approved:承認済, rejected:却下, feedback:差戻し)",
                   "example": "draft",
-                  "enum": ["draft", "in_progress", "approved", "rejected", "feedback"]
+                  "enum": [
+                    "draft",
+                    "in_progress",
+                    "approved",
+                    "rejected",
+                    "feedback"
+                  ]
                 },
                 "deal_id": {
                   "type": "integer",
@@ -32386,7 +35122,10 @@
                   "type": "string",
                   "description": "取引ステータス (申請ステータス:statusがapprovedで、取引が存在する時のみdeal_statusが表示されます settled:支払済み, unsettled:支払待ち)",
                   "example": "settled",
-                  "enum": ["settled", "unsettled"],
+                  "enum": [
+                    "settled",
+                    "unsettled"
+                  ],
                   "nullable": true
                 },
                 "applicant_id": {
@@ -32428,7 +35167,12 @@
                         "type": "string",
                         "description": "承認者の承認状態\n* `initial` - 初期状態\n* `approved` - 承認済\n* `rejected` - 却下\n* `feedback` - 差戻し",
                         "example": "initial",
-                        "enum": ["initial", "approved", "rejected", "feedback"]
+                        "enum": [
+                          "initial",
+                          "approved",
+                          "rejected",
+                          "feedback"
+                        ]
                       },
                       "is_force_action": {
                         "type": "boolean",
@@ -32524,13 +35268,20 @@
                 "qualified_invoice_status": {
                   "type": "string",
                   "description": "適格請求書発行事業者（qualified: 該当する、not_qualified: 該当しない、unspecified: 未選択）\n- 支払依頼をインボイス要件をみたす申請として扱うかどうかを表します。\n",
-                  "enum": ["qualified", "not_qualified", "unspecified"],
+                  "enum": [
+                    "qualified",
+                    "not_qualified",
+                    "unspecified"
+                  ],
                   "example": "qualified"
                 },
                 "input_mode": {
                   "type": "string",
                   "description": "内税/外税（inclusive: 内税、exclusive: 外税）\n外税の支払依頼は他のエンドポイントで利用できないため、Web 画面からご確認ください。",
-                  "enum": ["inclusive", "exclusive"],
+                  "enum": [
+                    "inclusive",
+                    "exclusive"
+                  ],
                   "example": "inclusive"
                 }
               }
@@ -32540,7 +35291,12 @@
       },
       "paymentRequestActionCreateParams": {
         "type": "object",
-        "required": ["company_id", "approval_action", "target_step_id", "target_round"],
+        "required": [
+          "company_id",
+          "approval_action",
+          "target_step_id",
+          "target_round"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -32553,7 +35309,14 @@
             "type": "string",
             "description": "操作(approve: 承認する、force_approve: 特権承認する、cancel: 申請を取り消す、reject: 却下する、feedback: 申請者へ差し戻す、force_feedback: 承認済み・却下済みを取り消す)",
             "example": "approve",
-            "enum": ["approve", "force_approve", "cancel", "reject", "feedback", "force_feedback"]
+            "enum": [
+              "approve",
+              "force_approve",
+              "cancel",
+              "reject",
+              "feedback",
+              "force_feedback"
+            ]
           },
           "target_step_id": {
             "type": "integer",
@@ -32582,7 +35345,13 @@
       },
       "approvalRequestCreateParams": {
         "type": "object",
-        "required": ["company_id", "approval_flow_route_id", "form_id", "request_items", "draft"],
+        "required": [
+          "company_id",
+          "approval_flow_route_id",
+          "form_id",
+          "request_items",
+          "draft"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -32668,7 +35437,12 @@
       },
       "approvalRequestUpdateParams": {
         "type": "object",
-        "required": ["company_id", "approval_flow_route_id", "request_items", "draft"],
+        "required": [
+          "company_id",
+          "approval_flow_route_id",
+          "request_items",
+          "draft"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -32740,7 +35514,12 @@
       },
       "approvalRequestActionCreateParams": {
         "type": "object",
-        "required": ["company_id", "approval_action", "target_step_id", "target_round"],
+        "required": [
+          "company_id",
+          "approval_action",
+          "target_step_id",
+          "target_round"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -32753,7 +35532,14 @@
             "type": "string",
             "description": "操作(approve: 承認する、force_approve: 特権承認する、cancel: 申請を取り消す、reject: 却下する、feedback: 申請者へ差し戻す、force_feedback: 承認済み・却下済みを取り消す)",
             "example": "approve",
-            "enum": ["approve", "force_approve", "cancel", "reject", "feedback", "force_feedback"]
+            "enum": [
+              "approve",
+              "force_approve",
+              "cancel",
+              "reject",
+              "feedback",
+              "force_feedback"
+            ]
           },
           "target_step_id": {
             "type": "integer",
@@ -32781,7 +35567,12 @@
       },
       "renewCreateParams": {
         "type": "object",
-        "required": ["company_id", "details", "renew_target_id", "update_date"],
+        "required": [
+          "company_id",
+          "details",
+          "renew_target_id",
+          "update_date"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -32807,7 +35598,11 @@
             "description": "+更新の明細行",
             "items": {
               "type": "object",
-              "required": ["account_item_id", "amount", "tax_code"],
+              "required": [
+                "account_item_id",
+                "amount",
+                "tax_code"
+              ],
               "properties": {
                 "account_item_id": {
                   "type": "integer",
@@ -32857,7 +35652,11 @@
                 "tag_ids": {
                   "type": "array",
                   "description": "メモタグID",
-                  "example": [1, 2, 3],
+                  "example": [
+                    1,
+                    2,
+                    3
+                  ],
                   "items": {
                     "type": "integer",
                     "format": "int64",
@@ -32897,7 +35696,11 @@
       },
       "renewUpdateParams": {
         "type": "object",
-        "required": ["company_id", "details", "update_date"],
+        "required": [
+          "company_id",
+          "details",
+          "update_date"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -32916,7 +35719,11 @@
             "description": "+更新の明細行",
             "items": {
               "type": "object",
-              "required": ["account_item_id", "amount", "tax_code"],
+              "required": [
+                "account_item_id",
+                "amount",
+                "tax_code"
+              ],
               "properties": {
                 "account_item_id": {
                   "type": "integer",
@@ -32966,7 +35773,11 @@
                 "tag_ids": {
                   "type": "array",
                   "description": "メモタグID",
-                  "example": [1, 2, 3],
+                  "example": [
+                    1,
+                    2,
+                    3
+                  ],
                   "items": {
                     "type": "integer",
                     "format": "int64",
@@ -33006,7 +35817,12 @@
       },
       "expenseApplicationLineTemplateParams": {
         "type": "object",
-        "required": ["company_id", "name", "account_item_id", "tax_code"],
+        "required": [
+          "company_id",
+          "name",
+          "account_item_id",
+          "tax_code"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -33064,7 +35880,9 @@
       },
       "approvalRequestsIndexResponse": {
         "type": "object",
-        "required": ["approval_requests"],
+        "required": [
+          "approval_requests"
+        ],
         "properties": {
           "approval_requests": {
             "type": "array",
@@ -33127,14 +35945,24 @@
                   "type": "string",
                   "description": "申請ステータス(draft:下書き, in_progress:申請中, approved:承認済, rejected:却下, feedback:差戻し)",
                   "example": "draft",
-                  "enum": ["draft", "in_progress", "approved", "rejected", "feedback"]
+                  "enum": [
+                    "draft",
+                    "in_progress",
+                    "approved",
+                    "rejected",
+                    "feedback"
+                  ]
                 },
                 "request_items": {
                   "type": "array",
                   "description": "各種申請の項目一覧（配列）",
                   "items": {
                     "type": "object",
-                    "required": ["id", "type", "value"],
+                    "required": [
+                      "id",
+                      "type",
+                      "value"
+                    ],
                     "properties": {
                       "id": {
                         "type": "integer",
@@ -33210,7 +36038,10 @@
                   "type": "string",
                   "description": "取引ステータス (申請ステータス:statusがapprovedで、取引が存在する時のみdeal_statusが表示されます settled:決済済み, unsettled:未決済)",
                   "example": "settled",
-                  "enum": ["settled", "unsettled"],
+                  "enum": [
+                    "settled",
+                    "unsettled"
+                  ],
                   "nullable": true
                 }
               }
@@ -33220,7 +36051,9 @@
       },
       "approvalRequestResponse": {
         "type": "object",
-        "required": ["approval_request"],
+        "required": [
+          "approval_request"
+        ],
         "properties": {
           "approval_request": {
             "type": "object",
@@ -33282,7 +36115,13 @@
                 "description": "承認者（配列）\n  承認ステップのresource_typeがunspecified (指定なし)の場合はapproversはレスポンスに含まれません。\n  しかし、resource_typeがunspecifiedの承認ステップにおいて誰かが承認・却下・差し戻しのいずれかのアクションを取った後は、\n  approversはレスポンスに含まれるようになります。\n  その場合approversにはアクションを行ったステップのIDとアクションを行ったユーザーのIDが含まれます。",
                 "items": {
                   "type": "object",
-                  "required": ["step_id", "user_id", "status", "is_force_action", "resource_type"],
+                  "required": [
+                    "step_id",
+                    "user_id",
+                    "status",
+                    "is_force_action",
+                    "resource_type"
+                  ],
                   "properties": {
                     "step_id": {
                       "type": "integer",
@@ -33303,7 +36142,12 @@
                       "type": "string",
                       "description": "承認者の承認状態\n* `initial` - 初期状態\n* `approved` - 承認済\n* `rejected` - 却下\n* `feedback` - 差戻し",
                       "example": "initial",
-                      "enum": ["initial", "approved", "rejected", "feedback"]
+                      "enum": [
+                        "initial",
+                        "approved",
+                        "rejected",
+                        "feedback"
+                      ]
                     },
                     "is_force_action": {
                       "type": "boolean",
@@ -33336,14 +36180,24 @@
                 "type": "string",
                 "description": "申請ステータス(draft:下書き, in_progress:申請中, approved:承認済, rejected:却下, feedback:差戻し)",
                 "example": "draft",
-                "enum": ["draft", "in_progress", "approved", "rejected", "feedback"]
+                "enum": [
+                  "draft",
+                  "in_progress",
+                  "approved",
+                  "rejected",
+                  "feedback"
+                ]
               },
               "request_items": {
                 "type": "array",
                 "description": "各種申請の項目一覧（配列）",
                 "items": {
                   "type": "object",
-                  "required": ["id", "type", "value"],
+                  "required": [
+                    "id",
+                    "type",
+                    "value"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -33396,7 +36250,11 @@
                 "description": "各種申請のコメント一覧（配列）",
                 "items": {
                   "type": "object",
-                  "required": ["comment", "user_id", "posted_at"],
+                  "required": [
+                    "comment",
+                    "user_id",
+                    "posted_at"
+                  ],
                   "properties": {
                     "comment": {
                       "type": "string",
@@ -33423,12 +36281,23 @@
                 "description": "各種申請の承認履歴（配列）",
                 "items": {
                   "type": "object",
-                  "required": ["action", "user_id", "updated_at"],
+                  "required": [
+                    "action",
+                    "user_id",
+                    "updated_at"
+                  ],
                   "properties": {
                     "action": {
                       "type": "string",
                       "description": "操作(apply: 申請, approve: 承認, force_approve: 特権承認, cancel: 取消, reject: 却下, feedback: 差戻し)",
-                      "enum": ["apply", "approve", "force_approve", "cancel", "reject", "feedback"],
+                      "enum": [
+                        "apply",
+                        "approve",
+                        "force_approve",
+                        "cancel",
+                        "reject",
+                        "feedback"
+                      ],
                       "example": "approve"
                     },
                     "user_id": {
@@ -33464,14 +36333,18 @@
               },
               "approval_request_form": {
                 "type": "object",
-                "required": ["parts"],
+                "required": [
+                  "parts"
+                ],
                 "properties": {
                   "parts": {
                     "type": "array",
                     "description": "申請フォームの項目",
                     "items": {
                       "type": "object",
-                      "required": ["id"],
+                      "required": [
+                        "id"
+                      ],
                       "properties": {
                         "id": {
                           "type": "integer",
@@ -33527,7 +36400,10 @@
                           "description": "選択項目",
                           "items": {
                             "type": "object",
-                            "required": ["name", "order"],
+                            "required": [
+                              "name",
+                              "order"
+                            ],
                             "properties": {
                               "name": {
                                 "type": "string",
@@ -33589,7 +36465,10 @@
                 "type": "string",
                 "description": "取引ステータス (申請ステータス:statusがapprovedで、取引が存在する時のみdeal_statusが表示されます settled:決済済み, unsettled:未決済)",
                 "example": "settled",
-                "enum": ["settled", "unsettled"],
+                "enum": [
+                  "settled",
+                  "unsettled"
+                ],
                 "nullable": true
               }
             }
@@ -33598,7 +36477,9 @@
       },
       "approvalRequestFormIndexResponse": {
         "type": "object",
-        "required": ["approval_request_forms"],
+        "required": [
+          "approval_request_forms"
+        ],
         "properties": {
           "approval_request_forms": {
             "type": "array",
@@ -33643,7 +36524,10 @@
                   "type": "string",
                   "description": "ステータス(draft: 申請で使用しない、active: 申請で使用する)",
                   "example": "active",
-                  "enum": ["draft", "active"]
+                  "enum": [
+                    "draft",
+                    "active"
+                  ]
                 },
                 "created_date": {
                   "type": "string",
@@ -33674,7 +36558,9 @@
       },
       "approvalRequestFormResponse": {
         "type": "object",
-        "required": ["approval_request_form"],
+        "required": [
+          "approval_request_form"
+        ],
         "properties": {
           "approval_request_form": {
             "type": "object",
@@ -33717,7 +36603,10 @@
                 "type": "string",
                 "description": "ステータス(draft: 申請で使用しない、active: 申請で使用する)",
                 "example": "active",
-                "enum": ["draft", "active"]
+                "enum": [
+                  "draft",
+                  "active"
+                ]
               },
               "created_date": {
                 "type": "string",
@@ -33738,7 +36627,9 @@
                 "description": "申請フォームの項目",
                 "items": {
                   "type": "object",
-                  "required": ["id"],
+                  "required": [
+                    "id"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -33794,7 +36685,10 @@
                       "description": "選択項目",
                       "items": {
                         "type": "object",
-                        "required": ["name", "order"],
+                        "required": [
+                          "name",
+                          "order"
+                        ],
                         "properties": {
                           "name": {
                             "type": "string",
@@ -33848,13 +36742,18 @@
       },
       "approvalFlowRoutesIndexResponse": {
         "type": "object",
-        "required": ["approval_flow_routes"],
+        "required": [
+          "approval_flow_routes"
+        ],
         "properties": {
           "approval_flow_routes": {
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["id", "default_route"],
+              "required": [
+                "id",
+                "default_route"
+              ],
               "properties": {
                 "id": {
                   "type": "integer",
@@ -33931,11 +36830,16 @@
       },
       "approvalFlowRouteResponse": {
         "type": "object",
-        "required": ["approval_flow_route"],
+        "required": [
+          "approval_flow_route"
+        ],
         "properties": {
           "approval_flow_route": {
             "type": "object",
-            "required": ["id", "request_form_ids"],
+            "required": [
+              "id",
+              "request_form_ids"
+            ],
             "properties": {
               "id": {
                 "type": "integer",
@@ -34005,7 +36909,11 @@
                 "description": "承認ステップ（配列）",
                 "items": {
                   "type": "object",
-                  "required": ["id", "next_step_id", "resource_type"],
+                  "required": [
+                    "id",
+                    "next_step_id",
+                    "resource_type"
+                  ],
                   "properties": {
                     "id": {
                       "type": "integer",
@@ -34038,7 +36946,7 @@
                     },
                     "user_ids": {
                       "type": "array",
-                      "description": "承認者のユーザーID (配列)",
+                      "description": "承認者のユーザーID (配列)。承認ステップのresource_typeが部門指定、役職指定等の場合は空の配列になります。",
                       "items": {
                         "type": "integer",
                         "format": "int64",
@@ -34056,7 +36964,13 @@
       },
       "segment_tag": {
         "type": "object",
-        "required": ["description", "id", "name", "shortcut1", "shortcut2"],
+        "required": [
+          "description",
+          "id",
+          "name",
+          "shortcut1",
+          "shortcut2"
+        ],
         "properties": {
           "id": {
             "type": "integer",
@@ -34097,12 +37011,19 @@
             "example": "code001",
             "pattern": "^[0-9a-zA-Z_-]+$",
             "nullable": true
+          },
+          "update_date": {
+            "type": "string",
+            "description": "更新日(yyyy-mm-dd)",
+            "example": "2020-06-15"
           }
         }
       },
       "segmentTagResponse": {
         "type": "object",
-        "required": ["segment_tag"],
+        "required": [
+          "segment_tag"
+        ],
         "properties": {
           "segment_tag": {
             "$ref": "#/components/schemas/segment_tag"
@@ -34111,7 +37032,10 @@
       },
       "segmentTagParams": {
         "type": "object",
-        "required": ["company_id", "name"],
+        "required": [
+          "company_id",
+          "name"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -34121,9 +37045,9 @@
             "example": 1
           },
           "name": {
-            "maxLength": 30,
+            "maxLength": 100,
             "type": "string",
-            "description": "セグメントタグ名 (30文字以内)",
+            "description": "セグメントタグ名 (100文字以内)",
             "example": "プロジェクトA"
           },
           "description": {
@@ -34155,7 +37079,9 @@
       },
       "invoiceIndexResponse": {
         "type": "object",
-        "required": ["invoices"],
+        "required": [
+          "invoices"
+        ],
         "properties": {
           "invoices": {
             "type": "array",
@@ -34273,7 +37199,11 @@
                 "payment_status": {
                   "type": "string",
                   "description": "入金ステータス  (unsettled: 入金待ち, settled: 入金済み)",
-                  "enum": ["", "unsettled", "settled"]
+                  "enum": [
+                    "",
+                    "unsettled",
+                    "settled"
+                  ]
                 },
                 "payment_date": {
                   "type": "string",
@@ -34426,7 +37356,11 @@
                   "type": "string",
                   "description": "支払方法 (振込: transfer, 引き落とし: direct_debit)",
                   "example": "transfer",
-                  "enum": ["", "transfer", "direct_debit"]
+                  "enum": [
+                    "",
+                    "transfer",
+                    "direct_debit"
+                  ]
                 },
                 "payment_bank_info": {
                   "type": "string",
@@ -34465,7 +37399,11 @@
                   "type": "string",
                   "description": "請求書の消費税計算方法(inclusive: 内税, exclusive: 外税)",
                   "example": "exclusive",
-                  "enum": ["", "inclusive", "exclusive"]
+                  "enum": [
+                    "",
+                    "inclusive",
+                    "exclusive"
+                  ]
                 },
                 "deal_id": {
                   "type": "integer",
@@ -34521,7 +37459,11 @@
                         "type": "string",
                         "description": "行の種類",
                         "example": "normal",
-                        "enum": ["normal", "discount", "text"]
+                        "enum": [
+                          "normal",
+                          "discount",
+                          "text"
+                        ]
                       },
                       "qty": {
                         "type": "number",
@@ -34680,7 +37622,12 @@
                 },
                 "total_amount_per_vat_rate": {
                   "type": "object",
-                  "required": ["reduced_vat_8", "vat_10", "vat_5", "vat_8"],
+                  "required": [
+                    "reduced_vat_8",
+                    "vat_10",
+                    "vat_5",
+                    "vat_8"
+                  ],
                   "properties": {
                     "vat_5": {
                       "type": "integer",
@@ -34719,7 +37666,9 @@
       },
       "invoiceResponse": {
         "type": "object",
-        "required": ["invoice"],
+        "required": [
+          "invoice"
+        ],
         "properties": {
           "invoice": {
             "type": "object",
@@ -34834,7 +37783,11 @@
               "payment_status": {
                 "type": "string",
                 "description": "入金ステータス  (unsettled: 入金待ち, settled: 入金済み)",
-                "enum": ["", "unsettled", "settled"]
+                "enum": [
+                  "",
+                  "unsettled",
+                  "settled"
+                ]
               },
               "payment_date": {
                 "type": "string",
@@ -34987,7 +37940,11 @@
                 "type": "string",
                 "description": "支払方法 (振込: transfer, 引き落とし: direct_debit)",
                 "example": "transfer",
-                "enum": ["", "transfer", "direct_debit"]
+                "enum": [
+                  "",
+                  "transfer",
+                  "direct_debit"
+                ]
               },
               "payment_bank_info": {
                 "type": "string",
@@ -35026,7 +37983,11 @@
                 "type": "string",
                 "description": "請求書の消費税計算方法(inclusive: 内税, exclusive: 外税)",
                 "example": "exclusive",
-                "enum": ["", "inclusive", "exclusive"]
+                "enum": [
+                  "",
+                  "inclusive",
+                  "exclusive"
+                ]
               },
               "deal_id": {
                 "type": "integer",
@@ -35083,7 +38044,11 @@
                       "type": "string",
                       "description": "行の種類",
                       "example": "normal",
-                      "enum": ["normal", "discount", "text"]
+                      "enum": [
+                        "normal",
+                        "discount",
+                        "text"
+                      ]
                     },
                     "qty": {
                       "type": "number",
@@ -35242,7 +38207,12 @@
               },
               "total_amount_per_vat_rate": {
                 "type": "object",
-                "required": ["reduced_vat_8", "vat_10", "vat_5", "vat_8"],
+                "required": [
+                  "reduced_vat_8",
+                  "vat_10",
+                  "vat_5",
+                  "vat_8"
+                ],
                 "properties": {
                   "vat_5": {
                     "type": "integer",
@@ -35291,7 +38261,11 @@
       },
       "invoiceCreateParams": {
         "type": "object",
-        "required": ["company_id", "partner_display_name", "partner_title"],
+        "required": [
+          "company_id",
+          "partner_display_name",
+          "partner_title"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -35347,7 +38321,12 @@
           "invoice_status": {
             "type": "string",
             "description": "請求書ステータス<br>\n<ul>\n  <li>draft: 下書き (デフォルト)</li>\n  <li>(廃止予定) issue: 発行 (送付待ち (unsubmitted) と同じです。)</li>\n  <li>unsubmitted: 送付待ち</li>\n  <li>submitted: 送付済み</li>\n</ul>\nissue, unsubmitted, submitted は請求書承認ワークフローを利用している場合は指定できません。\n",
-            "enum": ["draft", "issue", "unsubmitted", "submitted"]
+            "enum": [
+              "draft",
+              "issue",
+              "unsubmitted",
+              "submitted"
+            ]
           },
           "partner_display_name": {
             "type": "string",
@@ -35430,7 +38409,10 @@
             "type": "string",
             "description": "支払方法 (振込: transfer, 引き落とし: direct_debit)",
             "example": "transfer",
-            "enum": ["transfer", "direct_debit"]
+            "enum": [
+              "transfer",
+              "direct_debit"
+            ]
           },
           "payment_bank_info": {
             "type": "string",
@@ -35441,7 +38423,10 @@
             "type": "string",
             "description": "振込専用口座の利用(利用しない: not_use(デフォルト), 利用する: use)",
             "example": "use",
-            "enum": ["not_use", "use"]
+            "enum": [
+              "not_use",
+              "use"
+            ]
           },
           "message": {
             "type": "string",
@@ -35472,13 +38457,19 @@
             "type": "string",
             "description": "請求書の消費税計算方法(inclusive: 内税表示, exclusive: 外税表示 (デフォルト))",
             "example": "exclusive",
-            "enum": ["inclusive", "exclusive"]
+            "enum": [
+              "inclusive",
+              "exclusive"
+            ]
           },
           "invoice_contents": {
             "type": "array",
             "description": "請求内容",
             "items": {
-              "required": ["order", "type"],
+              "required": [
+                "order",
+                "type"
+              ],
               "type": "object",
               "properties": {
                 "order": {
@@ -35493,7 +38484,11 @@
                   "type": "string",
                   "description": "行の種類\n<ul>\n<li>normal、discountを指定する場合、account_item_id,tax_codeとunit_priceが必須となります。</li>\n<li>normalを指定した場合、qtyが必須となります。</li>\n</ul>",
                   "example": "normal",
-                  "enum": ["normal", "discount", "text"]
+                  "enum": [
+                    "normal",
+                    "discount",
+                    "text"
+                  ]
                 },
                 "qty": {
                   "type": "number",
@@ -35593,7 +38588,11 @@
       },
       "invoiceUpdateParams": {
         "type": "object",
-        "required": ["company_id", "partner_display_name", "partner_title"],
+        "required": [
+          "company_id",
+          "partner_display_name",
+          "partner_title"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -35649,7 +38648,12 @@
           "invoice_status": {
             "type": "string",
             "description": "請求書ステータス<br>\n<ul>\n  <li>draft: 下書き (デフォルト)</li>\n  <li>(廃止予定) issue: 発行 (送付待ち (unsubmitted) と同じです。)</li>\n  <li>unsubmitted: 送付待ち</li>\n  <li>submitted: 送付済み</li>\n</ul>\nissue, unsubmitted は請求書承認ワークフローを利用している場合は、承認済みの請求書にのみ指定できます。<br>\nsubmitted は請求書承認ワークフローを利用している場合は、送付待ちの請求書にのみ指定できます。\n",
-            "enum": ["draft", "issue", "unsubmitted", "submitted"]
+            "enum": [
+              "draft",
+              "issue",
+              "unsubmitted",
+              "submitted"
+            ]
           },
           "partner_display_name": {
             "type": "string",
@@ -35732,7 +38736,10 @@
             "type": "string",
             "description": "支払方法 (振込: transfer, 引き落とし: direct_debit)",
             "example": "transfer",
-            "enum": ["transfer", "direct_debit"]
+            "enum": [
+              "transfer",
+              "direct_debit"
+            ]
           },
           "payment_bank_info": {
             "type": "string",
@@ -35743,7 +38750,10 @@
             "type": "string",
             "description": "振込専用口座の利用(利用しない: not_use(デフォルト), 利用する: use)",
             "example": "use",
-            "enum": ["not_use", "use"]
+            "enum": [
+              "not_use",
+              "use"
+            ]
           },
           "message": {
             "type": "string",
@@ -35774,14 +38784,20 @@
             "type": "string",
             "description": "請求書の消費税計算方法(inclusive: 内税表示, exclusive: 外税表示 (デフォルト))",
             "example": "exclusive",
-            "enum": ["inclusive", "exclusive"]
+            "enum": [
+              "inclusive",
+              "exclusive"
+            ]
           },
           "invoice_contents": {
             "type": "array",
             "description": "請求内容",
             "items": {
               "type": "object",
-              "required": ["order", "type"],
+              "required": [
+                "order",
+                "type"
+              ],
               "properties": {
                 "id": {
                   "type": "integer",
@@ -35802,7 +38818,11 @@
                   "type": "string",
                   "description": "行の種類\n<ul>\n<li>normal、discountを指定する場合、account_item_id,tax_codeとunit_priceが必須となります。</li>\n<li>normalを指定した場合、qtyが必須となります。</li>\n</ul>",
                   "example": "normal",
-                  "enum": ["normal", "discount", "text"]
+                  "enum": [
+                    "normal",
+                    "discount",
+                    "text"
+                  ]
                 },
                 "qty": {
                   "type": "number",
@@ -35902,7 +38922,9 @@
       },
       "quotationIndexResponse": {
         "type": "object",
-        "required": ["quotations"],
+        "required": [
+          "quotations"
+        ],
         "properties": {
           "quotations": {
             "type": "array",
@@ -35994,7 +39016,11 @@
                 "quotation_status": {
                   "type": "string",
                   "description": "見積書ステータス  (unsubmitted: 送付待ち, submitted: 送付済み, all: 全て)",
-                  "enum": ["unsubmitted", "submitted", "all"]
+                  "enum": [
+                    "unsubmitted",
+                    "submitted",
+                    "all"
+                  ]
                 },
                 "web_published_at": {
                   "type": "string",
@@ -36150,7 +39176,11 @@
                   "type": "string",
                   "description": "見積書の消費税計算方法(inclusive: 内税, exclusive: 外税)",
                   "example": "exclusive",
-                  "enum": ["", "inclusive", "exclusive"]
+                  "enum": [
+                    "",
+                    "inclusive",
+                    "exclusive"
+                  ]
                 },
                 "quotation_contents": {
                   "type": "array",
@@ -36196,7 +39226,11 @@
                         "type": "string",
                         "description": "行の種類",
                         "example": "normal",
-                        "enum": ["normal", "discount", "text"]
+                        "enum": [
+                          "normal",
+                          "discount",
+                          "text"
+                        ]
                       },
                       "qty": {
                         "type": "number",
@@ -36351,7 +39385,12 @@
                 },
                 "total_amount_per_vat_rate": {
                   "type": "object",
-                  "required": ["reduced_vat_8", "vat_10", "vat_5", "vat_8"],
+                  "required": [
+                    "reduced_vat_8",
+                    "vat_10",
+                    "vat_5",
+                    "vat_8"
+                  ],
                   "properties": {
                     "vat_5": {
                       "type": "integer",
@@ -36390,7 +39429,9 @@
       },
       "quotationResponse": {
         "type": "object",
-        "required": ["quotation"],
+        "required": [
+          "quotation"
+        ],
         "properties": {
           "quotation": {
             "type": "object",
@@ -36480,7 +39521,11 @@
               "quotation_status": {
                 "type": "string",
                 "description": "見積書ステータス  (unsubmitted: 送付待ち, submitted: 送付済み, all: 全て)",
-                "enum": ["unsubmitted", "submitted", "all"]
+                "enum": [
+                  "unsubmitted",
+                  "submitted",
+                  "all"
+                ]
               },
               "web_published_at": {
                 "type": "string",
@@ -36636,7 +39681,11 @@
                 "type": "string",
                 "description": "見積書の消費税計算方法(inclusive: 内税, exclusive: 外税)",
                 "example": "exclusive",
-                "enum": ["", "inclusive", "exclusive"]
+                "enum": [
+                  "",
+                  "inclusive",
+                  "exclusive"
+                ]
               },
               "quotation_contents": {
                 "type": "array",
@@ -36682,7 +39731,11 @@
                       "type": "string",
                       "description": "行の種類",
                       "example": "normal",
-                      "enum": ["normal", "discount", "text"]
+                      "enum": [
+                        "normal",
+                        "discount",
+                        "text"
+                      ]
                     },
                     "qty": {
                       "type": "number",
@@ -36837,7 +39890,12 @@
               },
               "total_amount_per_vat_rate": {
                 "type": "object",
-                "required": ["reduced_vat_8", "vat_10", "vat_5", "vat_8"],
+                "required": [
+                  "reduced_vat_8",
+                  "vat_10",
+                  "vat_5",
+                  "vat_8"
+                ],
                 "properties": {
                   "vat_5": {
                     "type": "integer",
@@ -36895,7 +39953,11 @@
       },
       "quotationCreateParams": {
         "type": "object",
-        "required": ["company_id", "partner_display_name", "partner_title"],
+        "required": [
+          "company_id",
+          "partner_display_name",
+          "partner_title"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -36939,7 +40001,10 @@
           "quotation_status": {
             "type": "string",
             "description": "見積書ステータス  (unsubmitted: 送付待ち, submitted: 送付済み) (請求書承認ワークフローを利用している場合、unsubmitted を指定すると、下書きの見積書が作成されます)",
-            "enum": ["unsubmitted", "submitted"]
+            "enum": [
+              "unsubmitted",
+              "submitted"
+            ]
           },
           "partner_display_name": {
             "type": "string",
@@ -37044,14 +40109,20 @@
             "type": "string",
             "description": "見積書の消費税計算方法(inclusive: 内税表示, exclusive: 外税表示 (デフォルト))",
             "example": "exclusive",
-            "enum": ["inclusive", "exclusive"]
+            "enum": [
+              "inclusive",
+              "exclusive"
+            ]
           },
           "quotation_contents": {
             "type": "array",
             "description": "見積内容",
             "items": {
               "type": "object",
-              "required": ["order", "type"],
+              "required": [
+                "order",
+                "type"
+              ],
               "properties": {
                 "order": {
                   "type": "integer",
@@ -37065,7 +40136,11 @@
                   "type": "string",
                   "description": "行の種類\n<ul>\n<li>normal、discountを指定する場合、account_item_id,tax_codeとunit_priceが必須となります。</li>\n<li>normalを指定した場合、qtyが必須となります。</li>\n</ul>",
                   "example": "normal",
-                  "enum": ["normal", "discount", "text"]
+                  "enum": [
+                    "normal",
+                    "discount",
+                    "text"
+                  ]
                 },
                 "qty": {
                   "type": "number",
@@ -37165,7 +40240,11 @@
       },
       "quotationUpdateParams": {
         "type": "object",
-        "required": ["company_id", "partner_display_name", "partner_title"],
+        "required": [
+          "company_id",
+          "partner_display_name",
+          "partner_title"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -37211,7 +40290,10 @@
           "quotation_status": {
             "type": "string",
             "description": "見積書ステータス  (unsubmitted: 送付待ち, submitted: 送付済み) (請求書承認ワークフローを利用している場合、unsubmitted を指定すると、下書きの見積書が作成されます)",
-            "enum": ["unsubmitted", "submitted"]
+            "enum": [
+              "unsubmitted",
+              "submitted"
+            ]
           },
           "partner_display_name": {
             "type": "string",
@@ -37316,14 +40398,20 @@
             "type": "string",
             "description": "見積書の消費税計算方法(inclusive: 内税表示, exclusive: 外税表示 (デフォルト))",
             "example": "exclusive",
-            "enum": ["inclusive", "exclusive"]
+            "enum": [
+              "inclusive",
+              "exclusive"
+            ]
           },
           "quotation_contents": {
             "type": "array",
             "description": "見積内容",
             "items": {
               "type": "object",
-              "required": ["order", "type"],
+              "required": [
+                "order",
+                "type"
+              ],
               "properties": {
                 "id": {
                   "type": "integer",
@@ -37344,7 +40432,11 @@
                   "type": "string",
                   "description": "行の種類\n<ul>\n<li>normal、discountを指定する場合、account_item_id,tax_codeとunit_priceが必須となります。</li>\n<li>normalを指定した場合、qtyが必須となります。</li>\n</ul>",
                   "example": "normal",
-                  "enum": ["normal", "discount", "text"]
+                  "enum": [
+                    "normal",
+                    "discount",
+                    "text"
+                  ]
                 },
                 "qty": {
                   "type": "number",
@@ -37444,7 +40536,12 @@
       },
       "fixedAssetResponse": {
         "type": "object",
-        "required": ["fixed_assets", "fiscal_year", "up_to_date", "up_to_date_reasons"],
+        "required": [
+          "fixed_assets",
+          "fiscal_year",
+          "up_to_date",
+          "up_to_date_reasons"
+        ],
         "properties": {
           "fixed_assets": {
             "type": "array",
@@ -37594,7 +40691,13 @@
                 "depreciation_status": {
                   "type": "string",
                   "description": "売却もしくは除却ステータス: (売却済: sold, 除却済: retired, 償却済: depreciated, 償却中: depreciation, 償却なし: non_depreciation)",
-                  "enum": ["sold", "retired", "depreciated", "depreciation", "non_depreciation"],
+                  "enum": [
+                    "sold",
+                    "retired",
+                    "depreciated",
+                    "depreciation",
+                    "non_depreciation"
+                  ],
                   "example": "depreciation"
                 },
                 "retire_date": {
@@ -37609,7 +40712,10 @@
           },
           "fiscal_year": {
             "type": "object",
-            "required": ["start_date", "end_date"],
+            "required": [
+              "start_date",
+              "end_date"
+            ],
             "properties": {
               "start_date": {
                 "type": "string",
@@ -37633,13 +40739,19 @@
             "description": "集計が最新でない場合の要因情報",
             "items": {
               "type": "object",
-              "required": ["code", "message"],
+              "required": [
+                "code",
+                "message"
+              ],
               "properties": {
                 "code": {
                   "type": "string",
                   "description": "コード",
                   "example": "depreciation_creating",
-                  "enum": ["depreciation_creating", "depreciation_create_error"]
+                  "enum": [
+                    "depreciation_creating",
+                    "depreciation_create_error"
+                  ]
                 },
                 "message": {
                   "type": "string",
@@ -37653,7 +40765,9 @@
       },
       "generalLedgersResponse": {
         "type": "object",
-        "required": ["general_ledgers"],
+        "required": [
+          "general_ledgers"
+        ],
         "properties": {
           "general_ledgers": {
             "type": "array",
@@ -37702,7 +40816,11 @@
       },
       "accountGroupCreateParams": {
         "type": "object",
-        "required": ["company_id", "name", "account_category_id"],
+        "required": [
+          "company_id",
+          "name",
+          "account_category_id"
+        ],
         "properties": {
           "company_id": {
             "type": "integer",
@@ -37732,7 +40850,9 @@
       },
       "accountGroupCreateResponse": {
         "type": "object",
-        "required": ["account_group"],
+        "required": [
+          "account_group"
+        ],
         "properties": {
           "account_group": {
             "type": "object",

--- a/openapi/hr-api-schema.json
+++ b/openapi/hr-api-schema.json
@@ -1,0 +1,20600 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "freee人事労務 API",
+    "description": "\n<p>freee人事労務のAPI仕様です。</p>\n\n<hr />\n\n<h2 id=\"start_guide\">スタートガイド</h2>\n\n<p>freee API開発がはじめての方は<a href=\"https://developer.freee.co.jp/getting-started\">freee API スタートガイド</a>を参照してください。</p>\n\n<hr />\n<h2 id=\"specification\">仕様</h2>\n\n<h3 id=\"api_endpoint\">APIエンドポイント</h3>\n\n<p>https://api.freee.co.jp/hr</p>\n\n<h3 id=\"about_authorize\">認証について</h3>\n\n<p>OAuth2.0を利用します。<a href=\"https://developer.freee.co.jp/reference/#%e8%aa%8d%e8%a8%bc\" target=\"_blank\">詳細はリファレンスの認証に関する記載を参照してください。</a></p>\n\n<h3 id=\"data_format\">データフォーマット</h3>\n\n<p>リクエスト、レスポンスともにJSON形式をサポートしていますが、詳細は、API毎の説明欄（application/jsonなど）を確認してください。</p>\n\n<h3 id=\"compatibility\">後方互換性ありの変更</h3>\n\n<p>freeeでは、APIを改善していくために以下のような変更は後方互換性ありとして通知なく変更を入れることがあります。アプリケーション実装者は以下を踏まえて開発を行ってください。</p>\n\n<ul>\n<li>新しいAPIリソース・エンドポイントの追加</li>\n<li>既存のAPIに対して必須ではない新しいリクエストパラメータの追加</li>\n<li>既存のAPIレスポンスに対する新しいプロパティの追加</li>\n<li>既存のAPIレスポンスに対するプロパティの順番の入れ変え</li>\n<li>keyとなっているidやcodeの長さの変更（長くする）</li>\n<li>エラーメッセージの変更</li>\n</ul>\n\n<h3 id=\"common_response_header\">共通レスポンスヘッダー</h3>\n\n<p>すべてのAPIのレスポンスには以下のHTTPヘッダーが含まれます。</p>\n\n<ul>\n<li>\n<p>X-Request-Id</p>\n<ul>\n<li>各リクエスト毎に発行されるID</li>\n</ul>\n</li>\n</ul>\n\n<h3 id=\"error_response\">共通エラーレスポンス</h3>\n\n<p>APIリクエストでエラーが発生した場合は、エラー原因に応じたステータスコードおよびメッセージを返します。</p>\n\n  <table border=\"1\">\n  <tbody>\n    <tr>\n      <th style=\"padding: 10px\"><strong>ステータスコード</strong></th>\n      <th style=\"padding: 10px\"><strong>原因</strong></th>\n    </tr>\n    <tr><td style=\"padding: 10px\">400</td><td style=\"padding: 10px\">リクエストパラメータが不正</td></tr>\n    <tr><td style=\"padding: 10px\">401</td><td style=\"padding: 10px\">アクセストークンが無効</td></tr>\n    <tr><td style=\"padding: 10px\">403</td><td style=\"padding: 10px\">アクセス権限がない</td></tr>\n    <tr><td style=\"padding: 10px\">404</td><td style=\"padding: 10px\">リソースが存在しない</td></tr>\n    <tr><td style=\"padding: 10px\">429</td><td style=\"padding: 10px\">リクエスト回数制限を超えた</td></tr>\n    <tr><td style=\"padding: 10px\">503</td><td style=\"padding: 10px\">システム内で予期しないエラーが発生</td></tr>\n  </tbody>\n</table>\n\n<p>メッセージボディ内の <code>messages</code> にはエラー内容を説明する文字列が入ります。</p>\n<pre><code>  {\n    &quot;status_code&quot; : 400,\n    &quot;errors&quot; : [\n      {\n        &quot;type&quot; : &quot;bad_request&quot;,\n        &quot;messages&quot; : [\n          &quot;リクエストの形式が不正です。&quot;\n        ]\n      }\n    ]\n  }  </code></pre>\n\n</br>\n\n<h3 id=\"api_rate_limit\">API使用制限</h3> \n<p>APIリクエストは1時間で10000回を上限としています。API使用ステータスはレスポンスヘッダに付与されます。</p>\n<pre><code>X-Ratelimit-Limit:10000\nX-Ratelimit-Remaining:9998\nX-Ratelimit-Reset:2018-01-01T12:00:00.000000Z\n</code></pre>\n\n<br> 各ヘッダの意味は次のとおりです。</p>\n\n <table border=\"1\">\n  <tbody>\n    <tr>\n      <th style=\"padding: 10px\"><strong>ヘッダ名</strong></th>\n      <th style=\"padding: 10px\"><strong>説明</strong></th>\n    </tr>\n    <tr><td style=\"padding: 10px\">X-RateLimit-Limit</td><td style=\"padding: 10px\">使用回数の上限</td></tr>\n    <tr><td style=\"padding: 10px\">X-RateLimit-Remaining</td><td style=\"padding: 10px\">残り使用回数</td></tr>\n    <tr><td style=\"padding: 10px\">X-RateLimit-Reset</td><td style=\"padding: 10px\">使用回数がリセットされる時刻</td></tr>\n  </tbody>\n</table>\n\n<p>上記に加え、freeeは一定期間に過度のアクセスを検知した場合、APIアクセスをコントロールする場合があります。<br> その際のhttp status codeは403となります。制限がかかってから10分程度が過ぎると再度使用することができるようになります。</p>\n\n</br>\n\n<h3 id=\"api_rate_limit\">プランごとの利用可能API</h3> \n\n<p>契約プランごとに利用可能なfreee人事労務APIはfreee人事労務のWeb版でご利用できる機能と同様です。例えば、スタンダードプラン（または旧ベーシックプラン）を契約している場合、Web版では打刻機能をご利用いただけますので、APIでもタイムレコーダー(打刻)APIが利用可能です。<a href=\"https://support.freee.co.jp/hc/ja/articles/203309710\" target=\"_blank\">freee人事労務のWeb版のプラン別機能比較はfreee人事労務のプラン・料金についてのヘルプを参照してください。</a></p>\n\n</br>\n\n<hr />",
+    "termsOfService": "https://app.secure.freee.co.jp/terms-freee-api.html",
+    "contact": {
+      "name": "サポートデスクへのお問い合わせ",
+      "url": "https://accounts.secure.freee.co.jp/contacts?from=payroll"
+    },
+    "license": {
+      "name": "© Since 2013 freee K.K."
+    },
+    "version": "2022-02-01"
+  },
+  "servers": [
+    {
+      "url": "https://api.freee.co.jp/hr"
+    }
+  ],
+  "security": [
+    {
+      "bearer": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "ログインユーザー",
+      "description": "ログインユーザーの取得"
+    },
+    {
+      "name": "従業員の特別休暇",
+      "description": "従業員の特別休暇の操作"
+    },
+    {
+      "name": "従業員",
+      "description": "従業員の操作"
+    },
+    {
+      "name": "従業員の姓名・住所など",
+      "description": "従業員の姓名・住所などの操作"
+    },
+    {
+      "name": "従業員の健康保険",
+      "description": "従業員の健康保険の操作"
+    },
+    {
+      "name": "従業員の厚生年金保険",
+      "description": "従業員の厚生年金保険の操作"
+    },
+    {
+      "name": "従業員の家族情報",
+      "description": "従業員の家族情報の操作"
+    },
+    {
+      "name": "従業員の銀行口座",
+      "description": "従業員の銀行口座の操作"
+    },
+    {
+      "name": "従業員の基本給",
+      "description": "従業員の基本給の操作"
+    },
+    {
+      "name": "従業員のカスタム項目",
+      "description": "従業員のカスタム項目の操作"
+    },
+    {
+      "name": "勤怠",
+      "description": "勤怠の操作"
+    },
+    {
+      "name": "勤怠情報サマリ",
+      "description": "勤怠情報の月次サマリの操作"
+    },
+    {
+      "name": "タイムレコーダー(打刻)",
+      "description": "タイムレコーダー(打刻)機能の操作"
+    },
+    {
+      "name": "給与明細",
+      "description": "給与明細の操作"
+    },
+    {
+      "name": "賞与明細",
+      "description": "賞与明細の操作"
+    },
+    {
+      "name": "所属",
+      "description": "所属の操作"
+    },
+    {
+      "name": "勤怠タグサマリ",
+      "description": "勤怠タグサマリの操作"
+    },
+    {
+      "name": "勤怠タグ",
+      "description": "勤怠タグの操作"
+    },
+    {
+      "name": "部門",
+      "description": "部門の操作"
+    },
+    {
+      "name": "役職",
+      "description": "役職の操作"
+    },
+    {
+      "name": "月次勤怠締め申請",
+      "description": "月次勤怠締め申請の操作"
+    },
+    {
+      "name": "勤務時間修正申請",
+      "description": "勤務時間修正申請の操作"
+    },
+    {
+      "name": "有給申請",
+      "description": "有給申請の操作"
+    },
+    {
+      "name": "特別休暇申請",
+      "description": "特別休暇申請の操作"
+    },
+    {
+      "name": "残業申請",
+      "description": "残業申請の操作"
+    },
+    {
+      "name": "申請経路",
+      "description": "申請経路の操作"
+    },
+    {
+      "name": "年末調整",
+      "description": "年末調整の操作"
+    }
+  ],
+  "paths": {
+    "/api/v1/users/me": {
+      "get": {
+        "tags": [
+          "ログインユーザー"
+        ],
+        "summary": "ログインユーザーの取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>このリクエストの認可セッションにおけるログインユーザーの情報を返します。</p>\n<p>freee人事労務では一人のログインユーザーを複数の事業所に関連付けられるため、このユーザーと関連のあるすべての事業所の情報をリストで返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>他のAPIのパラメータとしてcompany_idが求められる場合は、このAPIで取得したcompany_idを使用します。</li>\n  <li>給与計算対象外の従業員のemployee_idとdisplay_nameは取得できません。</li>\n</ul>",
+        "operationId": "get_users_me",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1UsersMeSerializer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/companies/{company_id}/employees": {
+      "get": {
+        "tags": [
+          "従業員"
+        ],
+        "summary": "全期間の従業員一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所に所属する従業員をリストで返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n  <li>退職ユーザーも含めて取得可能です。</li>\n</ul>",
+        "operationId": "get_company_employees",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "取得レコードの件数 (デフォルト: 50, 最小: 1, 最大: 100)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "example": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647,
+              "example": 0
+            }
+          },
+          {
+            "name": "company_id",
+            "in": "path",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "with_no_payroll_calculation",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "trueを指定すると給与計算対象外の従業員情報をレスポンスに含めます。",
+            "example": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ApiV1CompaniesEmployeeSerializer"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/employees": {
+      "get": {
+        "tags": [
+          "従業員"
+        ],
+        "summary": "従業員一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した対象年月に事業所に所属する従業員をリストで返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n  <li>指定した年月に退職済みユーザーは取得できません。</li>\n  <li>保険料計算方法が自動計算の場合、対応する保険料の直接指定金額は無視されnullが返されます。(例: 給与計算時の健康保険料の計算方法が自動計算の場合、給与計算時の健康保険料の直接指定金額はnullが返されます)</li>\n  <li>事業所が定額制の健康保険組合に加入している場合、保険料の直接指定金額は無視されnullが返されます。</li>\n</ul>",
+        "operationId": "get_employees",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "description": "事業所ID",
+            "example": 1
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            },
+            "description": "従業員情報を取得したい年",
+            "example": 2021
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12
+            },
+            "example": 1,
+            "description": "従業員情報を取得したい月<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、 指定したmonth + 1の値が検索結果として返します。<br>\n翌月払いの従業員の2022/01の従業員情報を取得する場合は、year=2021,month=12を指定してください。<br>"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "取得レコードの件数 (デフォルト: 50, 最小: 1, 最大: 100)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "example": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647,
+              "example": 0
+            }
+          },
+          {
+            "name": "with_no_payroll_calculation",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "trueを指定すると給与計算対象外の従業員情報をレスポンスに含めます。",
+            "example": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesIndexSerializer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "従業員"
+        ],
+        "summary": "従業員の作成",
+        "description": "<h2 id=\"\">概要</h2>\n<p>従業員を新規作成します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>",
+        "operationId": "create_employee",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeesController.create_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesController.create_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/employees/{id}": {
+      "get": {
+        "tags": [
+          "従業員"
+        ],
+        "summary": "従業員の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定したIDの従業員を返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n  <li>指定した年月に退職済みユーザーは取得できません。</li>\n  <li>保険料計算方法が自動計算の場合、対応する保険料の直接指定金額は無視されnullが返されます。(例: 給与計算時の健康保険料の計算方法が自動計算の場合、給与計算時の健康保険料の直接指定金額はnullが返されます)</li>\n  <li>事業所が定額制の健康保険組合に加入している場合、保険料の直接指定金額は無視されnullが返されます。</li>\n</ul>",
+        "operationId": "get_employee",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "description": "事業所ID",
+            "example": 1
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            },
+            "description": "従業員情報を取得したい年",
+            "example": 2021
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12
+            },
+            "example": 1,
+            "description": "従業員情報を取得したい月<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、 指定したmonth + 1の値が検索結果として返します。<br>\n翌月払いの従業員の2022/01の従業員情報を取得する場合は、year=2021,month=12を指定してください。<br>"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesController.show_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "従業員"
+        ],
+        "summary": "従業員の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の情報を更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>",
+        "operationId": "update_employee",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeesController.update_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesController.update_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "従業員"
+        ],
+        "summary": "従業員の削除",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定したIDの従業員を削除します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>",
+        "operationId": "destroy_employee",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/employees/{employee_id}/profile_rule": {
+      "get": {
+        "tags": [
+          "従業員の姓名・住所など"
+        ],
+        "summary": "従業員の姓名・住所などの取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員・日付の姓名などの情報を返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>本APIは、給与計算対象外の従業員には非対応です。employee_idに給与計算対象外の従業員IDを指定した場合、本APIを利用できません。</li>\n</ul>",
+        "operationId": "get_employee_profile_rule",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "description": "従業員情報を取得したい年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "description": "従業員情報を取得したい月<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、指定したmonth + 1の値が検索結果として返します。<br>\n翌月払いの従業員の2022/01の従業員情報を取得する場合は、year=2021,month=12を指定してください。<br>",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesProfileRulesController.show_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "従業員の姓名・住所など"
+        ],
+        "summary": "従業員の姓名・住所などの更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の姓名・住所などを更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>本APIは、給与計算対象外の従業員には非対応です。employee_idに給与計算対象外の従業員IDを指定した場合、本APIを利用できません。</li>\n</ul>",
+        "operationId": "update_employee_profile_rule",
+        "parameters": [
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeesProfileRulesController.update_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesProfileRulesController.update_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/employees/{employee_id}/health_insurance_rule": {
+      "get": {
+        "tags": [
+          "従業員の健康保険"
+        ],
+        "summary": "従業員の健康保険の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員・日付の健康保険情報を返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n  <li>保険料計算方法が自動計算の場合、対応する保険料の直接指定金額は無視されnullが返されます。(例: 給与計算時の健康保険料の計算方法が自動計算の場合、給与計算時の健康保険料の直接指定金額はnullが返されます)</li>\n</ul>",
+        "operationId": "get_employee_health_insurance_rule",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "example": 1
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "description": "従業員情報を取得したい年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100,
+              "example": 2021
+            }
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "description": "従業員情報を取得したい月<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、 指定したmonth + 1の値が検索結果として返します。<br>\n翌月払いの従業員の2022/01の従業員情報を取得する場合は、year=2021,month=12を指定してください。<br>",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12,
+              "example": 1
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "example": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesHealthInsuranceRulesController.show_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "従業員の健康保険"
+        ],
+        "summary": "従業員の健康保険の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の健康保険情報を更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n  <li>保険料計算方法が自動計算の場合、対応する保険料の直接指定金額は無視されnullが返されます。(例: 給与計算時の健康保険料の計算方法が自動計算の場合、給与計算時の健康保険料の直接指定金額はnullが返されます)</li>\n  <li>事業所が定額制の健康保険組合に加入している場合、保険料の直接指定金額は無視されnullが返されます。</li>\n  <li>事業所が定額制の健康保険組合に加入している場合、保険料の計算方法と保険料の更新はできません。</li>\n</ul>",
+        "operationId": "update_employee_health_insurance_rule",
+        "parameters": [
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "example": 1
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeesHealthInsuranceRulesController.update_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesHealthInsuranceRulesController.update_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/employees/{employee_id}/welfare_pension_insurance_rule": {
+      "get": {
+        "tags": [
+          "従業員の厚生年金保険"
+        ],
+        "summary": "従業員の厚生年金保険の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員・日付の厚生年金保険情報を返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n  <li>保険料計算方法が自動計算の場合、対応する保険料の直接指定金額は無視されnullが返されます。(例: 給与計算時の厚生年金保険料の計算方法が自動計算の場合、給与計算時の厚生年金保険料の直接指定金額はnullが返されます)</li>\n</ul>",
+        "operationId": "get_employee_welfare_pension_insurance_rule",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "description": "従業員情報を取得したい年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "description": "従業員情報を取得したい月<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、 指定したmonth + 1の値が検索結果として返します。<br>\n翌月払いの従業員の2022/01の従業員情報を取得する場合は、year=2021,month=12を指定してください。<br>",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesWelfarePensionInsuranceRulesController.show_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "従業員の厚生年金保険"
+        ],
+        "summary": "従業員の厚生年金保険の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の厚生年金保険情報を更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n  <li>保険料計算方法が自動計算の場合、対応する保険料の直接指定金額は無視されnullが返されます。(例: 給与計算時の厚生年金保険料の計算方法が自動計算の場合、給与計算時の厚生年金保険料の直接指定金額はnullが返されます)</li>\n</ul>",
+        "operationId": "update_employee_welfare_pension_insurance_rule",
+        "parameters": [
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeesWelfarePensionInsuranceRulesController.update_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesWelfarePensionInsuranceRulesController.update_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/employees/{employee_id}/dependent_rules": {
+      "get": {
+        "tags": [
+          "従業員の家族情報"
+        ],
+        "summary": "従業員の家族情報の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員・日付の家族情報を返します。</p>",
+        "operationId": "get_employee_dependent_rules",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "description": "従業員情報を取得したい年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "description": "従業員情報を取得したい月<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、 指定したmonth + 1の値が検索結果として返します。<br>\n翌月払いの従業員の2022/01の従業員情報を取得する場合は、year=2021,month=12を指定してください。<br>",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesDependentRulesController.index_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/employees/{employee_id}/dependent_rules/bulk_update": {
+      "put": {
+        "tags": [
+          "従業員の家族情報"
+        ],
+        "summary": "従業員の家族情報の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の家族情報を更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>idがない場合は新規作成、destroyがtrueの場合は削除になります。</li>\n  <li>residence_type=live_in: 同居の場合、以下のパラメータに指定した値はWebに反映されません。</li>\n  <ul>\n    <li>zipcode1</li>\n    <li>zipcode2</li>\n    <li>prefecture_code</li>\n    <li>address</li>\n    <li>address_kana</li>\n    <li>annual_remittance_amount</li>\n  </ul>\n  <li>residence_type=non_resident: 別居(国外)の場合、以下のパラメータに指定した値はWebに反映されません。</li>\n  <ul>\n    <li>prefecture_code</li>\n  </ul>\n</ul>",
+        "operationId": "bulk_update_employee_dependent_rules",
+        "parameters": [
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeesDependentRulesController.bulk_update_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesDependentRulesController.bulk_update_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/employees/{employee_id}/bank_account_rule": {
+      "get": {
+        "tags": [
+          "従業員の銀行口座"
+        ],
+        "summary": "従業員の銀行口座の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員・日付の銀行口座情報を返します。</p>",
+        "operationId": "get_employee_bank_account_rule",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "description": "従業員情報を取得したい年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "description": "従業員情報を取得したい月<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、 指定したmonth + 1の値が検索結果として返します。<br>\n翌月払いの従業員の2022/01の従業員情報を取得する場合は、year=2021,month=12を指定してください。<br>",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesBankAccountRulesController.show_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "従業員の銀行口座"
+        ],
+        "summary": "従業員の銀行口座の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の銀行口座1の情報を更新します。</p>",
+        "operationId": "update_employee_bank_account_rule",
+        "parameters": [
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeesBankAccountRulesController.update_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesBankAccountRulesController.update_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/employees/{employee_id}/basic_pay_rule": {
+      "get": {
+        "tags": [
+          "従業員の基本給"
+        ],
+        "summary": "従業員の基本給の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員・日付の基本給情報を返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>",
+        "operationId": "get_employee_basic_pay_rule",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "example": 1
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "description": "従業員情報を取得したい年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100,
+              "example": 2021
+            }
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "description": "従業員情報を取得したい月<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、 指定したmonth + 1の値が検索結果として返します。<br>\n翌月払いの従業員の2022/01の従業員情報を取得する場合は、year=2021,month=12を指定してください。<br>",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12,
+              "example": 1
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "example": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesBasicPayRulesController.show_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "従業員の基本給"
+        ],
+        "summary": "従業員の基本給の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の基本給情報を更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>",
+        "operationId": "update_employee_basic_pay_rule",
+        "parameters": [
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "example": 1
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeesBasicPayRulesController.update_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesBasicPayRulesController.update_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/employees/{employee_id}/profile_custom_fields": {
+      "get": {
+        "tags": [
+          "従業員のカスタム項目"
+        ],
+        "summary": "従業員のカスタム項目の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員・日付のカスタム項目情報を返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n  <li>指定年月に在籍していない従業員および給与計算対象外の従業員ではデータが存在しないため、空の配列が返ります。</li>\n</ul>",
+        "operationId": "get_employee_profile_custom_fields_rule",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "example": 1
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "description": "従業員情報を取得したい年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100,
+              "example": 2021
+            }
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "description": "従業員情報を取得したい月<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、 指定したmonth + 1の値が検索結果として返します。<br>\n翌月払いの従業員の2022/01の従業員情報を取得する場合は、year=2021,month=12を指定してください。<br>",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12,
+              "example": 1
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "example": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesProfileCustomFieldRulesController.index_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/employees/{employee_id}/work_records/{date}": {
+      "get": {
+        "tags": [
+          "勤怠"
+        ],
+        "summary": "勤怠の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員・日付の勤怠情報を返します。</p>",
+        "operationId": "get_employee_work_record",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "date",
+            "in": "path",
+            "description": "従業員情報を取得したい年月日(YYYY-MM-DD)(例:2018-08-01)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordSerializer"
+                    },
+                    {
+                      "$ref": "#/components/schemas/LegacyApiV1EmployeesWorkRecordSerializer"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "勤怠"
+        ],
+        "summary": "勤怠の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の勤怠情報を更新します。</p>\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>振替出勤・振替休日・代休出勤・代休の登録はAPIでは行うことができません。</li>\n</ul>\n\n<h2 id=\"_2\">examples</h2>\n<ul>\n  <li>出勤日について出退勤時刻および休憩時間を更新する場合は以下のようなパラメータをリクエストします。\n    <pre>\n      <code>\n      {\n        \"company_id\": 1,\n        \"break_records\": [\n          {\n            \"clock_in_at\": \"2017-05-25 12:00:00\",\n            \"clock_out_at\": \"2017-05-25 13:00:00\"\n          }\n        ],\n        \"work_record_segments\": [\n          {\n            \"clock_in_at\": \"2017-05-25 09:10:00\",\n            \"clock_out_at\": \"2017-05-25 18:20:00\"\n          }\n        ]\n      }\n      </code>\n    </pre>\n  </li>\n\n  <li>勤務パターンや既定の所定労働時間を変更する場合は use_default_work_pattern に false を指定するとともに、各設定を上書きするパラメータをリクエストします。\n    <pre>\n      <code>\n      {\n        \"company_id\": 1,\n        \"break_records\": [\n          {\n            \"clock_in_at\": \"2017-05-25 12:00:00\",\n            \"clock_out_at\": \"2017-05-25 13:00:00\"\n          }\n        ],\n        \"work_record_segments\": [\n          {\n            \"clock_in_at\": \"2017-05-25 09:10:00\",\n            \"clock_out_at\": \"2017-05-25 18:20:00:00\"\n          }\n        ],\n        \"day_pattern\": \"normal_day\",\n        \"normal_work_clock_in_at\": \"2017-05-25 11:00:00\",\n        \"normal_work_clock_out_at\": \"2017-12-20 20:00:00\",\n        \"normal_work_mins\": 0,\n        \"use_default_work_pattern\": false\n      }\n      </code>\n    </pre>\n  </li>\n\n  <li>有給取得時の連携について半休の場合は通常勤務のように勤務開始・終了時間を指定しつつ、加えて以下の要素を指定することで API での勤怠をつけることができます。\n    <pre>\n      <code>\n      {\n        \"company_id\": 1,\n        \"break_records\": [\n          {\n            \"clock_in_at\": \"2023-12-22 12:00:00\",\n            \"clock_out_at\": \"2023-12-22 13:00:00\"\n          }\n        ],\n        \"work_record_segments\": [\n          {\n            \"clock_in_at\": \"2017-05-25 09:10:00\",\n            \"clock_out_at\": \"2017-05-25 18:20:00:00\"\n          }\n        ],\n        \"paid_holidays\": [\n          {\n            \"type\": \"half\"\n            \"mins\": 240\n          }\n        ]\n      }\n      </code>\n    </pre>\n  </li>\n\n  <li>有給取得時の連携について午前休または午後休の場合は通常勤務のように勤務開始・終了時間を指定しつつ、加えて以下の要素を指定することで API での勤怠をつけることができます。\n    <pre>\n      <code>\n      {\n        \"company_id\": 1,\n        \"break_records\": [\n          {\n            \"clock_in_at\": \"2023-12-22 16:00:00\",\n            \"clock_out_at\": \"2023-12-22 16:30:00\"\n          }\n        ],\n        \"clock_in_at\": \"2023-12-22 14:00:00\",\n        \"clock_out_at\": \"2023-12-22 18:00:00\",\n        \"paid_holidays\": [\n          {\n            \"type\": \"morning_off\"\n          }\n        ]\n      }\n      </code>\n    </pre>\n  </li>\n\n  <li>有給取得時の連携について半日単位の年次有給休暇と時間単位の年次有給休暇を同日に取得する場合は通常勤務のように勤務開始・終了時間を指定しつつ、加えて以下の要素を指定することで API での勤怠をつけることができます。\n    <pre>\n      <code>\n      {\n        \"company_id\": 1,\n        \"break_records\": [\n          {\n            \"clock_in_at\": \"2023-12-22 16:00:00\",\n            \"clock_out_at\": \"2023-12-22 16:30:00\"\n          }\n        ],\n        \"clock_in_at\": \"2023-12-22 14:00:00\",\n        \"clock_out_at\": \"2023-12-22 18:00:00\",\n        \"paid_holidays\": [\n          {\n            \"type\": \"half\",\n            \"mins\": 240\n          },\n          {\n            \"type\": \"hourly\",\n            \"mins\": 120\n          },\n        ]\n      }\n      </code>\n    </pre>\n  </li>\n\n  <li>特別休暇取得時の連携について全休の場合は以下の要素を指定することで API での勤怠をつけることができます。\n    <ul>\n      <li>special_holiday (全休の場合1.0を指定します)</li>\n      <li>special_holiday_setting_id (特別休暇設定IDを指定します)</li>\n    </ul>\n    <pre>\n      <code>\n      {\n        \"company_id\": 1,\n        \"special_holiday\": 1.0\n        \"special_holiday_setting_id\": 1\n      }\n      </code>\n    </pre>\n  </li>\n\n  <li>特別休暇取得時の連携について時間休の場合は通常勤務のように勤務開始・終了時間を指定しつつ、加えて以下の要素を指定することで API での勤怠をつけることができます。\n    <ul>\n      <li>special_holiday_setting_id (特別休暇設定IDを指定します)</li>\n      <li>hourly_special_holiday_mins (時間休により計上される所定労働時間を分で指定します)</li>\n    </ul>\n    <pre>\n      <code>\n      {\n        \"company_id\": 1,\n        \"break_records\": [\n          {\n            \"clock_in_at\": \"2023-12-22 12:00:00\",\n            \"clock_out_at\": \"2023-12-22 13:00:00\"\n          }\n        ],\n        \"work_record_segments\": [\n          {\n            \"clock_in_at\": \"2017-05-25 09:10:00\",\n            \"clock_out_at\": \"2017-05-25 18:20:00:00\"\n          }\n        ],\n        \"special_holiday_setting_id\": 1,\n        \"hourly_special_holiday_mins\": 120\n      }\n      </code>\n    </pre>\n  </li>\n\n  <li>特別休暇取得時の連携について午前休または午後休の場合は通常勤務のように勤務開始・終了時間を指定しつつ、加えて以下の要素を指定することで API での勤怠をつけることができます。\n    <ul>\n      <li>special_holiday_setting_id (特別休暇設定IDを指定します)</li>\n      <li>half_holiday_type (morning_off または afternoon_off を指定します)</li>\n    </ul>\n    <pre>\n      <code>\n      {\n        \"company_id\": 1,\n        \"break_records\": [\n          {\n            \"clock_in_at\": \"2023-12-22 12:00:00\",\n            \"clock_out_at\": \"2023-12-22 12:30:00\"\n          }\n        ],\n        \"clock_in_at\": \"2023-12-22 09:00:00\",\n        \"clock_out_at\": \"2023-12-22 13:00:00\",\n        \"special_holiday_setting_id\": 1,\n        \"half_holiday_type\": \"afternoon_off\"\n      }\n      </code>\n    </pre>\n  </li>\n\n  <li>欠勤を付ける場合は company_idとis_absence 以外のパラメータは必要ありません。\n    <pre>\n      <code>\n      {\n        \"company_id\": 1,\n        \"is_absence\": true\n      }\n      </code>\n    </pre>\n  </li>\n\n</ul>",
+        "operationId": "update_employee_work_record",
+        "parameters": [
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "date",
+            "in": "path",
+            "description": "更新対象年月日(YYYY-MM-DD)(例:2018-08-01)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordsController.update_body"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LegacyApiV1EmployeesWorkRecordsController.update_body"
+                  }
+                ]
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordSerializer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "勤怠"
+        ],
+        "summary": "勤怠の削除",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の勤怠情報を削除します。</p>",
+        "operationId": "destroy_employee_work_record",
+        "parameters": [
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "date",
+            "in": "path",
+            "description": "削除対象年月日(YYYY-MM-DD)(例:2018-08-01)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            }
+          },
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "maximum": 2147483647,
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/employees/{employee_id}/work_record_summaries/{year}/{month}": {
+      "get": {
+        "tags": [
+          "勤怠情報サマリ"
+        ],
+        "summary": "勤怠情報月次サマリの取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員、月の勤怠情報のサマリを返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>work_recordsオプションにtrueを指定することで、明細となる日次の勤怠情報もあわせて返却します。</li>\n</ul>",
+        "operationId": "get_employee_work_record_summary",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "work_records",
+            "in": "query",
+            "description": "サマリ情報に日次の勤怠情報を含める(true/false)(デフォルト: false)",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "example": 1
+            }
+          },
+          {
+            "name": "year",
+            "in": "path",
+            "description": "従業員情報を取得したい年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100,
+              "example": 2021
+            }
+          },
+          {
+            "name": "month",
+            "in": "path",
+            "description": "従業員情報を取得したい月",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12,
+              "example": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordSummarySerializer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "勤怠情報サマリ"
+        ],
+        "summary": "勤怠情報月次サマリの更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員、月の勤怠情報のサマリを更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n  <li>日毎の勤怠の更新はこのAPIではできません。日毎の勤怠の操作には勤怠APIを使用して下さい。</li>\n  <li>勤怠データが存在しない場合は新規作成、既に存在する場合は上書き更新されます。</li>\n  <li>値が設定された項目のみ更新されます。値が設定されなかった場合は自動的に0が設定されます。</li>\n</ul>",
+        "operationId": "update_employee_work_record_summary",
+        "parameters": [
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "example": 1
+            }
+          },
+          {
+            "name": "year",
+            "in": "path",
+            "description": "更新対象年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100,
+              "example": 2021
+            }
+          },
+          {
+            "name": "month",
+            "in": "path",
+            "description": "更新対象月",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12,
+              "example": 1
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordSummaryController.update_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordSummarySerializer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/employees/{employee_id}/time_clocks": {
+      "get": {
+        "tags": [
+          "タイムレコーダー(打刻)"
+        ],
+        "summary": "打刻一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員・期間の打刻情報を返します。</p>",
+        "operationId": "get_employee_time_clocks",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "from_date",
+            "in": "query",
+            "description": "取得する打刻期間の開始日(YYYY-MM-DD)(例:2018-08-01)(デフォルト: 当月の打刻開始日)",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            }
+          },
+          {
+            "name": "to_date",
+            "in": "query",
+            "description": "取得する打刻期間の終了日(YYYY-MM-DD)(例:2018-08-31)(デフォルト: 当日)",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "取得レコードの件数 (デフォルト: 50, 最小: 1, 最大: 100)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesTimeClocksController.index_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "タイムレコーダー(打刻)"
+        ],
+        "summary": "打刻の登録",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の打刻情報を登録します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>休憩開始の連続や退勤のみなど、整合性の取れていない打刻は登録できません。\n打刻可能種別の取得APIを呼ぶことで、その従業員がその時点で登録可能な打刻種別が取得できます。</li>\n\n  <li>出勤の打刻は</li>\n  <ul>\n    <li>前日の出勤時刻から24時間以内の場合、前日の退勤打刻が必須です。</li>\n    <li> 前日の出勤時刻から24時間経過している場合は、前日の退勤打刻がなくとも出勤打刻を登録することができます。</li>\n  </ul>\n\n  <li>退勤の打刻は</li>\n  <ul>\n    <li><a href=\\\"https://support.freee.co.jp/hc/ja/articles/900004490226-%E5%8B%A4%E6%80%A0%E5%9F%BA%E6%9C%AC%E8%A8%AD%E5%AE%9A%E3%82%92%E8%A1%8C%E3%81%86#h_01EYPYTR9HZ7YB8V5F18VMD1BT\"target=\\\"_blank\\\">『退勤を自動打刻する』</a>の設定を使用している場合は、出勤打刻から24時間経過しても退勤打刻がない場合に、退勤打刻が自動で登録されます。</li>\n    <li>すでに登録されている退勤打刻よりも後の時刻であれば上書き登録することができます。</li>\n  </ul>\n\n  <li>打刻が日をまたぐ場合は、base_date(打刻日)に前日の日付を指定してください。</li>\n\n  <li>datetime(打刻日時)を指定できるのは管理者の権限を持ったユーザーのみです。</li>\n</ul>",
+        "operationId": "create_employee_time_clock",
+        "parameters": [
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeesTimeClocksController.create_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesTimeClocksController.create_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/employees/{employee_id}/time_clocks/{id}": {
+      "get": {
+        "tags": [
+          "タイムレコーダー(打刻)"
+        ],
+        "summary": "打刻の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員・指定した打刻の詳細情報を返します。</p>",
+        "operationId": "get_employee_time_clock",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "打刻ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesTimeClocksController.show_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/employees/{employee_id}/time_clocks/available_types": {
+      "get": {
+        "tags": [
+          "タイムレコーダー(打刻)"
+        ],
+        "summary": "打刻可能種別の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員・日付の打刻可能種別と打刻基準日を返します。</p>\n<p>例: すでに出勤した状態だと、休憩開始、退勤が配列で返ります。</p>",
+        "operationId": "get_employee_time_clocks_available_types",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "description": "従業員情報を取得したい年月日(YYYY-MM-DD)(例:2018-08-01)(デフォルト：当日)",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesTimeClocksController.available_types_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/employees/{employee_id}/special_holidays": {
+      "get": {
+        "tags": [
+          "従業員の特別休暇"
+        ],
+        "summary": "従業員の特別休暇一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員に付与された特別休暇情報をリストで返します。</p>",
+        "operationId": "get_employees_special_holidays",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "description": "事業所ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "example": 1
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "description": "対象日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2023-04-01"
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "description": "対象開始日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2023-04-01"
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "description": "対象終了日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2023-04-01"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "employee_special_holidays": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "description": "特別休暇付与ID",
+                            "format": "int32",
+                            "minimum": 1,
+                            "maximum": 2147483647,
+                            "example": 1
+                          },
+                          "company_id": {
+                            "type": "integer",
+                            "description": "事業所ID",
+                            "format": "int32",
+                            "minimum": 1,
+                            "maximum": 2147483647,
+                            "example": 1
+                          },
+                          "employee_id": {
+                            "type": "integer",
+                            "description": "従業員ID",
+                            "format": "int32",
+                            "minimum": 1,
+                            "maximum": 2147483647,
+                            "example": 1
+                          },
+                          "special_holiday_setting_id": {
+                            "type": "integer",
+                            "description": "特別休暇設定ID",
+                            "format": "int32",
+                            "minimum": 1,
+                            "maximum": 2147483647,
+                            "example": 1
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "特別休暇名称",
+                            "example": "育休"
+                          },
+                          "type_name": {
+                            "type": "string",
+                            "description": "特別休暇・休業休職種別名",
+                            "example": "育児休業日"
+                          },
+                          "paid_type": {
+                            "type": "string",
+                            "description": "有給・無給区分（paid: 有給、unpaid: 無休）",
+                            "enum": [
+                              "paid",
+                              "unpaid"
+                            ],
+                            "example": "paid"
+                          },
+                          "attendance_rate_calc_type": {
+                            "type": "string",
+                            "description": "出勤率計算方法（in_workdays: 出勤日数に含める、not_in_workdays: 出勤日数に含めない、not_in_total_workdays: 全労働日に含めない）",
+                            "enum": [
+                              "in_workdays",
+                              "not_in_workdays",
+                              "not_in_total_workdays"
+                            ],
+                            "example": "in_workdays"
+                          },
+                          "usage_day": {
+                            "type": "string",
+                            "description": "最小消化単位（full: 全休、half: 半休、hour: 時間休）",
+                            "enum": [
+                              "full",
+                              "half",
+                              "hour"
+                            ],
+                            "example": "half"
+                          },
+                          "valid_date_from": {
+                            "type": "string",
+                            "description": "有効期間開始日(YYYY-MM-DD)(例:2023-01-01)",
+                            "format": "date"
+                          },
+                          "valid_date_to": {
+                            "type": "string",
+                            "description": "有効期間終了日(YYYY-MM-DD)(例:2023-01-31)",
+                            "format": "date"
+                          },
+                          "days": {
+                            "type": "integer",
+                            "description": "付与日数",
+                            "format": "int32",
+                            "minimum": 0,
+                            "maximum": 2147483647,
+                            "example": 2
+                          },
+                          "used": {
+                            "type": "number",
+                            "description": "使用数",
+                            "format": "float",
+                            "minimum": 0,
+                            "maximum": 999999999.9999,
+                            "example": 0.5
+                          },
+                          "num_days_and_hours_used": {
+                            "type": "object",
+                            "description": "使用日数・時間数",
+                            "properties": {
+                              "days": {
+                                "type": "number",
+                                "description": "日数",
+                                "format": "float",
+                                "example": 0.5
+                              },
+                              "hours": {
+                                "type": "integer",
+                                "description": "時間数",
+                                "format": "int32",
+                                "example": 0
+                              }
+                            }
+                          },
+                          "left": {
+                            "type": "number",
+                            "description": "残数",
+                            "format": "float",
+                            "minimum": 0,
+                            "maximum": 999999999.9999,
+                            "example": 1.5
+                          },
+                          "num_days_and_hours_left": {
+                            "type": "object",
+                            "description": "残日数・時間数",
+                            "properties": {
+                              "days": {
+                                "type": "number",
+                                "description": "日数",
+                                "format": "float",
+                                "example": 1.5
+                              },
+                              "hours": {
+                                "type": "integer",
+                                "description": "時間数",
+                                "format": "int32",
+                                "example": 0
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/employees/{employee_id}/attendance_tag_summaries/{year}/{month}": {
+      "get": {
+        "tags": [
+          "勤怠タグサマリ"
+        ],
+        "summary": "勤怠タグ月次サマリの取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>\n  指定した従業員・年月の勤怠タグサマリを更新します。<br />\n  年月は給与支払い月を指定してください。\n</p>",
+        "operationId": "get_employees_attendance_tag_summaries",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "year",
+            "in": "path",
+            "description": "勤怠タグサマリを取得したい年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100,
+              "example": 2021
+            }
+          },
+          {
+            "name": "month",
+            "in": "path",
+            "description": "勤怠タグサマリを取得したい月",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12,
+              "example": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesAttendanceTagSummariesController.show_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "勤怠タグサマリ"
+        ],
+        "summary": "勤怠タグ月次サマリの更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>\n  指定した従業員・年月の勤怠タグサマリを更新します。<br />\n  年月は給与支払い月を指定してください。\n</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n  <li>指定した従業員・年月の勤怠タグサマリが存在する場合は、上書き更新されます。</li>\n  <li>指定がなかった勤怠タグは自動的に0が設定されます。</li>\n</ul>",
+        "operationId": "update_employees_attendance_tag_summaries",
+        "parameters": [
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "year",
+            "in": "path",
+            "description": "勤怠タグサマリを更新したい年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100,
+              "example": 2021
+            }
+          },
+          {
+            "name": "month",
+            "in": "path",
+            "description": "勤怠タグサマリを更新したい月",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12,
+              "example": 1
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeesAttendanceTagSummariesController.update_body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesAttendanceTagSummariesController.update_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/employees/{employee_id}/attendance_tags": {
+      "get": {
+        "tags": [
+          "勤怠タグ"
+        ],
+        "summary": "勤怠タグ一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の利用可能な勤怠タグの一覧を返します。</p>",
+        "operationId": "get_employees_attendance_tags",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesAttendanceTagsController.index_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/employees/{employee_id}/attendance_tags/{date}": {
+      "get": {
+        "tags": [
+          "勤怠タグ"
+        ],
+        "summary": "勤怠タグと利用回数の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員・日付の勤怠タグと利用回数の一覧を返します。</p>",
+        "operationId": "get_employees_attendance_tags_by_date",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "date",
+            "in": "path",
+            "description": "対象年月日(YYYY-MM-DD)(例:2018-08-01)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeesAttendanceTagsController.show_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "勤怠タグ"
+        ],
+        "summary": "勤怠タグの更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員・日付の勤怠タグを更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>指定した従業員・日付の勤怠タグが存在する場合は、上書き更新されます。</li>\n  <li>指定がなかった勤怠タグは削除されます。</li>\n</ul>",
+        "operationId": "update_employees_attendance_tags",
+        "parameters": [
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "date",
+            "in": "path",
+            "description": "更新対象年月日(YYYY-MM-DD)(例:2018-08-01)",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeesAttendanceTagsController.update_body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "employee_attendance_tags": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ApiV1EmployeesAssignedAttendanceTagSerializer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/salaries/employee_payroll_statements": {
+      "get": {
+        "tags": [
+          "給与明細"
+        ],
+        "summary": "給与明細一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所に所属する従業員の給与明細をリストで返します。</p>\n<p>指定した年月に支払いのある給与明細が返されます。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>複数時給を設定している場合はpaymentsに内訳が返されます。</li>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n  <li>給与計算中の場合は、各パラメータはnullおよび空配列が返ります。</li>\n</ul>",
+        "operationId": "get_salaries_employee_payroll_statements",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "description": "事業所ID"
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            },
+            "description": "従業員情報を取得したい年"
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12
+            },
+            "description": "従業員情報を取得したい月"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "取得レコードの件数 (デフォルト: 50, 最小: 1, 最大: 100)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1SalariesEmployeePayrollStatementsController.index_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/salaries/employee_payroll_statements/{employee_id}": {
+      "get": {
+        "tags": [
+          "給与明細"
+        ],
+        "summary": "給与明細の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員ID、年月の給与明細を返します。</p>\n<p>指定した年月に支払いのある給与明細が返されます。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>複数時給を設定している場合はpaymentsに内訳が返されます。</li>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n  <li>給与計算中の場合は、各パラメータはnullおよび空配列が返ります。</li>\n</ul>\n\n<h2 id=\"_2\">examples</h2>\n<pre>\n  <code>\n  {\n  \"employee_payroll_statement\": {\n    \"id\": 1,\n    \"company_id\": 1,\n    \"employee_id\": 1,\n    \"employee_name\": \"給与 太郎\",\n    \"employee_display_name\": \"給与 太郎\",\n    \"employee_num\": \"001\",\n    \"pay_date\": \"2018-02-25\",\n    \"start_date\": \"2018-02-01\",\n    \"closing_date\": \"2018-02-28\",\n    \"variable_pay_start_date\": \"2018-01-01\",\n    \"variable_pay_closing_date\": \"2018-01-31\",\n    \"fixed\": true,\n    \"calc_status\": \"calculated\",\n    \"calculated_at\": \"2018-09-27T05:06:45.315Z\",\n    \"pay_calc_type\": \"monthly\",\n    \"board_member_remuneration_amount\": \"400000.0\",\n    \"basic_pay_amount\": \"300000.0\",\n    \"work_days\": \"21.0\",\n    \"normal_work_time\": \"8.0\",\n    \"normal_work_days\": \"21.0\",\n    \"work_mins_by_paid_holiday\": \"480.0\",\n    \"num_paid_holidays\": \"1.0\",\n    \"is_board_member\": true,\n    \"total_attendance_deduction_amount\": \"0.0\",\n    \"total_allowance_amount\": \"0.0\",\n    \"total_deduction_amount\": \"23830.0\",\n    \"total_deduction_employer_share\": \"16830.0\",\n    \"net_payment_amount\": \"277170.0\",\n    \"gross_payment_amount\": \"301000.0\",\n    \"total_worked_days_count\": \"21.0\",\n    \"total_taxable_payment_amount\": \"301000.0\",\n    \"total_expense_amount\": \"0.0\",\n    \"total_transfer_amount\": \"277170.0\",\n    \"total_annual_payment_amount\": \"600000.0\",\n    \"payments\": [{ \"name\": \"基本給\", \"amount\": \"300000.0\"},{ \"name\": \"残業代\", \"amount\": \"1000.0\"}],\n    \"deductions\": [{\"name\": \"所得税\", \"amount\": \"7000.0\"}, {\"name\": \"健康保険料\", \"amount\": \"16830.0\"}],\n    \"deductions_emloyers_share\": [{\"name\": \"健康保険料(会社負担分)\", \"amount\": \"16830.0\"}],\n    \"attendances\": [{\"name\": \"遅刻・早退\", \"time\": \"0.0\", \"amount\": \"0.0\"}],\n    \"overtime_pays\": [{ \"name\": \"時間外労働\", \"time\": \"60.0\", \"amount\": \"1000.0\", \"code\": null }, { \"name\": \"カスタム固定残業代\", \"time\": null, \"amount\": \"10000.0\", \"code\": \"a001\" }],\n    \"remark\": \"備考\"\n    }\n  }\n  </code>\n</pre>",
+        "operationId": "get_salaries_employee_payroll_statement",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "description": "事業所ID"
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            },
+            "description": "従業員情報を取得したい年"
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12
+            },
+            "description": "従業員情報を取得したい月"
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1SalariesEmployeePayrollStatementsController.show_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/bonuses/employee_payroll_statements": {
+      "get": {
+        "tags": [
+          "賞与明細"
+        ],
+        "summary": "賞与明細一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所に所属する従業員の賞与明細をリストで返します。</p>\n<p>指定した年月に支払いのある賞与明細が返されます。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>",
+        "operationId": "get_bonuses_employee_payroll_statements",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "description": "事業所ID"
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            },
+            "description": "従業員情報を取得したい年"
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12
+            },
+            "description": "従業員情報を取得したい月"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "取得レコードの件数 (デフォルト: 50, 最小: 1, 最大: 100)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "example": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647,
+              "example": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1BonusesEmployeePayrollStatementsIndexSerializer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/bonuses/employee_payroll_statements/{employee_id}": {
+      "get": {
+        "tags": [
+          "賞与明細"
+        ],
+        "summary": "賞与明細の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員ID、年月の賞与明細を返します。</p>\n<p>指定した年月に支払いのある賞与明細が返されます。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>\n\n<h2 id=\"_2\">examples</h2>\n<pre>\n  <code>\n    {\n    \"employee_payroll_statement\": {\n      \"id\": 1,\n      \"company_id\": 1,\n      \"employee_id\": 1,\n      \"employee_name\": \"給与 太郎\",\n      \"employee_display_name\": \"給与 太郎\",\n      \"employee_num\": \"001\",\n      \"closing_date\": \"2018-03-31\",\n      \"pay_date\": \"2018-03-31\",\n      \"fixed\": true,\n      \"calc_status\": \"calculated\",\n      \"calculated_at\": \"2018-09-27T05:06:45.315Z\",\n      \"bonus_amount\": \"300000.0\",\n      \"total_allowance_amount\": \"0.0\",\n      \"total_deduction_amount\": \"23830.0\",\n      \"net_payment_amount\": \"268000.0\",\n      \"gross_payment_amount\": \"330000.0\",\n      \"total_taxable_payment_amount\": \"330000.0\",\n      \"allowances\": [{\"name\": \"地域手当\", \"amount\": \"30000.0\"}],\n      \"deductions\": [{\"name\": \"所得税\", \"amount\": \"46000.0\"}, {\"name\": \"健康保険料\", \"amount\": \"16000.0\"}],\n      \"remark\": \"備考\"\n    }\n    }\n  </code>\n</pre>",
+        "operationId": "get_bonuses_employee_payroll_statement",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "description": "事業所ID"
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            },
+            "description": "従業員情報を取得したい年"
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12
+            },
+            "description": "従業員情報を取得したい月"
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1BonusesEmployeePayrollStatementsController.show_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/employee_group_memberships": {
+      "get": {
+        "tags": [
+          "所属"
+        ],
+        "summary": "所属一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の指定日付時点における所属情報をリストで返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>",
+        "operationId": "get_employee_group_memberships",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1,
+            "description": "事業所ID"
+          },
+          {
+            "name": "base_date",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "description": "指定日。指定日付時点における所属情報をリストで返します。(YYYY-MM-DD)(例:2018-07-31)",
+            "example": "2018-07-31"
+          },
+          {
+            "name": "with_no_payroll_calculation",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "trueを指定すると給与計算対象外の従業員情報をレスポンスに含めます。",
+            "example": true
+          },
+          {
+            "name": "employee_ids",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "maxLength": 8192
+            },
+            "description": "取得対象とする従業員IDを指定することができます。指定しない場合は全従業員が対象となります。\n(例:1,2,3,4,5)\n"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "取得レコードの件数 (デフォルト: 50, 最小: 1, 最大: 100)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "example": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647,
+              "example": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeeGroupMembershipsIndexSerializer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/groups": {
+      "get": {
+        "tags": [
+          "部門"
+        ],
+        "summary": "部門一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の指定日付時点における部門情報をリストで返します。</p>\n<p>部門APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/groups-api-hierarchy\" target=\"_blank\">部門APIを利用した組織図の取得について</a> をご参照ください。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>",
+        "operationId": "get_groups",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "description": "事業所ID",
+            "example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1GroupsIndexResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "部門"
+        ],
+        "summary": "部門の作成",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の部門を新規作成します。</p>\n<p>部門APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/groups-api-hierarchy\" target=\"_blank\">部門APIを利用した組織図の取得について</a> をご参照ください。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>",
+        "operationId": "create_group",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1GroupCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1GroupResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/groups/{id}": {
+      "put": {
+        "tags": [
+          "部門"
+        ],
+        "summary": "部門の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の部門の情報を更新します。</p>\n<p>部門APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/groups-api-hierarchy\" target=\"_blank\">部門APIを利用した組織図の取得について</a> をご参照ください。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>",
+        "operationId": "update_group",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "部門ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1GroupUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1GroupResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "部門"
+        ],
+        "summary": "部門の削除",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の部門の情報を削除します。</p>\n<p>部門APIの使い方については、<a href=\"https://developer.freee.co.jp/tips/groups-api-hierarchy\" target=\"_blank\">部門APIを利用した組織図の取得について</a> をご参照ください。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>",
+        "operationId": "destroy_group",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "部門ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/positions": {
+      "get": {
+        "tags": [
+          "役職"
+        ],
+        "summary": "役職一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の指定日付時点における役職情報をリストで返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>",
+        "operationId": "get_positions",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "description": "事業所ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1PositionIndexResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "役職"
+        ],
+        "summary": "役職の作成",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の役職を新規作成します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>",
+        "operationId": "create_position",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1PositionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1PositionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/positions/{id}": {
+      "put": {
+        "tags": [
+          "役職"
+        ],
+        "summary": "役職の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の役職の情報を更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n</ul>",
+        "operationId": "update_position",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "役職ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1PositionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1PositionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "役職"
+        ],
+        "summary": "役職の削除",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の役職の情報を削除します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>管理者権限を持ったユーザーのみ実行可能です。</li>\n  <li>従業員に役職が適用されている場合、従業員の役職情報も削除されます。</li>\n</ul>",
+        "operationId": "destroy_position",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "役職ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/monthly_attendances": {
+      "get": {
+        "tags": [
+          "月次勤怠締め申請"
+        ],
+        "summary": "月次勤怠締め申請一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の指定日付時点における月次勤怠締め申請情報をリストで返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n</ul>",
+        "operationId": "get_approval_requests_monthly_attendances",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "description": "事業所ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "申請ステータス\n- `draft` - 下書き\n- `in_progress` - 申請中\n- `approved` - 承認済\n- `feedback` - 差戻し",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "draft",
+                "in_progress",
+                "approved",
+                "feedback"
+              ],
+              "example": "in_progress"
+            }
+          },
+          {
+            "name": "application_number",
+            "in": "query",
+            "description": "申請No",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "start_issue_date",
+            "in": "query",
+            "description": "申請開始日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "end_issue_date",
+            "in": "query",
+            "description": "申請終了日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "approver_id",
+            "in": "query",
+            "description": "現在承認ステップの承認者のユーザーID\n\napprover_idに値を指定する場合、指定なしの申請経路を利用した申請は返却されません\n",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "applicant_id",
+            "in": "query",
+            "description": "申請者のユーザーID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "start_target_date",
+            "in": "query",
+            "description": "対象開始日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "end_target_date",
+            "in": "query",
+            "description": "対象終了日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "passed_auto_check",
+            "in": "query",
+            "description": "自動チェック結果\n- trueを指定した場合、自動チェック結果がtrueの申請のみ返却します。\n- falseを指定した場合、自動チェック結果がfalseの申請のみ返却します。\n- キーごと指定しない場合、すべての申請を返却します。",
+            "schema": {
+              "type": "boolean"
+            },
+            "example": false
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "取得レコードの件数 (デフォルト: 50, 最小: 1, 最大: 100)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "example": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647,
+              "example": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1MonthlyAttendanceIndexResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "月次勤怠締め申請"
+        ],
+        "summary": "月次勤怠締め申請の作成",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の月次勤怠締め申請を新規作成します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "create_approval_requests_monthly_attendance",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1MonthlyAttendanceCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1MonthlyAttendanceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/monthly_attendances/{id}": {
+      "get": {
+        "tags": [
+          "月次勤怠締め申請"
+        ],
+        "summary": "月次勤怠締め申請の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の月次勤怠締め申請情報を取得します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "get_approval_requests_monthly_attendance",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "description": "事業所ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "月次勤怠締め申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1MonthlyAttendanceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "月次勤怠締め申請"
+        ],
+        "summary": "月次勤怠締め申請の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の月次勤怠締め申請情報を更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "update_approval_requests_monthly_attendance",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "月次勤怠締め申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1MonthlyAttendanceUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1MonthlyAttendanceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "月次勤怠締め申請"
+        ],
+        "summary": "月次勤怠締め申請の削除",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の月次勤怠締め申請情報を削除します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n</ul>",
+        "operationId": "destroy_approval_requests_monthly_attendance",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "月次勤怠締め申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/monthly_attendances/{id}/actions": {
+      "post": {
+        "tags": [
+          "月次勤怠締め申請"
+        ],
+        "summary": "月次勤怠締め申請の承認操作",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の月次勤怠締め申請情報を承認操作します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "action_approval_requests_monthly_attendance",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "月次勤怠締め申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1ApprovalActionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1MonthlyAttendanceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/work_times": {
+      "get": {
+        "tags": [
+          "勤務時間修正申請"
+        ],
+        "summary": "勤務時間修正申請一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の指定日付時点における勤務時間修正申請情報をリストで返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n</ul>",
+        "operationId": "get_approval_requests_work_times",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "description": "事業所ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "申請ステータス\n- `draft` - 下書き\n- `in_progress` - 申請中\n- `approved` - 承認済\n- `feedback` - 差戻し",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "draft",
+                "in_progress",
+                "approved",
+                "feedback"
+              ],
+              "example": "in_progress"
+            }
+          },
+          {
+            "name": "application_number",
+            "in": "query",
+            "description": "申請No",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "start_issue_date",
+            "in": "query",
+            "description": "申請開始日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2023-04-01"
+          },
+          {
+            "name": "end_issue_date",
+            "in": "query",
+            "description": "申請終了日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2023-04-01"
+          },
+          {
+            "name": "approver_id",
+            "in": "query",
+            "description": "現在承認ステップの承認者のユーザーID\napprover_idに値を指定する場合、指定なしの申請経路を利用した申請は返却されません\n",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "applicant_id",
+            "in": "query",
+            "description": "申請者のユーザーID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "start_target_date",
+            "in": "query",
+            "description": "対象開始日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2023-04-01"
+          },
+          {
+            "name": "end_target_date",
+            "in": "query",
+            "description": "対象終了日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2023-04-01"
+          },
+          {
+            "name": "passed_auto_check",
+            "in": "query",
+            "description": "自動チェック結果\n- trueを指定した場合、自動チェック結果がtrueの申請のみ返却します。\n- falseを指定した場合、自動チェック結果がfalseの申請のみ返却します。\n- キーごと指定しない場合、すべての申請を返却します。",
+            "schema": {
+              "type": "boolean"
+            },
+            "example": false
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "取得レコードの件数 (デフォルト: 50, 最小: 1, 最大: 100)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "example": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647,
+              "example": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "work_times",
+                    "total_count"
+                  ],
+                  "properties": {
+                    "work_times": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ApiV1WorkTimeIndexResponseParams"
+                      }
+                    },
+                    "total_count": {
+                      "type": "integer",
+                      "description": "合計件数",
+                      "format": "int32",
+                      "minimum": 0,
+                      "maximum": 2147483647,
+                      "example": 1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "勤務時間修正申請"
+        ],
+        "summary": "勤務時間修正申請の作成",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の勤務時間修正を新規作成します。</p>\n\n<h2 id=\"_2\">examples</h2>\n<ul>\n  <li>勤務時間を修正する場合は以下のようなパラメータを指定します。\n    <pre>\n      <code>\n        {\n          \"company_id\": 1,\n          \"target_date\": \"2017-05-25\",\n          \"break_records\": [\n            {\n              \"clock_in_at\": \"2017-05-25 12:00:00\",\n              \"clock_out_at\": \"2017-05-25 13:00:00\"\n            }\n          ],\n          \"work_records\": [\n            {\n              \"clock_in_at\": \"2017-05-25 09:10:00\",\n              \"clock_out_at\": \"2017-05-25 18:20:00\"\n            }\n          ],\n          \"approval_flow_route_id\": 1\n        }\n      </code>\n    </pre>\n  </li>\n</ul>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "create_approval_requests_work_time",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "company_id",
+                  "target_date",
+                  "approval_flow_route_id"
+                ],
+                "properties": {
+                  "company_id": {
+                    "type": "integer",
+                    "description": "事業所ID（必須）",
+                    "format": "int32",
+                    "minimum": 1,
+                    "maximum": 2147483647,
+                    "example": 1
+                  },
+                  "target_date": {
+                    "type": "string",
+                    "description": "対象日（必須）",
+                    "format": "date",
+                    "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+                  },
+                  "clear_work_time": {
+                    "type": "boolean",
+                    "description": "false: 勤務時間を修正する  \ntrue: 勤務時間を削除する\n\n勤務時間を削除する場合は以下のパラメータは指定しないでください。\n- work_records\n- lateness_mins\n- early_leaving_mins\n- break_records",
+                    "default": false
+                  },
+                  "work_records": {
+                    "type": "array",
+                    "description": "勤務時間のリスト",
+                    "items": {
+                      "$ref": "#/components/schemas/ApiV1WorkTimeIndexResponseParams/properties/work_records/items"
+                    }
+                  },
+                  "lateness_mins": {
+                    "type": "integer",
+                    "description": "遅刻分の時間（分単位）",
+                    "format": "int32"
+                  },
+                  "early_leaving_mins": {
+                    "type": "integer",
+                    "description": "早退分の時間（分単位）",
+                    "format": "int32"
+                  },
+                  "break_records": {
+                    "type": "array",
+                    "description": "休憩時間のリスト",
+                    "items": {
+                      "$ref": "#/components/schemas/ApiV1WorkTimeIndexResponseParams/properties/break_records/items"
+                    }
+                  },
+                  "comment": {
+                    "type": "string",
+                    "description": "申請理由",
+                    "maxLength": 255,
+                    "example": "申請理由"
+                  },
+                  "approval_flow_route_id": {
+                    "type": "integer",
+                    "description": "申請経路ID（必須）",
+                    "format": "int32",
+                    "minimum": 1,
+                    "maximum": 2147483647,
+                    "example": 1
+                  },
+                  "approver_id": {
+                    "type": "integer",
+                    "description": "承認者のユーザーID",
+                    "format": "int32",
+                    "minimum": 1,
+                    "maximum": 2147483647,
+                    "example": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "work_time"
+                  ],
+                  "properties": {
+                    "work_time": {
+                      "$ref": "#/components/schemas/ApiV1WorkTimeResponseParams"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/work_times/{id}": {
+      "get": {
+        "tags": [
+          "勤務時間修正申請"
+        ],
+        "summary": "勤務時間修正申請の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の勤務時間修正申請情報を取得します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "get_approval_requests_work_time",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "description": "事業所ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "勤務時間修正申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1api~1v1~1approval_requests~1work_times/post/responses/201/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "勤務時間修正申請"
+        ],
+        "summary": "勤務時間修正申請の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の勤務時間修正申請情報を更新します。</p>\n\n<h2 id=\"_2\">examples</h2>\n<ul>\n  <li>勤務時間を修正する場合は以下のようなパラメータを指定します。\n    <pre>\n      <code>\n        {\n          \"company_id\": 1,\n          \"target_date\": \"2017-05-25\",\n          \"break_records\": [\n            {\n              \"clock_in_at\": \"2017-05-25 12:00:00\",\n              \"clock_out_at\": \"2017-05-25 13:00:00\"\n            }\n          ],\n          \"work_records\": [\n            {\n              \"clock_in_at\": \"2017-05-25 09:10:00\",\n              \"clock_out_at\": \"2017-05-25 18:20:00\"\n            }\n          ],\n          \"approval_flow_route_id\": 1\n        }\n      </code>\n    </pre>\n  </li>\n</ul>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "update_approval_requests_work_time",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "勤務時間修正申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/paths/~1api~1v1~1approval_requests~1work_times/post/requestBody/content/application~1json/schema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1api~1v1~1approval_requests~1work_times/post/responses/201/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "勤務時間修正申請"
+        ],
+        "summary": "勤務時間修正申請の削除",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の勤務時間修正申請情報を削除します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n</ul>",
+        "operationId": "destroy_approval_requests_work_time",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "勤務時間修正申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/work_times/{id}/actions": {
+      "post": {
+        "tags": [
+          "勤務時間修正申請"
+        ],
+        "summary": "勤務時間修正申請の承認操作",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の勤務時間修正申請情報を承認操作します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "action_approval_requests_work_time",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "勤務時間修正申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1ApprovalActionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1api~1v1~1approval_requests~1work_times/post/responses/201/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/paid_holidays": {
+      "get": {
+        "tags": [
+          "有給申請"
+        ],
+        "summary": "有給申請一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の指定日付時点における有給申請情報をリストで返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "get_approval_requests_paid_holidays",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "description": "事業所ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "申請ステータス\n- `draft` - 下書き\n- `in_progress` - 申請中\n- `approved` - 承認済\n- `feedback` - 差戻し",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "draft",
+                "in_progress",
+                "approved",
+                "feedback"
+              ],
+              "example": "in_progress"
+            }
+          },
+          {
+            "name": "application_number",
+            "in": "query",
+            "description": "申請No",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "start_issue_date",
+            "in": "query",
+            "description": "申請開始日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "end_issue_date",
+            "in": "query",
+            "description": "申請終了日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "approver_id",
+            "in": "query",
+            "description": "現在承認ステップの承認者のユーザーID\n\napprover_idに値を指定する場合、指定なしの申請経路を利用した申請は返却されません\n",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "applicant_id",
+            "in": "query",
+            "description": "申請者のユーザーID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "start_target_date",
+            "in": "query",
+            "description": "対象開始日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "end_target_date",
+            "in": "query",
+            "description": "対象終了日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "passed_auto_check",
+            "in": "query",
+            "description": "自動チェック結果\n- trueを指定した場合、自動チェック結果がtrueの申請のみ返却します。\n- falseを指定した場合、自動チェック結果がfalseの申請のみ返却します。\n- キーごと指定しない場合、すべての申請を返却します。",
+            "schema": {
+              "type": "boolean"
+            },
+            "example": false
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "取得レコードの件数 (デフォルト: 50, 最小: 1, 最大: 100)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "example": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647,
+              "example": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1PaidHolidayIndexResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "有給申請"
+        ],
+        "summary": "有給申請の作成",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の有給申請を新規作成します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "create_approval_requests_paid_holiday",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ApiV1PaidHolidayRequest"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LegacyApiV1PaidHolidayRequest"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1PaidHolidayResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/paid_holidays/{id}": {
+      "get": {
+        "tags": [
+          "有給申請"
+        ],
+        "summary": "有給申請の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の有給申請情報を取得します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "get_approval_requests_paid_holiday",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "description": "事業所ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "有給申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1PaidHolidayResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "有給申請"
+        ],
+        "summary": "有給申請の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の有給申請情報を更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "update_approval_requests_paid_holiday",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "有給申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ApiV1PaidHolidayRequest"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LegacyApiV1PaidHolidayRequest"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1PaidHolidayResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "有給申請"
+        ],
+        "summary": "有給申請の削除",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の有給申請情報を削除します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n</ul>",
+        "operationId": "destroy_approval_requests_paid_holiday",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "有給申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/paid_holidays/{id}/actions": {
+      "post": {
+        "tags": [
+          "有給申請"
+        ],
+        "summary": "有給申請の承認操作",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の有給申請情報を承認操作します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>全休の有給申請は承認されると申請者の有給の残数が減ります。</li>\n  <li>半休と時間休の有給申請は承認されても申請者の有給の残数が減らない場合があります。以下の条件を満たす場合、申請者の有給の残数が減ります。</li>\n  <ul>\n    <li>申請承認後、申請者が申請の対象日に出勤打刻と退勤打刻をする。</li>\n    <li>申請承認前に、申請者が申請の対象日に勤怠を登録している。</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "action_approval_requests_paid_holiday",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "有給申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1ApprovalActionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1PaidHolidayResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/special_holidays": {
+      "get": {
+        "tags": [
+          "特別休暇申請"
+        ],
+        "summary": "特別休暇申請一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の指定日付時点における特別休暇申請情報をリストで返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "get_approval_requests_special_holidays",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "description": "事業所ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "申請ステータス\n- `draft` - 下書き\n- `in_progress` - 申請中\n- `approved` - 承認済\n- `feedback` - 差戻し",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "draft",
+                "in_progress",
+                "approved",
+                "feedback"
+              ],
+              "example": "in_progress"
+            }
+          },
+          {
+            "name": "application_number",
+            "in": "query",
+            "description": "申請No",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "start_issue_date",
+            "in": "query",
+            "description": "申請開始日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "end_issue_date",
+            "in": "query",
+            "description": "申請終了日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "approver_id",
+            "in": "query",
+            "description": "現在承認ステップの承認者のユーザーID\n\napprover_idに値を指定する場合、指定なしの申請経路を利用した申請は返却されません\n",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "applicant_id",
+            "in": "query",
+            "description": "申請者のユーザーID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "start_target_date",
+            "in": "query",
+            "description": "対象開始日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "end_target_date",
+            "in": "query",
+            "description": "対象終了日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "passed_auto_check",
+            "in": "query",
+            "description": "自動チェック結果\n- trueを指定した場合、自動チェック結果がtrueの申請のみ返却します。\n- falseを指定した場合、自動チェック結果がfalseの申請のみ返却します。\n- キーごと指定しない場合、すべての申請を返却します。",
+            "schema": {
+              "type": "boolean"
+            },
+            "example": false
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "取得レコードの件数 (デフォルト: 50, 最小: 1, 最大: 100)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "example": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647,
+              "example": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1specialHolidayIndexResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "特別休暇申請"
+        ],
+        "summary": "特別休暇申請の作成",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の特別休暇申請を新規作成します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "create_approval_requests_special_holiday",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1specialHolidayRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1specialHolidayResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/special_holidays/{id}": {
+      "get": {
+        "tags": [
+          "特別休暇申請"
+        ],
+        "summary": "特別休暇申請の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の特別休暇申請情報を取得します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "get_approval_requests_special_holiday",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "description": "事業所ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "特別休暇申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1specialHolidayResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "特別休暇申請"
+        ],
+        "summary": "特別休暇申請の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の特別休暇申請情報を更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "update_approval_requests_special_holiday",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "特別休暇申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1specialHolidayRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1specialHolidayResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "特別休暇申請"
+        ],
+        "summary": "特別休暇申請の削除",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の特別休暇申請情報を削除します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n</ul>",
+        "operationId": "destroy_approval_requests_special_holiday",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "特別休暇申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/special_holidays/{id}/actions": {
+      "post": {
+        "tags": [
+          "特別休暇申請"
+        ],
+        "summary": "特別休暇申請の承認操作",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の特別休暇申請情報を承認操作します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>全休の特別休暇申請は承認されると申請者の特別休暇の残数が減ります。</li>\n  <li>半休と時間休の特別休暇申請は承認されても申請者の特別休暇の残数が減らない場合があります。以下の条件を満たす場合、申請者の特別休暇の残数が減ります。</li>\n  <ul>\n    <li>申請承認後、申請者が申請の対象日に出勤打刻と退勤打刻をする。</li>\n    <li>申請承認前に、申請者が申請の対象日に勤怠を登録している。</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "action_approval_requests_special_holiday",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "特別休暇申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1ApprovalActionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1specialHolidayResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/overtime_works": {
+      "get": {
+        "tags": [
+          "残業申請"
+        ],
+        "summary": "残業申請一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の指定日付時点における残業申請情報をリストで返します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n</ul>",
+        "operationId": "get_approval_requests_overtime_works",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "description": "事業所ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "申請ステータス\n- `draft` - 下書き\n- `in_progress` - 申請中\n- `approved` - 承認済\n- `feedback` - 差戻し",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "draft",
+                "in_progress",
+                "approved",
+                "feedback"
+              ],
+              "example": "in_progress"
+            }
+          },
+          {
+            "name": "application_number",
+            "in": "query",
+            "description": "申請No",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "start_issue_date",
+            "in": "query",
+            "description": "申請開始日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "end_issue_date",
+            "in": "query",
+            "description": "申請終了日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "approver_id",
+            "in": "query",
+            "description": "現在承認ステップの承認者のユーザーID\n\napprover_idに値を指定する場合、指定なしの申請経路を利用した申請は返却されません\n",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "applicant_id",
+            "in": "query",
+            "description": "申請者のユーザーID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "start_target_date",
+            "in": "query",
+            "description": "対象開始日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "end_target_date",
+            "in": "query",
+            "description": "対象終了日",
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "example": "2022-02-01"
+          },
+          {
+            "name": "passed_auto_check",
+            "in": "query",
+            "description": "自動チェック結果\n- trueを指定した場合、自動チェック結果がtrueの申請のみ返却します。\n- falseを指定した場合、自動チェック結果がfalseの申請のみ返却します。\n- キーごと指定しない場合、すべての申請を返却します。",
+            "schema": {
+              "type": "boolean"
+            },
+            "example": false
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "取得レコードの件数 (デフォルト: 50, 最小: 1, 最大: 100)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "example": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647,
+              "example": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1OvertimeWorkIndexResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "残業申請"
+        ],
+        "summary": "残業申請の作成",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の残業申請を新規作成します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請の内容を勤怠に反映させるかの設定次第でリクエスト時に指定するパラメータが異なります。残業申請に必要な設定情報の取得APIで確認してください。</li>\n  <ul>\n    <li>勤怠に反映する設定の場合</li>\n    <ul>\n      <li>設定情報の取得APIで受け取った値を用いてパラメータを指定します。</li>\n      <li>早出（early_work_start_at, early_work_end_at）か残業（overtime_work_start_at, overtime_work_end_at）のどちらか、もしくは両方を指定してください。</li>\n      <ul>\n        <li>早出・残業両方とも指定しなかった場合は取り消し申請となります。対象日の承認済み残業申請は全て取り消され、打刻データがあれば勤怠に反映し直します。</li>\n      </ul>\n      <li>早出の終了時刻（early_work_end_at）は所定の出勤時刻と同じ、残業の開始時刻（overtime_work_start_at）は所定の退勤時刻と同じ時刻を指定する必要があります。</li>\n      <li>早出・残業の時刻に指定できる分の単位はそれぞれ設定（early_work_mins_unit, overtime_work_mins_unit）の通りです。</li>\n    </ul>\n    <li>勤怠に反映しない設定の場合</li>\n    <ul>\n      <li>残業開始（start_at）と残業終了（end_at）を指定してください。</li>\n    </ul>\n  </ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "create_approval_requests_overtime_work",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1OvertimeWorkRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1OvertimeWorkResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/overtime_works/{id}": {
+      "get": {
+        "tags": [
+          "残業申請"
+        ],
+        "summary": "残業申請の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の残業申請情報を取得します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "get_approval_requests_overtime_work",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "description": "事業所ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "残業申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1OvertimeWorkResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "残業申請"
+        ],
+        "summary": "残業申請の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の残業申請情報を更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請の内容を勤怠に反映させるかの設定次第でリクエスト時に指定するパラメータが異なります。残業申請に必要な設定情報の取得APIで確認してください。</li>\n  <ul>\n    <li>勤怠に反映する設定の場合</li>\n    <ul>\n      <li>設定情報の取得APIで受け取った値を用いてパラメータを指定します。</li>\n      <li>早出（early_work_start_at, early_work_end_at）か残業（overtime_work_start_at, overtime_work_end_at）のどちらか、もしくは両方を指定してください。</li>\n      <ul>\n        <li>早出・残業両方とも指定しなかった場合は取り消し申請となります。対象日の承認済み残業申請は全て取り消され、打刻データがあれば勤怠に反映し直します。</li>\n      </ul>\n      <li>早出の終了時刻（early_work_end_at）は所定の出勤時刻と同じ、残業の開始時刻（overtime_work_start_at）は所定の退勤時刻と同じ時刻を指定する必要があります。</li>\n      <li>早出・残業の時刻に指定できる分の単位はそれぞれ設定（early_work_mins_unit, overtime_work_mins_unit）の通りです。</li>\n    </ul>\n    <li>勤怠に反映しない設定の場合</li>\n    <ul>\n      <li>残業開始（start_at）と残業終了（end_at）を指定してください。</li>\n    </ul>\n  </ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "update_approval_requests_overtime_work",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "残業申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1OvertimeWorkRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1OvertimeWorkResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "残業申請"
+        ],
+        "summary": "残業申請の削除",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の残業申請情報を削除します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n</ul>",
+        "operationId": "destroy_approval_requests_overtime_work",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "残業申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/overtime_works/{id}/actions": {
+      "post": {
+        "tags": [
+          "残業申請"
+        ],
+        "summary": "残業申請の承認操作",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の残業申請情報を承認操作します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n  <li>申請者と承認者が同一ユーザーの場合、feedback(差戻し)をするとレスポンスは以下のようになります。</li>\n  <ul>\n    <li>status: draft</li>\n    <li>approval_flow_logs.action: cancel</li>\n  </ul>\n</ul>",
+        "operationId": "action_approval_requests_overtime_work",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "残業申請ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1ApprovalActionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1OvertimeWorkResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_requests/overtime_works/setting": {
+      "get": {
+        "tags": [
+          "残業申請"
+        ],
+        "summary": "残業申請に必要な設定情報の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員・日付の残業申請に必要な設定情報を取得します。</p>\n<ul>\n  <li>取得できる設定の一覧</li>\n  <ul>\n    <li>勤怠カレンダーに申請を反映するかどうかの設定</li>\n    <ul>\n      <li>この設定により、残業申請の作成や更新のリクエスト時に使用するパラメータが変わります。詳細は、残業申請の作成や更新の仕様を参照してください。</li>\n    </ul>\n    <li>所定の出退勤時間</li>\n    <ul>\n      <li>反映あり申請の場合、残業申請の作成や更新のリクエスト時に所定の出退勤時間が必要になります。詳細は、残業申請の作成や更新の仕様を参照してください。</li>\n    </ul>\n    <li>申請で指定できる分の単位</li>\n    <ul>\n      <li>反映あり申請の場合、勤務賃金設定の申請の単位設定によって、残業申請できる分単位が変わります。</li>\n    </ul>\n  </ul>\n</ul>",
+        "operationId": "get_approval_requests_overtime_work_setting",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "description": "事業所ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "example": 1
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "description": "対象日(YYYY-MM-DD)(例:2018-08-01)\n- 申請の対象日を指定してください。",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "2018-08-01"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "start_at": {
+                      "description": "所定出勤時刻",
+                      "type": "string",
+                      "format": "date-time",
+                      "example": "12:00"
+                    },
+                    "end_at": {
+                      "description": "所定退勤時刻",
+                      "type": "string",
+                      "format": "date-time",
+                      "example": "23:59"
+                    },
+                    "should_reflect_in_work_record": {
+                      "description": "勤務カレンダーに反映するかどうか",
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "early_work_mins_unit": {
+                      "description": "早出に指定できる分の単位",
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "example": [
+                          0,
+                          15,
+                          30,
+                          45
+                        ]
+                      }
+                    },
+                    "overtime_work_mins_unit": {
+                      "description": "残業に指定できる分の単位",
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "example": [
+                          0,
+                          30
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "should_reflect_in_work_record"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_flow_routes": {
+      "get": {
+        "tags": [
+          "申請経路"
+        ],
+        "summary": "申請経路一覧の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の申請経路一覧を取得する。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>指定した事業所の従業員に紐づくユーザーのみ実行可能です。</li>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n</ul>",
+        "operationId": "get_approval_flow_routes",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "included_user_id",
+            "in": "query",
+            "description": "経路に含まれるユーザーのユーザーID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "usage",
+            "in": "query",
+            "description": "申請種別（申請経路を使用できる申請種別を示します。例えば、AttendanceWorkflow の場合は、勤怠申請で使用できる申請経路です。）\n- `AttendanceWorkflow` - 勤怠申請\n- `PersonalDataWorkflow` - 身上変更申請",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "AttendanceWorkflow",
+                "PersonalDataWorkflow"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1ApprovalFlowRoutesIndexResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/approval_flow_routes/{id}": {
+      "get": {
+        "tags": [
+          "申請経路"
+        ],
+        "summary": "申請経路の取得",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した事業所の申請経路を取得する。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>指定した事業所の従業員に紐づくユーザーのみ実行可能です。</li>\n  <li>申請経路、承認者の指定として部門役職データ連携を活用し、以下のいずれかを利用している申請と申請経路はAPI経由で参照は可能ですが、作成と更新、承認ステータスの変更ができません。</li>\n  <ul>\n    <li>役職指定（申請者の所属部門）</li>\n    <li>役職指定（申請時に部門指定）</li>\n    <li>部門および役職指定</li>\n  </ul>\n</ul>",
+        "operationId": "get_approval_flow_route",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "申請経路ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "company_id",
+            "in": "query",
+            "description": "事業所ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1ApprovalFlowRouteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/yearend_adjustments/{year}/employees": {
+      "get": {
+        "tags": [
+          "年末調整"
+        ],
+        "summary": "年末調整対象一覧の取得",
+        "description": "\n指定した年の年末調整対象のリスト返します。",
+        "operationId": "get_yearend_adjustment_employees",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "description": "事業所ID"
+          },
+          {
+            "name": "year",
+            "in": "path",
+            "description": "年末調整対象を取得したい年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "取得レコードの件数 (デフォルト: 50, 最小: 1, 最大: 100)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.index_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/yearend_adjustments/{year}/employees/{employee_id}": {
+      "get": {
+        "tags": [
+          "年末調整"
+        ],
+        "summary": "年末調整の取得",
+        "description": "指定した年、従業員IDの年末調整の詳細内容を返します。<br>\n年末調整対象外の従業員は、本人情報、給与・賞与、前職情報のみが取得できます。",
+        "operationId": "get_yearend_adjustment_employee",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "description": "事業所ID"
+          },
+          {
+            "name": "year",
+            "in": "path",
+            "description": "年末調整を取得したい年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.show_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "年末調整"
+        ],
+        "summary": "年末調整従業員情報の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の姓名・住所などを更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>本APIは、年末調整が確定済みの従業員には非対応です。</li>\n</ul>",
+        "operationId": "put_yearend_adjustment_employee",
+        "parameters": [
+          {
+            "name": "year",
+            "in": "path",
+            "description": "更新対象年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_employee_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_employee_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/yearend_adjustments/{year}/payroll_and_bonus/{employee_id}": {
+      "put": {
+        "tags": [
+          "年末調整"
+        ],
+        "summary": "年末調整従業員給与・賞与の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の給与・賞与を更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>本APIは、年末調整が確定済みの従業員には非対応です。</li>\n</ul>",
+        "operationId": "put_yearend_adjustment_payroll_and_bonus",
+        "parameters": [
+          {
+            "name": "year",
+            "in": "path",
+            "description": "更新対象年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_payroll_and_bonus_body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_payroll_and_bonus_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/yearend_adjustments/{year}/dependents/{employee_id}": {
+      "put": {
+        "tags": [
+          "年末調整"
+        ],
+        "summary": "年末調整家族情報の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した年末調整の家族情報を更新します。</p>\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>本APIは、年末調整が確定済みの従業員には非対応です。</li>\n  <li>idがない場合は新規作成、destroyがtrueの場合は削除になります。</li>\n</ul>",
+        "operationId": "put_yearend_adjustment_dependents",
+        "parameters": [
+          {
+            "name": "year",
+            "in": "path",
+            "description": "更新対象年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_dependents_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_dependents_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/yearend_adjustments/{year}/previous_jobs/{employee_id}": {
+      "put": {
+        "tags": [
+          "年末調整"
+        ],
+        "summary": "年末調整従業員前職情報の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の前職情報を更新します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>本APIは、年末調整が確定済みの従業員には非対応です。</li>\n</ul>",
+        "operationId": "put_yearend_adjustment_previous_job",
+        "parameters": [
+          {
+            "name": "year",
+            "in": "path",
+            "description": "更新対象年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_previous_job_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_previous_job_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "年末調整"
+        ],
+        "summary": "年末調整従業員前職情報の削除",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の前職情報を削除します。</p>\n\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>本APIは、年末調整が確定済みの従業員には非対応です。</li>\n</ul>",
+        "operationId": "destroy_yearend_adjustment_previous_job",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "description": "事業所ID"
+          },
+          {
+            "name": "year",
+            "in": "path",
+            "description": "更新対象年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/yearend_adjustments/{year}/insurances/{employee_id}": {
+      "post": {
+        "tags": [
+          "年末調整"
+        ],
+        "summary": "年末調整従業員保険料情報の作成",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の保険料情報を作成します。</p>\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>本APIは、年末調整が確定済みの従業員には非対応です。</li>\n</ul>",
+        "operationId": "post_yearend_adjustment_insurances",
+        "parameters": [
+          {
+            "name": "year",
+            "in": "path",
+            "description": "作成対象年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_insurance_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_insurance_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/yearend_adjustments/{year}/insurances/{employee_id}/{id}": {
+      "put": {
+        "tags": [
+          "年末調整"
+        ],
+        "summary": "年末調整従業員保険料情報の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の保険料情報を更新します。</p>\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>本APIは、年末調整が確定済みの従業員には非対応です。</li>\n  <li>certification_type=\"xml\"の場合、recipient_first_name、recipient_last_name、recipient_relationshipのみが更新の対象となります。</li>\n</ul>",
+        "operationId": "put_yearend_adjustment_insurances",
+        "parameters": [
+          {
+            "name": "year",
+            "in": "path",
+            "description": "更新対象年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "保険料ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_insurance_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_insurance_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "年末調整"
+        ],
+        "summary": "年末調整従業員保険料情報の削除",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の保険料情報を削除します。</p>\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>本APIは、年末調整が確定済みの従業員には非対応です。</li>\n</ul>",
+        "operationId": "destroy_yearend_adjustment_insurances",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "description": "事業所ID"
+          },
+          {
+            "name": "year",
+            "in": "path",
+            "description": "更新対象年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "保険料ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/yearend_adjustments/{year}/housing_loan_deductions/{employee_id}": {
+      "put": {
+        "tags": [
+          "年末調整"
+        ],
+        "summary": "年末調整従業員住宅ローン控除額の更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の住宅ローン控除額を更新します。</p>\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>本APIは、年末調整が確定済みの従業員には非対応です。</li>\n</ul>",
+        "operationId": "put_yearend_adjustment_housing_loan_deduction",
+        "parameters": [
+          {
+            "name": "year",
+            "in": "path",
+            "description": "更新対象年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "company_id",
+                  "housing_loan_deduction"
+                ],
+                "properties": {
+                  "company_id": {
+                    "type": "integer",
+                    "description": "更新対象事業所ID（必須）",
+                    "format": "int32",
+                    "minimum": 1,
+                    "maximum": 2147483647,
+                    "example": 1
+                  },
+                  "housing_loan_deduction": {
+                    "type": "integer",
+                    "description": "住宅借入金等特別控除（必須）",
+                    "format": "int32",
+                    "minimum": 0,
+                    "maximum": 999999999,
+                    "example": 1
+                  }
+                }
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "housing_loan_deduction": {
+                      "type": "integer",
+                      "description": "住宅借入金等特別控除",
+                      "format": "int32",
+                      "minimum": 0,
+                      "maximum": 999999999,
+                      "example": 1
+                    },
+                    "housing_loans": {
+                      "type": "array",
+                      "description": "住宅ローン",
+                      "items": {
+                        "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentHousingLoanSerializer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/yearend_adjustments/{year}/housing_loans/{employee_id}": {
+      "post": {
+        "tags": [
+          "年末調整"
+        ],
+        "summary": "年末調整従業員住宅ローンの作成",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の住宅ローンを作成します。</p>\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>本APIは、年末調整が確定済みの従業員には非対応です。</li>\n</ul>",
+        "operationId": "post_yearend_adjustment_housing_loan",
+        "parameters": [
+          {
+            "name": "year",
+            "in": "path",
+            "description": "作成対象年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_housing_loan_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_housing_loan_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/yearend_adjustments/{year}/housing_loans/{employee_id}/{id}": {
+      "put": {
+        "tags": [
+          "年末調整"
+        ],
+        "summary": "年末調整従業員住宅ローンの更新",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の住宅ローンを更新します。</p>\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>本APIは、年末調整が確定済みの従業員には非対応です。</li>\n</ul>",
+        "operationId": "put_yearend_adjustment_housing_loan",
+        "parameters": [
+          {
+            "name": "year",
+            "in": "path",
+            "description": "更新対象年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "住宅ローンID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_housing_loan_body"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentController.update_housing_loan_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "年末調整"
+        ],
+        "summary": "年末調整従業員住宅ローンの削除",
+        "description": "<h2 id=\"\">概要</h2>\n<p>指定した従業員の住宅ローンを削除します。</p>\n<h2 id=\"_1\">注意点</h2>\n<ul>\n  <li>本APIは、年末調整が確定済みの従業員には非対応です。</li>\n</ul>",
+        "operationId": "destroy_yearend_adjustment_housing_loan",
+        "parameters": [
+          {
+            "name": "company_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            },
+            "description": "事業所ID"
+          },
+          {
+            "name": "year",
+            "in": "path",
+            "description": "更新対象年",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 2000,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "employee_id",
+            "in": "path",
+            "description": "従業員ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "住宅ローンID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful operation"
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApiV1EmployeeUpdateRequestSerializer": {
+        "type": "object",
+        "required": [
+          "entry_date",
+          "birth_date"
+        ],
+        "properties": {
+          "num": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "従業員番号<br>\n従業員を判別しやすいよう管理することができます。（例: 1人目の正社員を A-001 と入力）",
+            "example": "A-001"
+          },
+          "display_name": {
+            "type": "string",
+            "description": "従業員名（freee人事労務上での表示にのみ使用される名前です。出力書類には姓名が使用されます。）\n- 給与計算対象外の従業員情報の場合は必須になります。",
+            "maxLength": 255,
+            "example": "山田 太郎"
+          },
+          "base_pension_num": {
+            "type": "string",
+            "description": "基礎年金番号 数値文字列10桁固定長 例: 1111111111",
+            "maxLength": 10,
+            "example": "1111111111"
+          },
+          "employment_insurance_reference_number": {
+            "type": "string",
+            "description": "被保険者番号（雇用保険） 数値文字列11桁固定長 例: 11111111111\n- 給与計算対象外の従業員情報の場合に指定するとエラーになります。",
+            "maxLength": 11,
+            "example": "11111111111"
+          },
+          "birth_date": {
+            "type": "string",
+            "description": "生年月日 null不可",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "example": "2000-01-01"
+          },
+          "entry_date": {
+            "type": "string",
+            "description": "入社日 null不可",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "example": "2021-04-01"
+          },
+          "retire_date": {
+            "type": "string",
+            "description": "退職日\n- 退職していない場合は指定不要です。\n- 指定する場合はentry_date以降の日付を指定してください。\n- retire_dateをクリアする場合、nullを指定してください。",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "nullable": true,
+            "example": "2022-03-31"
+          },
+          "company_reference_date_rule_name": {
+            "type": "string",
+            "maxLength": 15,
+            "description": "<a href=\"https://support.freee.co.jp/hc/ja/articles/360000666303-締め日支払い日を変更する方法は-\" target=\"_blank\">締め日支払い日グループ名</a>\nで設定した締め日支払い日を指定してください。\n- 未指定の際は、締め日支払い日は変わりません。\n- 指定した従業員が給与計算対象外の場合、指定するとエラーになります。",
+            "example": "当月締め翌月払い"
+          }
+        }
+      },
+      "ApiV1EmployeePayrollStatementsEmployeeAttendanceItemSerializer": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "項目名"
+          },
+          "time": {
+            "type": "string",
+            "description": "時間"
+          },
+          "amount": {
+            "type": "string",
+            "description": "控除額"
+          }
+        }
+      },
+      "ApiV1EmployeePayrollStatementsEmployeePayrollStatementItemSerializer": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "項目名"
+          },
+          "amount": {
+            "type": "string",
+            "description": "金額"
+          }
+        }
+      },
+      "ApiV1EmployeePayrollStatementsEmployeeOvertimePayItemSerializer": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "項目名",
+            "example": "時間外労働"
+          },
+          "time": {
+            "type": "string",
+            "nullable": true,
+            "description": "時間(単位: 分)。固定残業代の場合、nullになります。",
+            "example": "60.0"
+          },
+          "amount": {
+            "type": "string",
+            "description": "手当金額",
+            "example": "1000.0"
+          },
+          "code": {
+            "type": "string",
+            "nullable": true,
+            "description": "コード（事業所毎に設定可能な小文字英数最大10桁のコード）",
+            "example": "12345abcde"
+          }
+        }
+      },
+      "ApiV1EmployeeCreateRequestSerializer": {
+        "type": "object",
+        "required": [
+          "last_name",
+          "first_name",
+          "last_name_kana",
+          "first_name_kana",
+          "entry_date",
+          "birth_date"
+        ],
+        "properties": {
+          "num": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "従業員番号<br>\n従業員を判別しやすいよう管理することができます。（例: 1人目の正社員を A-001 と入力）",
+            "example": "A-001"
+          },
+          "working_hours_system_name": {
+            "type": "string",
+            "description": "<a href=\"https://support.freee.co.jp/hc/ja/articles/360000562403-労働時間制度と勤務-賃金設定について\" target=\"_blank\">勤務・賃金設定名</a>\nで設定した名称を指定してください。\n- 未指定の際は、最初に登録したデータが利用されます。\n- 入力パラメータのno_payroll_calculationがtrueの場合に指定するとエラーになります。",
+            "maxLength": 30,
+            "example": "固定"
+          },
+          "company_reference_date_rule_name": {
+            "type": "string",
+            "maxLength": 15,
+            "description": "<a href=\"https://support.freee.co.jp/hc/ja/articles/360000666303-締め日支払い日を変更する方法は-\" target=\"_blank\">締め日支払い日グループ名</a>\nで設定した締め日支払い日を指定してください。\n- 未指定の際は、最初に登録したデータが利用されます。\n- 入力パラメータのno_payroll_calculationがtrueの場合に指定するとエラーになります。",
+            "example": "15日締め（当月25日払い）"
+          },
+          "last_name": {
+            "type": "string",
+            "description": "姓（必須）<br>\nlast_nameとfirst_nameを空白文字で結合した文字列がdisplay_nameとして登録されます。\n- 例）last_name=田中、first_name＝太郎の場合、display_name＝田中 太郎\n- display_nameはput apiで更新可能です。",
+            "maxLength": 255,
+            "example": "山田"
+          },
+          "first_name": {
+            "type": "string",
+            "description": "名（必須）<br>\nlast_nameとfirst_nameを空白文字で結合した文字列がdisplay_nameとして登録されます。\n- 例）last_name=田中、first_name＝太郎の場合、display_name＝田中 太郎\n- display_nameはput apiで更新可能です。",
+            "maxLength": 255,
+            "example": "太郎"
+          },
+          "last_name_kana": {
+            "type": "string",
+            "description": "姓カナ（必須）",
+            "maxLength": 255,
+            "example": "ヤマダ"
+          },
+          "first_name_kana": {
+            "type": "string",
+            "description": "名カナ（必須）",
+            "maxLength": 255,
+            "example": "タロウ"
+          },
+          "birth_date": {
+            "type": "string",
+            "description": "生年月日（必須）",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "example": "2000-01-01"
+          },
+          "entry_date": {
+            "type": "string",
+            "description": "入社日（必須）",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "example": "2021-04-01"
+          },
+          "pay_calc_type": {
+            "type": "string",
+            "enum": [
+              "monthly",
+              "daily",
+              "hourly"
+            ],
+            "description": "給与方式 monthly: 月給, daily: 日給, hourly: 時給\n- フレックスタイム制を使用している場合はmonthly以外指定できません。\n- 入力パラメータのno_payroll_calculationがfalseの場合は必須になります。\n- 入力パラメータのno_payroll_calculationがtrueの場合に指定するとエラーになります。",
+            "example": "monthly"
+          },
+          "pay_amount": {
+            "type": "integer",
+            "description": "基本給\n- 入力パラメータのno_payroll_calculationがfalseの場合は必須になります。\n- 入力パラメータのno_payroll_calculationがtrueの場合に指定するとエラーになります。",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 99999999,
+            "example": 220000
+          },
+          "gender": {
+            "type": "string",
+            "description": "性別　unselected: 未選択, male: 男性, female: 女性（デフォルト: unselected: 未選択）",
+            "enum": [
+              "unselected",
+              "male",
+              "female"
+            ],
+            "example": "male"
+          },
+          "married": {
+            "type": "boolean",
+            "description": "配偶者の有無（デフォルト: false）"
+          },
+          "no_payroll_calculation": {
+            "type": "boolean",
+            "description": "給与計算対象外の従業員情報を作成する場合はtrueを指定します",
+            "default": false,
+            "example": true
+          }
+        }
+      },
+      "ApiV1GroupMembershipSerializer": {
+        "type": "object",
+        "properties": {
+          "start_date": {
+            "type": "string",
+            "description": "開始日",
+            "format": "date",
+            "example": "2000-01-01"
+          },
+          "end_date": {
+            "type": "string",
+            "description": "終了日",
+            "format": "date",
+            "example": "2020-01-01"
+          },
+          "boss_id": {
+            "type": "integer",
+            "description": "上司ID",
+            "format": "int64",
+            "nullable": true,
+            "example": 1
+          },
+          "main_duty": {
+            "type": "string",
+            "enum": [
+              "unspecified",
+              "sub_duty",
+              "main_duty"
+            ],
+            "description": "主務",
+            "example": "main_duty"
+          },
+          "group_id": {
+            "type": "integer",
+            "description": "部門ID",
+            "format": "int32",
+            "example": 10
+          },
+          "group_code": {
+            "type": "string",
+            "description": "部門コード",
+            "example": "group2"
+          },
+          "group_name": {
+            "type": "string",
+            "description": "部門名称",
+            "example": "営業部"
+          },
+          "level": {
+            "type": "integer",
+            "description": "部門階層レベル",
+            "format": "int32",
+            "example": 2
+          },
+          "position_id": {
+            "type": "integer",
+            "description": "役職ID",
+            "format": "int32",
+            "nullable": true,
+            "example": 1
+          },
+          "position_code": {
+            "type": "string",
+            "description": "役職コード",
+            "nullable": true,
+            "example": "position1"
+          },
+          "position_name": {
+            "type": "string",
+            "description": "役職名称",
+            "nullable": true,
+            "example": "部長"
+          },
+          "parent_group_id": {
+            "type": "integer",
+            "description": "親部門ID",
+            "format": "int32",
+            "nullable": true,
+            "example": 1
+          },
+          "parent_group_code": {
+            "type": "string",
+            "description": "親部門コード",
+            "nullable": true,
+            "example": "group1"
+          },
+          "parent_group_name": {
+            "type": "string",
+            "description": "親部門名称",
+            "example": "営業統括",
+            "nullable": true
+          }
+        }
+      },
+      "ApiV1SalariesEmployeePayrollStatementSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "給与明細ID",
+            "format": "int32"
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32"
+          },
+          "employee_id": {
+            "type": "integer",
+            "description": "従業員ID",
+            "format": "int32"
+          },
+          "employee_name": {
+            "type": "string",
+            "description": "従業員の姓名"
+          },
+          "employee_display_name": {
+            "type": "string",
+            "description": "従業員の表示名"
+          },
+          "employee_num": {
+            "type": "string",
+            "nullable": true,
+            "description": "従業員番号"
+          },
+          "pay_date": {
+            "type": "string",
+            "description": "支払日",
+            "format": "date"
+          },
+          "start_date": {
+            "type": "string",
+            "description": "給与計算開始日（固定給）",
+            "format": "date"
+          },
+          "closing_date": {
+            "type": "string",
+            "description": "給与計算締日（固定給）",
+            "format": "date"
+          },
+          "variable_pay_start_date": {
+            "type": "string",
+            "description": "給与計算開始日（変動給） 残業手当、遅刻早退・欠勤などの計算に使われる期間",
+            "format": "date"
+          },
+          "variable_pay_closing_date": {
+            "type": "string",
+            "description": "給与計算締日（変動給）",
+            "format": "date"
+          },
+          "fixed": {
+            "type": "boolean",
+            "description": "給与明細が確定されているかどうか"
+          },
+          "calc_status": {
+            "type": "string",
+            "description": "計算状況ステータス calculating: 計算中, calculated: 計算完了, overwritten: 直接編集, imported: インポート, error: エラー"
+          },
+          "calculated_at": {
+            "type": "string",
+            "nullable": true,
+            "description": "計算状況ステータスの更新日",
+            "format": "date-time"
+          },
+          "pay_calc_type": {
+            "type": "string",
+            "enum": [
+              "monthly",
+              "daily",
+              "hourly",
+              ""
+            ],
+            "description": "給与形態 monthly: 月給, daily: 日給, hourly: 時給, (空文字列): 計算中",
+            "example": "monthly"
+          },
+          "board_member_remuneration_amount": {
+            "type": "string",
+            "nullable": true,
+            "description": "役員報酬"
+          },
+          "basic_pay_amount": {
+            "type": "string",
+            "nullable": true,
+            "description": "基本給"
+          },
+          "work_days": {
+            "type": "string",
+            "nullable": true,
+            "description": "労働日数"
+          },
+          "normal_work_time": {
+            "type": "string",
+            "nullable": true,
+            "description": "労働時間のうち、所定労働時間に該当するもの"
+          },
+          "normal_work_days": {
+            "type": "string",
+            "nullable": true,
+            "description": "所定労働出勤日数"
+          },
+          "work_mins_by_paid_holiday": {
+            "type": "string",
+            "nullable": true,
+            "description": "有給休暇時間数"
+          },
+          "num_paid_holidays": {
+            "type": "string",
+            "nullable": true,
+            "description": "有給日数"
+          },
+          "is_board_member": {
+            "type": "boolean",
+            "description": "役員かどうか"
+          },
+          "total_attendance_deduction_amount": {
+            "type": "string",
+            "nullable": true,
+            "description": "勤怠控除額合計"
+          },
+          "total_allowance_amount": {
+            "type": "string",
+            "nullable": true,
+            "description": "支給手当額合計"
+          },
+          "total_deduction_amount": {
+            "type": "string",
+            "nullable": true,
+            "description": "控除額合計"
+          },
+          "total_deduction_employer_share": {
+            "type": "string",
+            "nullable": true,
+            "description": "法定福利費の会社負担分の合計（健康保険、厚生年金、雇用保険等）"
+          },
+          "net_payment_amount": {
+            "type": "string",
+            "nullable": true,
+            "description": "差引支給額(手取り額)"
+          },
+          "gross_payment_amount": {
+            "type": "string",
+            "nullable": true,
+            "description": "総支給額(額面)"
+          },
+          "total_worked_days_count": {
+            "type": "string",
+            "nullable": true,
+            "description": "平日と休日の合計労働日数（日給用）"
+          },
+          "total_taxable_payment_amount": {
+            "type": "string",
+            "nullable": true,
+            "description": "課税対象支給額"
+          },
+          "total_expense_amount": {
+            "type": "string",
+            "nullable": true,
+            "description": "総経費精算額"
+          },
+          "total_transfer_amount": {
+            "type": "string",
+            "nullable": true,
+            "description": "総振込額"
+          },
+          "total_annual_payment_amount": {
+            "type": "string",
+            "nullable": true,
+            "description": "課税支給累計額"
+          },
+          "payments": {
+            "type": "array",
+            "description": "支給項目（基本給、残業代、通勤手当等）",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeePayrollStatementsEmployeePayrollStatementItemSerializer"
+            }
+          },
+          "deductions": {
+            "type": "array",
+            "description": "控除項目（健康保険、厚生年金、雇用保険等）",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeePayrollStatementsEmployeePayrollStatementItemSerializer"
+            }
+          },
+          "deductions_employer_share": {
+            "type": "array",
+            "description": "法定福利費の会社負担分（健康保険、厚生年金、雇用保険等）",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeePayrollStatementsEmployeePayrollStatementItemSerializer"
+            }
+          },
+          "attendances": {
+            "type": "array",
+            "description": "勤怠控除項目（遅刻早退控除、欠勤控除等）",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeePayrollStatementsEmployeeAttendanceItemSerializer"
+            }
+          },
+          "overtime_pays": {
+            "type": "array",
+            "nullable": true,
+            "description": "時間外労働項目(法定内残業、時間外労働、法定休日労働、深夜労働等)",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeePayrollStatementsEmployeeOvertimePayItemSerializer"
+            }
+          },
+          "remark": {
+            "type": "string",
+            "nullable": true,
+            "description": "備考"
+          }
+        }
+      },
+      "ApiV1HolidaysAndHoursSerializer": {
+        "type": "object",
+        "properties": {
+          "days": {
+            "type": "number",
+            "description": "日数 0.5は半休を表す",
+            "format": "float"
+          },
+          "hours": {
+            "type": "integer",
+            "description": "時間数",
+            "format": "int32"
+          }
+        }
+      },
+      "ApiV1EmployeesIndexSerializer": {
+        "type": "object",
+        "properties": {
+          "employees": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeeSerializer"
+            }
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "合計件数",
+            "format": "int32"
+          }
+        }
+      },
+      "ApiV1GroupsIndexResponse": {
+        "type": "object",
+        "required": [
+          "groups",
+          "total_count"
+        ],
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1GroupResponseParams"
+            }
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "合計件数",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1GroupResponseParams": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "level"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "部門ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 3
+          },
+          "code": {
+            "type": "string",
+            "description": "部門コード",
+            "maxLength": 255,
+            "example": "group2",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "部門名称",
+            "maxLength": 255,
+            "example": "営業部門"
+          },
+          "level": {
+            "type": "integer",
+            "description": "部門階層レベル（数字が大きいほど階層が深いです。）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 2
+          },
+          "parent_group_id": {
+            "type": "integer",
+            "description": "親部門ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 2,
+            "nullable": true
+          },
+          "parent_group_code": {
+            "type": "string",
+            "description": "親部門コード",
+            "maxLength": 255,
+            "example": "group1",
+            "nullable": true
+          },
+          "parent_group_name": {
+            "type": "string",
+            "description": "親部門名称",
+            "maxLength": 255,
+            "example": "営業統括",
+            "nullable": true
+          }
+        }
+      },
+      "ApiV1GroupCreateRequestParams": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "部門コード（入力しない場合、空文字が入力されます。）",
+            "minLength": 1,
+            "maxLength": 255,
+            "nullable": true,
+            "example": "group2"
+          },
+          "name": {
+            "type": "string",
+            "description": "部門名称（必須）",
+            "minLength": 1,
+            "maxLength": 255,
+            "example": "営業部門"
+          },
+          "parent_group_id": {
+            "type": "integer",
+            "description": "親部門ID（部門階層レベルが10以内になるように親部門IDを指定してください。）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "nullable": true,
+            "example": 2
+          }
+        }
+      },
+      "ApiV1GroupUpdateRequestParams": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "部門コード（入力しない場合、空文字が入力されます。）",
+            "minLength": 1,
+            "maxLength": 255,
+            "nullable": true,
+            "example": "group2"
+          },
+          "name": {
+            "type": "string",
+            "description": "部門名称",
+            "minLength": 1,
+            "maxLength": 255,
+            "example": "営業部門"
+          }
+        }
+      },
+      "ApiV1PositionIndexResponse": {
+        "type": "object",
+        "required": [
+          "positions",
+          "total_count"
+        ],
+        "properties": {
+          "positions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1PositionResponseParams"
+            }
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "合計件数",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1PositionResponseParams": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "役職ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "code": {
+            "type": "string",
+            "description": "役職コード",
+            "maxLength": 255,
+            "example": "position1",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "役職名称",
+            "maxLength": 255,
+            "example": "部長"
+          }
+        }
+      },
+      "ApiV1PositionRequestParams": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "役職コード（入力しない場合、空文字が入力されます。）",
+            "minLength": 1,
+            "maxLength": 255,
+            "nullable": true,
+            "example": "position1"
+          },
+          "name": {
+            "type": "string",
+            "description": "役職名称（必須）",
+            "minLength": 1,
+            "maxLength": 255,
+            "example": "部長"
+          }
+        }
+      },
+      "ApiV1EmployeeGroupMembershipSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "従業員ID",
+            "format": "int32",
+            "example": 1
+          },
+          "num": {
+            "type": "string",
+            "description": "従業員番号",
+            "nullable": true,
+            "example": "A-001"
+          },
+          "display_name": {
+            "type": "string",
+            "description": "従業員名（表示名）",
+            "example": "山田 太郎"
+          },
+          "entry_date": {
+            "type": "string",
+            "description": "入社日",
+            "format": "date",
+            "example": "2021-04-01"
+          },
+          "retire_date": {
+            "type": "string",
+            "description": "退職日",
+            "format": "date",
+            "nullable": true,
+            "example": "2022-03-31"
+          },
+          "user_id": {
+            "type": "integer",
+            "format": "int32",
+            "description": "ユーザーID(従業員詳細未設定の場合、nullになります。)",
+            "nullable": true,
+            "example": 1
+          },
+          "login_email": {
+            "type": "string",
+            "description": "ログイン用メールアドレス(従業員詳細未設定の場合、nullになります。)",
+            "nullable": true,
+            "example": "example@example.com"
+          },
+          "birth_date": {
+            "type": "string",
+            "description": "生年月日",
+            "format": "date",
+            "example": "2000-01-01"
+          },
+          "gender": {
+            "type": "string",
+            "description": "性別　unselected: 未選択, male: 男性, female: 女性",
+            "enum": [
+              "unselected",
+              "male",
+              "female"
+            ],
+            "example": "male"
+          },
+          "payroll_calculation": {
+            "type": "boolean",
+            "description": "給与計算対象従業員の場合trueを返します",
+            "example": true
+          },
+          "group_memberships": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1GroupMembershipSerializer"
+            }
+          }
+        }
+      },
+      "ApiV1MonthlyAttendanceIndexResponseParams": {
+        "type": "object",
+        "required": [
+          "id",
+          "company_id",
+          "application_number",
+          "applicant_id",
+          "target_date",
+          "issue_date",
+          "status",
+          "passed_auto_check"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "申請ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "application_number": {
+            "type": "integer",
+            "description": "申請No",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "applicant_id": {
+            "type": "integer",
+            "description": "申請者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_ids": {
+            "description": "承認者のユーザーID配列<br>\n次の場合、空配列になります。\n- 指定なしの申請経路を利用した、申請ステータスが承認済み以外の申請\n- 申請が差戻された",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "承認者のユーザーID",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "nullable": true,
+              "example": 1
+            }
+          },
+          "target_date": {
+            "type": "string",
+            "description": "対象日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "example": "2022-02-01"
+          },
+          "issue_date": {
+            "type": "string",
+            "description": "申請日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "status": {
+            "type": "string",
+            "description": "申請ステータス。（draft:下書き、in_progress:申請中、approved:承認済、feedback:差戻し）",
+            "enum": [
+              "draft",
+              "in_progress",
+              "approved",
+              "feedback"
+            ],
+            "example": "in_progress"
+          },
+          "passed_auto_check": {
+            "type": "boolean",
+            "description": "自動チェック結果",
+            "example": true
+          }
+        }
+      },
+      "ApiV1MonthlyAttendanceResponseParams": {
+        "type": "object",
+        "required": [
+          "id",
+          "company_id",
+          "application_number",
+          "applicant_id",
+          "target_date",
+          "issue_date",
+          "status",
+          "passed_auto_check",
+          "approval_flow_route_id",
+          "approval_flow_route_name",
+          "approval_flow_logs",
+          "current_round"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "申請ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "application_number": {
+            "type": "integer",
+            "description": "申請No",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "applicant_id": {
+            "type": "integer",
+            "description": "申請者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_ids": {
+            "description": "承認者のユーザーID配列<br>\n次の場合、空配列になります。\n- 指定なしの申請経路を利用した、申請ステータスが承認済み以外の申請\n- 申請が差戻された",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "承認者のユーザーID",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "nullable": true,
+              "example": 1
+            }
+          },
+          "target_date": {
+            "type": "string",
+            "description": "対象日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "example": "2022-02-01"
+          },
+          "issue_date": {
+            "type": "string",
+            "description": "申請日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "status": {
+            "type": "string",
+            "description": "申請ステータス。（draft:下書き、in_progress:申請中、approved:承認済、feedback:差戻し）",
+            "enum": [
+              "draft",
+              "in_progress",
+              "approved",
+              "feedback"
+            ],
+            "example": "in_progress"
+          },
+          "passed_auto_check": {
+            "type": "boolean",
+            "description": "自動チェック結果",
+            "example": true
+          },
+          "approval_flow_route_id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "description": "申請経路ID",
+            "example": 1
+          },
+          "approval_flow_route_name": {
+            "type": "string",
+            "description": "申請経路名",
+            "example": "申請経路"
+          },
+          "approval_flow_logs": {
+            "type": "array",
+            "description": "承認履歴",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1ApprovalFlowLogsParams"
+            }
+          },
+          "current_step_id": {
+            "type": "integer",
+            "description": "現在承認ステップID<br>\n申請を差戻した場合、nullになります。",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1,
+            "nullable": true
+          },
+          "current_round": {
+            "type": "integer",
+            "description": "現在のround。差戻し等により申請がstepの最初からやり直しになるとroundの値が増えます。",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1PaidHolidayIndexResponseParams": {
+        "type": "object",
+        "required": [
+          "id",
+          "company_id",
+          "application_number",
+          "applicant_id",
+          "target_date",
+          "issue_date",
+          "status",
+          "revoke_status",
+          "passed_auto_check",
+          "values"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "申請ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "application_number": {
+            "type": "integer",
+            "description": "申請No",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "applicant_id": {
+            "type": "integer",
+            "description": "申請者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_ids": {
+            "description": "承認者のユーザーID配列<br>\n次の場合、空配列になります。\n- 指定なしの申請経路を利用した、申請ステータスが承認済み以外の申請\n- 申請が差戻された",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "承認者のユーザーID",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "nullable": true,
+              "example": 1
+            }
+          },
+          "target_date": {
+            "type": "string",
+            "description": "対象日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "取得単位。（full:全休、half:半休、morning:午前休、 afternoon:午後休、hourly:時間休）",
+                  "enum": [
+                    "full",
+                    "half",
+                    "morning",
+                    "afternoon",
+                    "hourly"
+                  ],
+                  "nullable": false,
+                  "example": "half"
+                },
+                "start_at": {
+                  "type": "string",
+                  "description": "取得予定開始時間",
+                  "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+                  "nullable": true,
+                  "example": "12:00"
+                },
+                "end_at": {
+                  "type": "string",
+                  "description": "取得予定終了時間",
+                  "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+                  "nullable": true,
+                  "example": "23:59"
+                }
+              }
+            }
+          },
+          "issue_date": {
+            "type": "string",
+            "description": "申請日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "comment": {
+            "type": "string",
+            "description": "申請理由",
+            "maxLength": 255,
+            "nullable": true,
+            "example": "申請理由"
+          },
+          "status": {
+            "type": "string",
+            "description": "申請ステータス。（draft:下書き、in_progress:申請中、approved:承認済、feedback:差戻し）",
+            "enum": [
+              "draft",
+              "in_progress",
+              "approved",
+              "feedback"
+            ],
+            "example": "in_progress"
+          },
+          "revoke_status": {
+            "type": "string",
+            "description": "取消申請ステータス。（null:取消申請されてない、revoking:取消中、revoked:取消済）",
+            "enum": [
+              "revoking",
+              "revoked"
+            ],
+            "nullable": true,
+            "example": "revoking"
+          },
+          "passed_auto_check": {
+            "type": "boolean",
+            "description": "自動チェック結果",
+            "example": true
+          }
+        }
+      },
+      "LegacyApiV1PaidHolidayIndexResponseParams": {
+        "type": "object",
+        "required": [
+          "id",
+          "company_id",
+          "application_number",
+          "applicant_id",
+          "target_date",
+          "holiday_type",
+          "issue_date",
+          "status",
+          "revoke_status",
+          "passed_auto_check"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "申請ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "application_number": {
+            "type": "integer",
+            "description": "申請No",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "applicant_id": {
+            "type": "integer",
+            "description": "申請者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_ids": {
+            "description": "承認者のユーザーID配列<br>\n次の場合、空配列になります。\n- 指定なしの申請経路を利用した、申請ステータスが承認済み以外の申請\n- 申請が差戻された",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "承認者のユーザーID",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "nullable": true,
+              "example": 1
+            }
+          },
+          "target_date": {
+            "type": "string",
+            "description": "対象日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "holiday_type": {
+            "type": "string",
+            "description": "[deprecated] 取得単位。（full:全休、half:半休、morning:午前休、 afternoon:午後休、hour:時間休）※ 削除予定のため paid_holiday->values->type を参照してください",
+            "enum": [
+              "full",
+              "half",
+              "morning",
+              "afternoon",
+              "hour"
+            ],
+            "example": "half"
+          },
+          "start_at": {
+            "type": "string",
+            "description": "[deprecated] 取得予定開始時間 ※ 削除予定のため paid_holiday->values->start_at を参照してください",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "nullable": true,
+            "example": "12:00"
+          },
+          "end_at": {
+            "type": "string",
+            "description": "[deprecated] 取得予定終了時間 ※ 削除予定のため paid_holiday->values->end_at を参照してください",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "nullable": true,
+            "example": "23:59"
+          },
+          "issue_date": {
+            "type": "string",
+            "description": "申請日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "comment": {
+            "type": "string",
+            "description": "申請理由",
+            "maxLength": 255,
+            "nullable": true,
+            "example": "申請理由"
+          },
+          "status": {
+            "type": "string",
+            "description": "申請ステータス。（draft:下書き、in_progress:申請中、approved:承認済、feedback:差戻し）",
+            "enum": [
+              "draft",
+              "in_progress",
+              "approved",
+              "feedback"
+            ],
+            "example": "in_progress"
+          },
+          "revoke_status": {
+            "type": "string",
+            "description": "取消申請ステータス。（null:取消申請されてない、revoking:取消中、revoked:取消済）",
+            "enum": [
+              "revoking",
+              "revoked"
+            ],
+            "nullable": true,
+            "example": "revoking"
+          },
+          "passed_auto_check": {
+            "type": "boolean",
+            "description": "自動チェック結果",
+            "example": true
+          }
+        }
+      },
+      "ApiV1PaidHolidayResponseParams": {
+        "type": "object",
+        "required": [
+          "id",
+          "company_id",
+          "application_number",
+          "applicant_id",
+          "target_date",
+          "issue_date",
+          "status",
+          "revoke_status",
+          "passed_auto_check",
+          "approval_flow_route_id",
+          "approval_flow_route_name",
+          "approval_flow_logs",
+          "current_round",
+          "values"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "申請ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "application_number": {
+            "type": "integer",
+            "description": "申請No",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "applicant_id": {
+            "type": "integer",
+            "description": "申請者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_ids": {
+            "description": "承認者のユーザーID配列<br>\n次の場合、空配列になります。\n- 指定なしの申請経路を利用した、申請ステータスが承認済み以外の申請\n- 申請が差戻された",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "承認者のユーザーID",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "nullable": true,
+              "example": 1
+            }
+          },
+          "target_date": {
+            "type": "string",
+            "description": "対象日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "取得単位。（full:全休、half:半休、morning:午前休、 afternoon:午後休、hourly:時間休）",
+                  "enum": [
+                    "full",
+                    "half",
+                    "morning",
+                    "afternoon",
+                    "hourly"
+                  ],
+                  "nullable": false,
+                  "example": "half"
+                },
+                "start_at": {
+                  "type": "string",
+                  "description": "取得予定開始時間",
+                  "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+                  "nullable": true,
+                  "example": "12:00"
+                },
+                "end_at": {
+                  "type": "string",
+                  "description": "取得予定終了時間",
+                  "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+                  "nullable": true,
+                  "example": "23:59"
+                }
+              }
+            }
+          },
+          "issue_date": {
+            "type": "string",
+            "description": "申請日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "comment": {
+            "type": "string",
+            "description": "申請理由",
+            "maxLength": 255,
+            "nullable": true,
+            "example": "申請理由"
+          },
+          "status": {
+            "type": "string",
+            "description": "申請ステータス。（draft:下書き、in_progress:申請中、approved:承認済、feedback:差戻し）",
+            "enum": [
+              "draft",
+              "in_progress",
+              "approved",
+              "feedback"
+            ],
+            "example": "in_progress"
+          },
+          "revoke_status": {
+            "type": "string",
+            "description": "取消申請ステータス。（null:取消申請されてない、revoking:取消中、revoked:取消済）",
+            "enum": [
+              "revoking",
+              "revoked"
+            ],
+            "nullable": true,
+            "example": "revoking"
+          },
+          "passed_auto_check": {
+            "type": "boolean",
+            "description": "自動チェック結果",
+            "example": true
+          },
+          "approval_flow_route_id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "description": "申請経路ID",
+            "example": 1
+          },
+          "approval_flow_route_name": {
+            "type": "string",
+            "description": "申請経路名",
+            "example": "申請経路"
+          },
+          "approval_flow_logs": {
+            "type": "array",
+            "description": "承認履歴",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1ApprovalFlowLogsParams"
+            }
+          },
+          "current_step_id": {
+            "type": "integer",
+            "description": "現在承認ステップID<br>\n申請を差戻した場合、nullになります。",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1,
+            "nullable": true
+          },
+          "current_round": {
+            "type": "integer",
+            "description": "現在のround。差戻し等により申請がstepの最初からやり直しになるとroundの値が増えます。",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "LegacyApiV1PaidHolidayResponseParams": {
+        "type": "object",
+        "required": [
+          "id",
+          "company_id",
+          "application_number",
+          "applicant_id",
+          "target_date",
+          "holiday_type",
+          "issue_date",
+          "status",
+          "revoke_status",
+          "passed_auto_check",
+          "approval_flow_route_id",
+          "approval_flow_route_name",
+          "approval_flow_logs",
+          "current_round"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "申請ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "application_number": {
+            "type": "integer",
+            "description": "申請No",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "applicant_id": {
+            "type": "integer",
+            "description": "申請者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_ids": {
+            "description": "承認者のユーザーID配列<br>\n次の場合、空配列になります。\n- 指定なしの申請経路を利用した、申請ステータスが承認済み以外の申請\n- 申請が差戻された",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "承認者のユーザーID",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "nullable": true,
+              "example": 1
+            }
+          },
+          "target_date": {
+            "type": "string",
+            "description": "対象日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "holiday_type": {
+            "type": "string",
+            "description": "[deprecated] 取得単位。（full:全休、half:半休、morning:午前休、 afternoon:午後休、hour:時間休）※ 削除予定のため paid_holiday->values->type を参照してください",
+            "enum": [
+              "full",
+              "half",
+              "morning",
+              "afternoon",
+              "hour"
+            ],
+            "example": "half"
+          },
+          "start_at": {
+            "type": "string",
+            "description": "[deprecated] 取得予定開始時間 ※ 削除予定のため paid_holiday->values->start_at を参照してください",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "nullable": true,
+            "example": "12:00"
+          },
+          "end_at": {
+            "type": "string",
+            "description": "[deprecated] 取得予定終了時間 ※ 削除予定のため paid_holiday->values->end_at を参照してください",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "nullable": true,
+            "example": "23:59"
+          },
+          "issue_date": {
+            "type": "string",
+            "description": "申請日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "comment": {
+            "type": "string",
+            "description": "申請理由",
+            "maxLength": 255,
+            "nullable": true,
+            "example": "申請理由"
+          },
+          "status": {
+            "type": "string",
+            "description": "申請ステータス。（draft:下書き、in_progress:申請中、approved:承認済、feedback:差戻し）",
+            "enum": [
+              "draft",
+              "in_progress",
+              "approved",
+              "feedback"
+            ],
+            "example": "in_progress"
+          },
+          "revoke_status": {
+            "type": "string",
+            "description": "取消申請ステータス。（null:取消申請されてない、revoking:取消中、revoked:取消済）",
+            "enum": [
+              "revoking",
+              "revoked"
+            ],
+            "nullable": true,
+            "example": "revoking"
+          },
+          "passed_auto_check": {
+            "type": "boolean",
+            "description": "自動チェック結果",
+            "example": true
+          },
+          "approval_flow_route_id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "description": "申請経路ID",
+            "example": 1
+          },
+          "approval_flow_route_name": {
+            "type": "string",
+            "description": "申請経路名",
+            "example": "申請経路"
+          },
+          "approval_flow_logs": {
+            "type": "array",
+            "description": "承認履歴",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1ApprovalFlowLogsParams"
+            }
+          },
+          "current_step_id": {
+            "type": "integer",
+            "description": "現在承認ステップID<br>\n申請を差戻した場合、nullになります。",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1,
+            "nullable": true
+          },
+          "current_round": {
+            "type": "integer",
+            "description": "現在のround。差戻し等により申請がstepの最初からやり直しになるとroundの値が増えます。",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1OvertimeWorkIndexResponseParams": {
+        "type": "object",
+        "required": [
+          "id",
+          "company_id",
+          "application_number",
+          "applicant_id",
+          "target_date",
+          "issue_date",
+          "status",
+          "revoke_status",
+          "passed_auto_check"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "申請ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "application_number": {
+            "type": "integer",
+            "description": "申請No",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "applicant_id": {
+            "type": "integer",
+            "description": "申請者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_ids": {
+            "description": "承認者のユーザーID配列<br>\n次の場合、空配列になります。\n- 指定なしの申請経路を利用した、申請ステータスが承認済み以外の申請\n- 申請が差戻された",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "承認者のユーザーID",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "nullable": true,
+              "example": 1
+            }
+          },
+          "target_date": {
+            "type": "string",
+            "description": "対象日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "start_at": {
+            "type": "string",
+            "description": "取得予定開始時間（必須）",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "12:00"
+          },
+          "end_at": {
+            "type": "string",
+            "description": "取得予定終了時間（必須）",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "23:59"
+          },
+          "issue_date": {
+            "type": "string",
+            "description": "申請日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "comment": {
+            "type": "string",
+            "description": "申請理由",
+            "maxLength": 255,
+            "nullable": true,
+            "example": "申請理由"
+          },
+          "status": {
+            "type": "string",
+            "description": "申請ステータス。（draft:下書き、in_progress:申請中、approved:承認済、feedback:差戻し）",
+            "enum": [
+              "draft",
+              "in_progress",
+              "approved",
+              "feedback"
+            ],
+            "example": "in_progress"
+          },
+          "revoke_status": {
+            "type": "string",
+            "description": "取消申請ステータス。（null:取消申請されてない、revoking:取消中、revoked:取消済）",
+            "enum": [
+              "revoking",
+              "revoked"
+            ],
+            "nullable": true,
+            "example": "revoking"
+          },
+          "passed_auto_check": {
+            "type": "boolean",
+            "description": "自動チェック結果",
+            "example": true
+          }
+        }
+      },
+      "ApiV1OvertimeWorkResponseParams": {
+        "type": "object",
+        "required": [
+          "id",
+          "company_id",
+          "application_number",
+          "applicant_id",
+          "target_date",
+          "issue_date",
+          "status",
+          "revoke_status",
+          "passed_auto_check",
+          "approval_flow_route_id",
+          "approval_flow_route_name",
+          "approval_flow_logs",
+          "current_round"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "申請ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "application_number": {
+            "type": "integer",
+            "description": "申請No",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "applicant_id": {
+            "type": "integer",
+            "description": "申請者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_ids": {
+            "description": "承認者のユーザーID配列<br>\n次の場合、空配列になります。\n- 指定なしの申請経路を利用した、申請ステータスが承認済み以外の申請\n- 申請が差戻された",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "承認者のユーザーID",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "nullable": true,
+              "example": 1
+            }
+          },
+          "target_date": {
+            "type": "string",
+            "description": "対象日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "start_at": {
+            "type": "string",
+            "description": "取得予定開始時間（必須）",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "12:00"
+          },
+          "end_at": {
+            "type": "string",
+            "description": "取得予定終了時間（必須）",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "23:59"
+          },
+          "issue_date": {
+            "type": "string",
+            "description": "申請日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "comment": {
+            "type": "string",
+            "description": "申請理由",
+            "maxLength": 255,
+            "nullable": true,
+            "example": "申請理由"
+          },
+          "status": {
+            "type": "string",
+            "description": "申請ステータス。（draft:下書き、in_progress:申請中、approved:承認済、feedback:差戻し）",
+            "enum": [
+              "draft",
+              "in_progress",
+              "approved",
+              "feedback"
+            ],
+            "example": "in_progress"
+          },
+          "revoke_status": {
+            "type": "string",
+            "description": "取消申請ステータス。（null:取消申請されてない、revoking:取消中、revoked:取消済）",
+            "enum": [
+              "revoking",
+              "revoked"
+            ],
+            "nullable": true,
+            "example": "revoking"
+          },
+          "passed_auto_check": {
+            "type": "boolean",
+            "description": "自動チェック結果",
+            "example": true
+          },
+          "approval_flow_route_id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "description": "申請経路ID",
+            "example": 1
+          },
+          "approval_flow_route_name": {
+            "type": "string",
+            "description": "申請経路名",
+            "example": "申請経路"
+          },
+          "approval_flow_logs": {
+            "type": "array",
+            "description": "承認履歴",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1ApprovalFlowLogsParams"
+            }
+          },
+          "current_step_id": {
+            "type": "integer",
+            "description": "現在承認ステップID<br>\n申請を差戻した場合、nullになります。",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1,
+            "nullable": true
+          },
+          "current_round": {
+            "type": "integer",
+            "description": "現在のround。差戻し等により申請がstepの最初からやり直しになるとroundの値が増えます。",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1ApprovalFlowLogsParams": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "description": "申請操作をしたユーザーのユーザーID",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "action": {
+            "type": "string",
+            "description": "申請操作。（apply:申請する、approve:承認、cancel:取り消し、feedback:差戻し）",
+            "enum": [
+              "apply",
+              "approve",
+              "cancel",
+              "feedback"
+            ],
+            "example": "approve"
+          },
+          "update_at": {
+            "type": "string",
+            "description": "申請操作をした日付時間",
+            "format": "date-time",
+            "example": "2022-06-08T09:46:46.000+09:00"
+          }
+        }
+      },
+      "ApiV1EmployeeSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "従業員ID",
+            "format": "int32"
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32"
+          },
+          "num": {
+            "type": "string",
+            "description": "従業員番号",
+            "nullable": true
+          },
+          "display_name": {
+            "type": "string",
+            "description": "従業員名（表示名）"
+          },
+          "base_pension_num": {
+            "type": "string",
+            "description": "基礎年金番号",
+            "nullable": true
+          },
+          "employment_insurance_reference_number": {
+            "type": "string",
+            "description": "被保険者番号（雇用保険）"
+          },
+          "birth_date": {
+            "type": "string",
+            "description": "生年月日",
+            "format": "date"
+          },
+          "entry_date": {
+            "type": "string",
+            "description": "入社日",
+            "format": "date"
+          },
+          "retire_date": {
+            "type": "string",
+            "description": "退職日",
+            "format": "date",
+            "nullable": true
+          },
+          "user_id": {
+            "type": "integer",
+            "description": "ユーザーID(従業員詳細未設定の場合、nullになります。)",
+            "format": "int32",
+            "nullable": true
+          },
+          "profile_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesProfileRuleSerializer"
+          },
+          "health_insurance_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesHealthInsuranceRuleSerializer"
+          },
+          "welfare_pension_insurance_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesWelfarePensionInsuranceRuleSerializer"
+          },
+          "dependent_rules": {
+            "type": "array",
+            "description": "家族情報",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesDependentRuleSerializer"
+            }
+          },
+          "bank_account_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesBankAccountRuleSerializer"
+          },
+          "basic_pay_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesBasicPayRuleSerializer"
+          },
+          "payroll_calculation": {
+            "type": "boolean",
+            "description": "給与計算対象従業員の場合trueを返します",
+            "example": true
+          },
+          "company_reference_date_rule_name": {
+            "type": "string",
+            "description": "締め日支払い日グループ名(給与計算対象外従業員の場合、nullを返します)",
+            "example": "当月締め翌月払い",
+            "nullable": true
+          }
+        }
+      },
+      "ApiV1UsersCompanySerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "description": "事業所名"
+          },
+          "role": {
+            "type": "string",
+            "description": "事業所におけるロール。\n\n- `company_admin`: 管理者\n- `self_only`: 一般\n- `attendance_manager`: 勤怠管理者\n- `physician`: 産業医\n- `shift_admin`: AIシフト担当者\n- `time_clock_device_setter`: 打刻機設定者\n\n[各権限でできることは各アカウントの権限についてのヘルプページを参照してください。](https://support.freee.co.jp/hc/ja/articles/204087410#3)"
+          },
+          "external_cid": {
+            "type": "string",
+            "description": "事業所番号(半角英数字10桁)"
+          },
+          "employee_id": {
+            "type": "integer",
+            "description": "事業所に所属する従業員としての従業員ID、従業員情報が未登録の場合はnullになります。",
+            "format": "int32",
+            "nullable": true
+          },
+          "display_name": {
+            "type": "string",
+            "description": "事業所に所属する従業員の表示名",
+            "nullable": true
+          }
+        }
+      },
+      "ApiV1UsersMeSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "ユーザーID",
+            "format": "int32"
+          },
+          "companies": {
+            "type": "array",
+            "description": "ユーザーが属する事業所の一覧",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1UsersCompanySerializer"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeeGroupMembershipsIndexSerializer": {
+        "type": "object",
+        "properties": {
+          "employee_group_memberships": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeeGroupMembershipSerializer"
+            }
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "合計件数",
+            "format": "int32",
+            "example": 1
+          }
+        }
+      },
+      "ApiV1BonusesEmployeePayrollStatementsIndexSerializer": {
+        "type": "object",
+        "properties": {
+          "employee_payroll_statements": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1BonusesEmployeePayrollStatementSerializer"
+            }
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "合計件数",
+            "format": "int32"
+          }
+        }
+      },
+      "ApiV1BonusesEmployeePayrollStatementSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "賞与明細ID",
+            "format": "int32"
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32"
+          },
+          "employee_id": {
+            "type": "integer",
+            "description": "従業員ID",
+            "format": "int32"
+          },
+          "employee_name": {
+            "type": "string",
+            "description": "従業員の姓名"
+          },
+          "employee_display_name": {
+            "type": "string",
+            "description": "従業員の表示名"
+          },
+          "employee_num": {
+            "type": "string",
+            "description": "従業員番号",
+            "nullable": true
+          },
+          "closing_date": {
+            "type": "string",
+            "description": "確定日",
+            "format": "date"
+          },
+          "pay_date": {
+            "type": "string",
+            "description": "支払日",
+            "format": "date"
+          },
+          "fixed": {
+            "type": "boolean",
+            "description": "賞与明細が確定されているかどうか"
+          },
+          "calc_status": {
+            "type": "string",
+            "description": "計算状況ステータス calculating: 計算中, calculated: 計算完了, error: エラー"
+          },
+          "calculated_at": {
+            "type": "string",
+            "description": "計算状況ステータスの更新日",
+            "format": "date-time",
+            "nullable": true
+          },
+          "bonus_amount": {
+            "type": "string",
+            "description": "賞与額",
+            "nullable": true
+          },
+          "total_allowance_amount": {
+            "type": "string",
+            "description": "手当額合計",
+            "nullable": true
+          },
+          "total_deduction_amount": {
+            "type": "string",
+            "description": "控除額合計",
+            "nullable": true
+          },
+          "net_payment_amount": {
+            "type": "string",
+            "description": "差引支給額(手取り額)",
+            "nullable": true
+          },
+          "gross_payment_amount": {
+            "type": "string",
+            "description": "総支給額(額面)",
+            "nullable": true
+          },
+          "total_taxable_payment_amount": {
+            "type": "string",
+            "description": "課税対象支給額",
+            "nullable": true
+          },
+          "allowances": {
+            "type": "array",
+            "description": "手当",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeePayrollStatementsEmployeePayrollStatementItemSerializer"
+            }
+          },
+          "deductions": {
+            "type": "array",
+            "description": "控除項目（所得税、社会保険料等）",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeePayrollStatementsEmployeePayrollStatementItemSerializer"
+            }
+          },
+          "remark": {
+            "type": "string",
+            "description": "備考"
+          }
+        }
+      },
+      "ApiV1CompaniesEmployeeSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "従業員ID",
+            "format": "int32"
+          },
+          "num": {
+            "type": "string",
+            "description": "従業員番号(従業員詳細未設定の場合、nullになります。)",
+            "nullable": true
+          },
+          "display_name": {
+            "type": "string",
+            "description": "従業員名（表示名）"
+          },
+          "entry_date": {
+            "type": "string",
+            "description": "入社日",
+            "format": "date"
+          },
+          "retire_date": {
+            "type": "string",
+            "description": "退職日",
+            "format": "date",
+            "nullable": true
+          },
+          "user_id": {
+            "type": "integer",
+            "format": "int32",
+            "description": "ユーザーID(従業員詳細未設定の場合、nullになります。)",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "description": "ログイン用メールアドレス(従業員詳細未設定の場合、nullになります。)",
+            "nullable": true
+          },
+          "payroll_calculation": {
+            "type": "boolean",
+            "description": "給与計算対象従業員の場合trueを返します",
+            "example": true
+          },
+          "closing_day": {
+            "type": "integer",
+            "description": "締め日(給与計算対象外従業員の場合、nullを返します)",
+            "example": 31,
+            "nullable": true
+          },
+          "pay_day": {
+            "type": "integer",
+            "description": "支払日(給与計算対象外従業員の場合、nullを返します)",
+            "example": 15,
+            "nullable": true
+          },
+          "month_of_pay_day": {
+            "type": "string",
+            "description": "翌月払いか、当月払いか(給与計算対象外従業員の場合、nullを返します)",
+            "example": "next_month",
+            "nullable": true
+          }
+        }
+      },
+      "ApiV1EmployeesProfileRuleUpdateRequestSerializer": {
+        "type": "object",
+        "required": [
+          "last_name",
+          "first_name",
+          "last_name_kana",
+          "first_name_kana"
+        ],
+        "properties": {
+          "last_name": {
+            "type": "string",
+            "description": "姓 null不可",
+            "maxLength": 255,
+            "example": "山田"
+          },
+          "first_name": {
+            "type": "string",
+            "description": "名 null不可",
+            "maxLength": 255,
+            "example": "太郎"
+          },
+          "last_name_kana": {
+            "type": "string",
+            "description": "姓カナ",
+            "maxLength": 255,
+            "example": "ヤマダ"
+          },
+          "first_name_kana": {
+            "type": "string",
+            "description": "名カナ",
+            "maxLength": 255,
+            "example": "タロウ"
+          },
+          "zipcode1": {
+            "type": "string",
+            "description": "住民票住所の郵便番号1",
+            "maxLength": 3,
+            "example": "000"
+          },
+          "zipcode2": {
+            "type": "string",
+            "description": "住民票住所の郵便番号2",
+            "maxLength": 4,
+            "example": "0000"
+          },
+          "prefecture_code": {
+            "type": "integer",
+            "minimum": -1,
+            "maximum": 46,
+            "description": "住民票住所の都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄)",
+            "example": 4
+          },
+          "address": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所",
+            "maxLength": 255
+          },
+          "address_kana": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所カナ",
+            "maxLength": 255
+          },
+          "phone1": {
+            "type": "string",
+            "description": "電話番号1（先頭番号、例:03-1111-222x の03部分）",
+            "maxLength": 5,
+            "example": "000"
+          },
+          "phone2": {
+            "type": "string",
+            "description": "電話番号2（中間番号、例:03-1111-222x の1111部分）",
+            "maxLength": 4,
+            "example": "0000"
+          },
+          "phone3": {
+            "type": "string",
+            "description": "電話番号3（末尾番号、例:03-1111-222x の222x部分）",
+            "maxLength": 4,
+            "example": "0000"
+          },
+          "residential_zipcode1": {
+            "type": "string",
+            "description": "現住所の郵便番号１",
+            "maxLength": 3,
+            "example": "000"
+          },
+          "residential_zipcode2": {
+            "type": "string",
+            "description": "現住所の郵便番号２",
+            "maxLength": 4,
+            "example": "0000"
+          },
+          "residential_prefecture_code": {
+            "type": "integer",
+            "minimum": -1,
+            "maximum": 46,
+            "description": "現住所の都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄)",
+            "example": 4
+          },
+          "residential_address": {
+            "type": "string",
+            "description": "現住所の住所",
+            "maxLength": 255
+          },
+          "residential_address_kana": {
+            "type": "string",
+            "description": "現住所の住所カナ",
+            "maxLength": 255
+          },
+          "employment_type": {
+            "type": "string",
+            "description": "雇用形態 board-member: 役員, regular: 正社員, fixed-term: 契約社員, part-time: アルバイト・パート, temporary: 派遣社員, (空文字列): その他",
+            "enum": [
+              "board-member",
+              "regular",
+              "fixed-term",
+              "part-time",
+              "temporary",
+              ""
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "肩書",
+            "maxLength": 255
+          },
+          "gender": {
+            "type": "string",
+            "description": "性別　unselected: 未選択, male: 男性, female: 女性（デフォルト: unselected: 未選択）",
+            "enum": [
+              "unselected",
+              "male",
+              "female"
+            ],
+            "example": "male"
+          },
+          "married": {
+            "type": "boolean",
+            "description": "null不可 配偶者の有無"
+          },
+          "is_working_student": {
+            "type": "boolean",
+            "description": "null不可 勤労学生かどうか"
+          },
+          "widow_type": {
+            "type": "string",
+            "description": "寡夫／寡婦かどうか null不可 na: 空白, widower: 寡夫, widow: 寡婦, special_widow: 特別寡婦, one_parent: ひとり親",
+            "enum": [
+              "na",
+              "widower",
+              "widow",
+              "special_widow",
+              "one_parent"
+            ]
+          },
+          "disability_type": {
+            "type": "string",
+            "description": "障害者かどうか null不可 na: 空白, general: 障害者, heavy: 特別障害者",
+            "enum": [
+              "na",
+              "general",
+              "heavy"
+            ]
+          },
+          "email": {
+            "type": "string",
+            "description": "メールアドレス",
+            "nullable": true,
+            "maxLength": 255,
+            "example": "test@example.com"
+          },
+          "householder_name": {
+            "type": "string",
+            "description": "世帯主の名前<br>世帯主の続柄に myself:本人 を指定している場合は、世帯主の名前は自動で従業員名で更新するため指定できません。",
+            "maxLength": 255,
+            "example": "山田 吾郎"
+          },
+          "householder": {
+            "type": "string",
+            "description": "世帯主の続柄 myself:本人, husband:夫, wife:妻, father:父, mother:母, child:子供, senior_brother:兄, junior_brother:弟, senior_sister:姉, junior_sister:妹, grandchild:孫, grandfather:祖父, grandmother:祖母, father_in_law:義父, mother_in_law:義母, grandfather_in_law:義祖父, grandmother_in_law:義祖母, other:その他",
+            "enum": [
+              "myself",
+              "husband",
+              "wife",
+              "father",
+              "mother",
+              "child",
+              "senior_brother",
+              "junior_brother",
+              "senior_sister",
+              "junior_sister",
+              "grandchild",
+              "grandfather",
+              "grandmother",
+              "father_in_law",
+              "mother_in_law",
+              "grandfather_in_law",
+              "grandmother_in_law",
+              "other"
+            ],
+            "example": "father"
+          }
+        }
+      },
+      "ApiV1EmployeesEmployeeMultiHourlyWageWorkRecordSummarySerializer": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "時給名"
+          },
+          "total_normal_time_mins": {
+            "type": "integer",
+            "description": "所定内労働時間（分）",
+            "format": "int32"
+          }
+        }
+      },
+      "ApiV1EmployeesWorkRecordTimeRangeSerializer": {
+        "type": "object",
+        "required": [
+          "clock_in_at",
+          "clock_out_at"
+        ],
+        "properties": {
+          "clock_in_at": {
+            "type": "string",
+            "description": "開始時刻",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "2018-07-31 08:00:00"
+          },
+          "clock_out_at": {
+            "type": "string",
+            "description": "終了時刻",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "2018-07-31 08:00:00"
+          }
+        }
+      },
+      "ApiV1EmployeesWorkRecordTimeRangeResponseSerializer": {
+        "type": "object",
+        "properties": {
+          "clock_in_at": {
+            "type": "string",
+            "description": "開始時刻",
+            "format": "date-time"
+          },
+          "clock_out_at": {
+            "type": "string",
+            "description": "終了時刻",
+            "format": "date-time"
+          }
+        }
+      },
+      "ApiV1EmployeesWelfarePensionInsuranceRuleSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "child_allowance_contribution_bonus_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "賞与計算時の子ども・子育て拠出金の計算方法",
+            "example": "manual"
+          },
+          "child_allowance_contribution_salary_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "給与計算時の子ども・子育て拠出金の計算方法",
+            "example": "manual"
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32"
+          },
+          "employee_id": {
+            "type": "integer",
+            "description": "従業員ID",
+            "format": "int32"
+          },
+          "entried": {
+            "type": "boolean",
+            "description": "厚生年金保険に加入しているかどうか"
+          },
+          "manual_child_allowance_contribution_amount_bonus": {
+            "type": "number",
+            "format": "float",
+            "description": "賞与計算時の子ども・子育て拠出金の直接指定金額",
+            "nullable": true,
+            "example": 111.0001,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "manual_child_allowance_contribution_amount_salary": {
+            "type": "number",
+            "format": "float",
+            "description": "給与計算時の子ども・子育て拠出金の直接指定金額",
+            "nullable": true,
+            "example": 222.0001,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "manual_welfare_pension_insurance_amount_of_company_bonus": {
+            "type": "number",
+            "format": "float",
+            "description": "賞与計算時の厚生年金保険料の直接指定金額（会社負担分）",
+            "nullable": true,
+            "example": 333.0001,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "manual_welfare_pension_insurance_amount_of_company_salary": {
+            "type": "number",
+            "format": "float",
+            "description": "給与計算時の厚生年金保険料の直接指定金額（会社負担分）",
+            "nullable": true,
+            "example": 444.0001,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "manual_welfare_pension_insurance_amount_of_employee_bonus": {
+            "type": "integer",
+            "format": "int32",
+            "description": "賞与計算時の厚生年金保険料の直接指定金額（従業員負担分）",
+            "nullable": true,
+            "example": 555,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "manual_welfare_pension_insurance_amount_of_employee_salary": {
+            "type": "integer",
+            "format": "int32",
+            "description": "給与計算時の厚生年金保険料の直接指定金額（従業員負担分）",
+            "nullable": true,
+            "example": 666,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "reference_num": {
+            "type": "string",
+            "description": "厚生年金保険の被保険者整理番号",
+            "nullable": true
+          },
+          "standard_monthly_remuneration": {
+            "type": "integer",
+            "description": "標準報酬月額",
+            "format": "int32"
+          },
+          "welfare_pension_insurance_bonus_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "賞与計算時の厚生年金保険料の計算方法",
+            "example": "manual"
+          },
+          "welfare_pension_insurance_salary_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "給与計算時の厚生年金保険料の計算方法",
+            "example": "manual"
+          }
+        },
+        "nullable": true
+      },
+      "ApiV1EmployeesHealthInsuranceRuleUpdateRequestSerializer": {
+        "type": "object",
+        "required": [
+          "standard_monthly_remuneration"
+        ],
+        "properties": {
+          "entried": {
+            "type": "boolean",
+            "description": "健康保険に加入しているかどうか null不可"
+          },
+          "health_insurance_salary_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "給与計算時の健康保険料の計算方法",
+            "example": "manual"
+          },
+          "health_insurance_bonus_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "賞与計算時の健康保険料の計算方法",
+            "example": "manual"
+          },
+          "manual_health_insurance_amount_of_employee_salary": {
+            "type": "integer",
+            "format": "int32",
+            "description": "給与計算時の健康保険料の直接指定金額（従業員負担分）",
+            "example": 8888,
+            "nullable": true,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "manual_health_insurance_amount_of_employee_bonus": {
+            "type": "integer",
+            "format": "int32",
+            "description": "賞与計算時の健康保険料の直接指定金額（従業員負担分）",
+            "example": 7777,
+            "nullable": true,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "manual_health_insurance_amount_of_company_salary": {
+            "type": "number",
+            "format": "float",
+            "description": "給与計算時の健康保険料の直接指定金額（会社負担分）",
+            "example": 6666.0001,
+            "nullable": true,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "manual_health_insurance_amount_of_company_bonus": {
+            "type": "number",
+            "format": "float",
+            "description": "賞与計算時の健康保険料の直接指定金額（会社負担分）",
+            "example": 5555.0001,
+            "nullable": true,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "care_insurance_salary_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "給与計算時の介護保険料の計算方法",
+            "example": "manual"
+          },
+          "care_insurance_bonus_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "賞与計算時の介護保険料の計算方法",
+            "example": "manual"
+          },
+          "manual_care_insurance_amount_of_employee_salary": {
+            "type": "integer",
+            "format": "int32",
+            "description": "給与計算時の介護保険料の直接指定金額（従業員負担分）",
+            "example": 4444,
+            "nullable": true,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "manual_care_insurance_amount_of_employee_bonus": {
+            "type": "integer",
+            "format": "int32",
+            "description": "賞与計算時の介護保険料の直接指定金額（従業員負担分）",
+            "example": 3333,
+            "nullable": true,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "manual_care_insurance_amount_of_company_salary": {
+            "type": "number",
+            "format": "float",
+            "description": "給与計算時の介護保険料の直接指定金額（会社負担分）",
+            "example": 2222.0001,
+            "nullable": true,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "manual_care_insurance_amount_of_company_bonus": {
+            "type": "number",
+            "format": "float",
+            "description": "賞与計算時の介護保険料の直接指定金額（会社負担分）",
+            "example": 1111.0001,
+            "nullable": true,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "reference_num": {
+            "type": "string",
+            "description": "健康保険の被保険者整理番号",
+            "maxLength": 255,
+            "example": "0000000000"
+          },
+          "standard_monthly_remuneration": {
+            "type": "integer",
+            "description": "標準報酬月額 null不可",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 58000
+          },
+          "health_insurance_qualification_required": {
+            "type": "boolean",
+            "description": "健康保険の資格確認書の発行が必要かどうか"
+          }
+        }
+      },
+      "ApiV1EmployeesProfileRuleSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32"
+          },
+          "employee_id": {
+            "type": "integer",
+            "description": "従業員ID",
+            "format": "int32"
+          },
+          "last_name": {
+            "type": "string",
+            "description": "姓"
+          },
+          "first_name": {
+            "type": "string",
+            "description": "名"
+          },
+          "last_name_kana": {
+            "type": "string",
+            "description": "姓カナ"
+          },
+          "first_name_kana": {
+            "type": "string",
+            "description": "名カナ"
+          },
+          "zipcode1": {
+            "type": "string",
+            "description": "住民票住所の郵便番号1",
+            "nullable": true,
+            "example": "000"
+          },
+          "zipcode2": {
+            "type": "string",
+            "description": "住民票住所の郵便番号2",
+            "nullable": true,
+            "example": "0000"
+          },
+          "prefecture_code": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": -1,
+            "maximum": 46,
+            "description": "住民票住所の都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄)",
+            "example": 4
+          },
+          "address": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所",
+            "nullable": true
+          },
+          "address_kana": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所カナ"
+          },
+          "phone1": {
+            "type": "string",
+            "description": "電話番号1（先頭番号、例:03-1111-222x の03部分）",
+            "nullable": true,
+            "example": "000"
+          },
+          "phone2": {
+            "type": "string",
+            "description": "電話番号2（中間番号、例:03-1111-222x の1111部分）",
+            "nullable": true,
+            "example": "0000"
+          },
+          "phone3": {
+            "type": "string",
+            "description": "電話番号3（末尾番号、例:03-1111-222x の222x部分）",
+            "nullable": true,
+            "example": "0000"
+          },
+          "residential_zipcode1": {
+            "type": "string",
+            "description": "現住所の郵便番号１",
+            "nullable": true,
+            "example": "000"
+          },
+          "residential_zipcode2": {
+            "type": "string",
+            "description": "現住所の郵便番号２",
+            "example": "0000",
+            "nullable": true
+          },
+          "residential_prefecture_code": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": -1,
+            "maximum": 46,
+            "description": "現住所の都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄)",
+            "example": 4
+          },
+          "residential_address": {
+            "type": "string",
+            "description": "現住所の住所",
+            "nullable": true
+          },
+          "residential_address_kana": {
+            "type": "string",
+            "description": "現住所の住所カナ",
+            "nullable": true
+          },
+          "employment_type": {
+            "type": "string",
+            "description": "雇用形態 board-member: 役員, regular: 正社員, fixed-term: 契約社員, part-time: アルバイト・パート, temporary: 派遣社員, (空文字列): その他",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "description": "肩書",
+            "nullable": true
+          },
+          "gender": {
+            "type": "string",
+            "description": "性別　unselected: 未選択, male: 男性, female: 女性",
+            "enum": [
+              "unselected",
+              "male",
+              "female"
+            ],
+            "example": "male"
+          },
+          "married": {
+            "type": "boolean",
+            "description": "配偶者の有無"
+          },
+          "is_working_student": {
+            "type": "boolean",
+            "description": "勤労学生かどうか"
+          },
+          "widow_type": {
+            "type": "string",
+            "description": "寡夫／寡婦かどうか na: 空白, widower: 寡夫, widow: 寡婦, special_widow: 特別寡婦, one_parent: ひとり親"
+          },
+          "disability_type": {
+            "type": "string",
+            "description": "障害者かどうか na: 空白, general: 障害者, heavy: 特別障害者"
+          },
+          "email": {
+            "type": "string",
+            "description": "メールアドレス",
+            "nullable": true,
+            "maxLength": 255,
+            "example": "test@example.com"
+          },
+          "householder_name": {
+            "type": "string",
+            "description": "世帯主の名前 世帯主の続柄がmyselfの場合は空白",
+            "maxLength": 255,
+            "example": "山田 吾郎"
+          },
+          "householder": {
+            "type": "string",
+            "description": "世帯主の続柄 myself:本人, husband:夫, wife:妻, father:父, mother:母, child:子供, senior_brother:兄, junior_brother:弟, senior_sister:姉, junior_sister:妹, grandchild:孫, grandfather:祖父, grandmother:祖母, father_in_law:義父, mother_in_law:義母, grandfather_in_law:義祖父, grandmother_in_law:義祖母, other:その他",
+            "nullable": true,
+            "enum": [
+              "myself",
+              "husband",
+              "wife",
+              "father",
+              "mother",
+              "child",
+              "senior_brother",
+              "junior_brother",
+              "senior_sister",
+              "junior_sister",
+              "grandchild",
+              "grandfather",
+              "grandmother",
+              "father_in_law",
+              "mother_in_law",
+              "grandfather_in_law",
+              "grandmother_in_law",
+              "other"
+            ],
+            "example": "father"
+          }
+        },
+        "nullable": true
+      },
+      "ApiV1EmployeesDependentRuleUpdateRequestSerializer": {
+        "type": "object",
+        "required": [
+          "last_name",
+          "first_name",
+          "gender",
+          "relationship",
+          "birth_date",
+          "residence_type",
+          "income",
+          "annual_revenue",
+          "disability_type",
+          "social_insurance_and_tax_dependent"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "家族情報ルールID（idがない場合は新規作成になる)",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "last_name": {
+            "type": "string",
+            "description": "姓 null不可",
+            "maxLength": 255,
+            "example": "山田"
+          },
+          "first_name": {
+            "type": "string",
+            "description": "名 null不可",
+            "maxLength": 255,
+            "example": "花子"
+          },
+          "last_name_kana": {
+            "type": "string",
+            "description": "姓カナ",
+            "maxLength": 255,
+            "example": "ヤマダ"
+          },
+          "first_name_kana": {
+            "type": "string",
+            "description": "名カナ",
+            "maxLength": 255,
+            "example": "ハナコ"
+          },
+          "gender": {
+            "type": "string",
+            "description": "性別　unselected: 未選択, male: 男性, female: 女性（デフォルト: unselected: 未選択）",
+            "enum": [
+              "unselected",
+              "male",
+              "female"
+            ],
+            "example": "male"
+          },
+          "relationship": {
+            "type": "string",
+            "description": "続柄 null不可 spouse: 配偶者, father: 父, mother: 母, child: 子, senior_brother: 兄, junior_brother: 弟, senior_sister: 姉, junior_sister: 妹, grandchild: 孫, grandfather: 祖父, grandmother: 祖母, father_in_law: 義父, mother_in_law: 義母, grandfather_in_law: 義祖父, grandmother_in_law: 義祖母, other: その他, great_grandfather: 曽祖父, great_grandmother: 曽祖母, spouses_child: 配偶者の連れ子",
+            "enum": [
+              "spouse",
+              "father",
+              "mother",
+              "child",
+              "senior_brother",
+              "junior_brother",
+              "senior_sister",
+              "junior_sister",
+              "grandchild",
+              "grandfather",
+              "grandmother",
+              "father_in_law",
+              "mother_in_law",
+              "grandfather_in_law",
+              "grandmother_in_law",
+              "other",
+              "great_grandfather",
+              "great_grandmother",
+              "spouses_child"
+            ]
+          },
+          "birth_date": {
+            "type": "string",
+            "description": "生年月日 null不可",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "maxLength": 10,
+            "example": "1999-01-01"
+          },
+          "residence_type": {
+            "type": "string",
+            "description": "同居・別居 null不可 live_in: 同居, resident: 別居(国内), non_resident: 別居(国外)",
+            "enum": [
+              "live_in",
+              "resident",
+              "non_resident"
+            ]
+          },
+          "zipcode1": {
+            "type": "string",
+            "description": "住民票住所の郵便番号1",
+            "maxLength": 3,
+            "example": "000"
+          },
+          "zipcode2": {
+            "type": "string",
+            "description": "住民票住所の郵便番号2",
+            "maxLength": 4,
+            "example": "0000"
+          },
+          "prefecture_code": {
+            "type": "integer",
+            "minimum": -1,
+            "maximum": 46,
+            "description": "住民票住所の都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄)",
+            "example": 4
+          },
+          "address": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所",
+            "maxLength": 255
+          },
+          "address_kana": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所カナ",
+            "maxLength": 255
+          },
+          "base_pension_num": {
+            "type": "string",
+            "description": "基礎年金番号",
+            "maxLength": 10,
+            "example": "1234567890"
+          },
+          "income": {
+            "type": "integer",
+            "description": "年間所得 null不可",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999
+          },
+          "annual_revenue": {
+            "type": "integer",
+            "description": "年間収入 null不可",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999
+          },
+          "disability_type": {
+            "type": "string",
+            "description": "障害に該当するか null不可 na: 障害なし, general: 一般の障害者, heavy: 特別障害者",
+            "enum": [
+              "na",
+              "general",
+              "heavy"
+            ]
+          },
+          "occupation": {
+            "type": "string",
+            "description": "職業",
+            "maxLength": 255
+          },
+          "annual_remittance_amount": {
+            "type": "integer",
+            "description": "一年間の送金額",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999
+          },
+          "employment_insurance_receive_status": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "unselected",
+              "receiving_employment_insurance",
+              "not_receiving_employment_insurance",
+              "pending_employment_insurance"
+            ],
+            "description": "雇用保険受給の有無\n- unselected 未選択\n- receiving_employment_insurance 雇用保険受給有り\n- not_receiving_employment_insurance 雇用保険受給無し\n- pending_employment_insurance 申請中",
+            "format": "string",
+            "example": "receiving_employment_insurance"
+          },
+          "employment_insurance_receives_from": {
+            "type": "string",
+            "nullable": true,
+            "description": "雇用保険受給開始年月日 employment_insurance_receive_statusが未選択、無しの場合は指定できません。",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "example": "2021-04-01"
+          },
+          "health_insurance_qualification_required": {
+            "type": "boolean",
+            "description": "健康保険の資格確認書の発行が必要かどうか"
+          },
+          "phone_type": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "unselected",
+              "home",
+              "office",
+              "mobile",
+              "other"
+            ],
+            "description": "電話番号の種別\n- unselected 未選択\n- home 自宅\n- office 勤務先\n- mobile 携帯\n- other その他"
+          },
+          "phone1": {
+            "type": "string",
+            "nullable": true,
+            "description": "電話番号1（先頭番号、例:03-1111-222x の03部分）",
+            "maxLength": 4,
+            "example": "000"
+          },
+          "phone2": {
+            "type": "string",
+            "nullable": true,
+            "description": "電話番号2（中間番号、例:03-1111-222x の1111部分）",
+            "maxLength": 4,
+            "example": "0000"
+          },
+          "phone3": {
+            "type": "string",
+            "nullable": true,
+            "description": "電話番号3（末尾番号、例:03-1111-222x の222x部分）",
+            "maxLength": 4,
+            "example": "0000"
+          },
+          "destroy": {
+            "type": "boolean",
+            "description": "家族情報を削除するか",
+            "example": false
+          },
+          "social_insurance_and_tax_dependent": {
+            "type": "string",
+            "description": "扶養状況 social_insurance_and_tax: 所得税・住民税と社会保険, tax_only: 所得税・住民税のみ, social_insurance_only: 社会保険のみ, not_dependent: 扶養していない",
+            "enum": [
+              "social_insurance_and_tax",
+              "tax_only",
+              "social_insurance_only",
+              "not_dependent"
+            ]
+          },
+          "social_insurance_dependent_acquisition_date": {
+            "type": "string",
+            "nullable": true,
+            "description": "社会保険の扶養加入日",
+            "format": "date"
+          },
+          "social_insurance_dependent_acquisition_reason": {
+            "type": "string",
+            "enum": [
+              "",
+              "start_working",
+              "marriage",
+              "turnover",
+              "decrease_in_income",
+              "other",
+              "birth",
+              "live_in"
+            ],
+            "description": "社会保険の扶養加入理由 配偶者の場合 \"\": 未選択, start_working: 配偶者の就職, marriage: 婚姻, turnover: 離職, decrease_in_income: 収入減少, other: その他 配偶者以外の場合 \"\": 未選択, birth: 出生, turnover: 離職, decrease_in_income: 収入減, live_in: 同居, other: その他"
+          },
+          "social_insurance_other_dependent_acquisition_reason": {
+            "type": "string",
+            "nullable": true,
+            "description": "社会保険のその他の扶養加入理由",
+            "maxLength": 255
+          },
+          "social_insurance_dependent_disqualification_date": {
+            "type": "string",
+            "nullable": true,
+            "description": "社会保険の扶養喪失日",
+            "format": "date"
+          },
+          "social_insurance_dependent_disqualification_reason": {
+            "type": "string",
+            "enum": [
+              "",
+              "death",
+              "divorce",
+              "start_working_or_increase_in_income",
+              "reach_75_years_old",
+              "disability",
+              "other",
+              "start_working",
+              "increase_in_income"
+            ],
+            "description": "社会保険の扶養喪失理由 配偶者の場合 \"\": 未選択, death: 死亡, divorce: 離婚, start_working_or_increase_in_income: 就職・収入増加, reach_75_years_old: 歳到達, disability: 障害認定, other: その他 配偶者以外の場合 \"\": 未選択, death: 死亡, start_working: 就職, increase_in_income: 収入増加, reach_75_years_old: ７５歳到達, disability: 障害認定, other: その他"
+          },
+          "social_insurance_other_dependent_disqualification_reason": {
+            "type": "string",
+            "nullable": true,
+            "description": "社会保険のその他の扶養喪失理由",
+            "maxLength": 255
+          },
+          "tax_dependent_acquisition_date": {
+            "type": "string",
+            "nullable": true,
+            "description": "税扶養の加入日",
+            "format": "date"
+          },
+          "tax_dependent_acquisition_reason": {
+            "type": "string",
+            "enum": [
+              "",
+              "start_working",
+              "marriage",
+              "turnover",
+              "decrease_in_income",
+              "other",
+              "birth",
+              "live_in"
+            ],
+            "description": "税扶養の加入理由 配偶者の場合 \"\": 未選択, start_working: 配偶者の就職, marriage: 婚姻, turnover: 離職, decrease_in_income: 収入減少, other: その他 配偶者以外の場合 \"\": birth: 出生, turnover: 離職, decrease_in_income: 収入減, live_in: 同居, other: その他"
+          },
+          "tax_other_dependent_acquisition_reason": {
+            "type": "string",
+            "nullable": true,
+            "description": "税扶養のその他の加入理由",
+            "maxLength": 255
+          },
+          "tax_dependent_disqualification_date": {
+            "type": "string",
+            "nullable": true,
+            "description": "税扶養の喪失日",
+            "format": "date"
+          },
+          "tax_dependent_disqualification_reason": {
+            "type": "string",
+            "enum": [
+              "",
+              "death",
+              "divorce",
+              "start_working_or_increase_in_income",
+              "reach_75_years_old",
+              "disability",
+              "other",
+              "start_working",
+              "increase_in_income"
+            ],
+            "description": "税扶養の喪失理由 配偶者の場合 \"\": 未選択, death: 死亡, divorce: 離婚, start_working_or_increase_in_income: 就職・収入増加, reach_75_years_old: 歳到達, disability: 障害認定, other: その他 配偶者以外の場合 \"\": 未選択, death: 死亡, start_working: 就職, increase_in_income: 収入増加, reach_75_years_old: ７５歳到達, disability: 障害認定, other: その他"
+          },
+          "tax_other_dependent_disqualification_reason": {
+            "type": "string",
+            "nullable": true,
+            "description": "税扶養のその他の喪失理由",
+            "maxLength": 255
+          },
+          "non_resident_dependents_reason": {
+            "type": "string",
+            "enum": [
+              "none",
+              "over_16_to_under_30_or_over_70",
+              "study_abroad",
+              "handicapped",
+              "over_38_man"
+            ],
+            "description": "非居住者である親族の条件 none: なし, over_16_to_under_30_or_over_70: 16歳以上30歳未満又は70歳以上, study_abroad: 留学, handicapped: 障害者, over_38_man: 38万円以上の支払",
+            "format": "string"
+          }
+        }
+      },
+      "ApiV1EmployeesTimeClockSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "打刻ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647
+          },
+          "date": {
+            "type": "string",
+            "description": "打刻日",
+            "format": "date"
+          },
+          "type": {
+            "type": "string",
+            "description": "打刻種別(clock_in:出勤, break_begin:休憩開始, break_end:休憩終了, clock_out:退勤)",
+            "enum": [
+              "clock_in",
+              "break_begin",
+              "break_end",
+              "clock_out"
+            ]
+          },
+          "datetime": {
+            "type": "string",
+            "description": "打刻時刻",
+            "format": "date-time"
+          },
+          "original_datetime": {
+            "type": "string",
+            "description": "オリジナルの打刻時間",
+            "format": "date-time"
+          },
+          "note": {
+            "type": "string",
+            "description": "打刻メモ",
+            "maxLength": 255
+          }
+        }
+      },
+      "ApiV1EmployeesWorkRecordSummarySerializer": {
+        "type": "object",
+        "properties": {
+          "year": {
+            "type": "integer",
+            "description": "給与支払い年",
+            "format": "int32"
+          },
+          "month": {
+            "type": "integer",
+            "description": "給与支払い月",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 12
+          },
+          "start_date": {
+            "type": "string",
+            "description": "集計開始日",
+            "format": "date"
+          },
+          "end_date": {
+            "type": "string",
+            "description": "集計終了日",
+            "format": "date"
+          },
+          "work_days": {
+            "type": "number",
+            "description": "労働日数",
+            "format": "float"
+          },
+          "total_work_mins": {
+            "type": "integer",
+            "description": "総勤務時間（分）",
+            "format": "int32"
+          },
+          "total_normal_work_mins": {
+            "type": "integer",
+            "description": "所定内労働時間（分）",
+            "format": "int32"
+          },
+          "total_excess_statutory_work_mins": {
+            "type": "integer",
+            "description": "給与計算に用いられる法定内残業時間（分）",
+            "format": "int32"
+          },
+          "total_overtime_except_normal_work_mins": {
+            "type": "integer",
+            "description": "所定外法定外労働時間",
+            "format": "int32"
+          },
+          "total_overtime_within_normal_work_mins": {
+            "type": "integer",
+            "description": "所定内法定外労働時間（裁量労働制の場合はみなしベース）",
+            "format": "int32"
+          },
+          "total_holiday_work_mins": {
+            "type": "integer",
+            "description": "法定休日労働時間（分）",
+            "format": "int32"
+          },
+          "total_latenight_work_mins": {
+            "type": "integer",
+            "description": "深夜労働allow(company)時間（分）",
+            "format": "int32"
+          },
+          "num_absences": {
+            "type": "number",
+            "description": "欠勤日数",
+            "format": "float"
+          },
+          "num_paid_holidays": {
+            "type": "number",
+            "description": "有給取得日数",
+            "format": "float"
+          },
+          "num_paid_holidays_and_hours": {
+            "$ref": "#/components/schemas/ApiV1HolidaysAndHoursSerializer"
+          },
+          "num_paid_holidays_left": {
+            "type": "number",
+            "description": "有給残日数",
+            "format": "float"
+          },
+          "num_paid_holidays_and_hours_left": {
+            "$ref": "#/components/schemas/ApiV1HolidaysAndHoursSerializer"
+          },
+          "num_substitute_holidays_used": {
+            "type": "number",
+            "description": "振替休日の使用日数",
+            "format": "float"
+          },
+          "num_compensatory_holidays_used": {
+            "type": "number",
+            "description": "代休の使用日数",
+            "format": "float"
+          },
+          "num_special_holidays_used": {
+            "type": "number",
+            "description": "特別休暇の使用日数",
+            "format": "float"
+          },
+          "num_special_holidays_and_hours_used": {
+            "$ref": "#/components/schemas/ApiV1HolidaysAndHoursSerializer"
+          },
+          "total_lateness_and_early_leaving_mins": {
+            "type": "integer",
+            "description": "遅刻早退時間（分）",
+            "format": "int32"
+          },
+          "multi_hourly_wages": {
+            "type": "array",
+            "description": "複数時給の労働時間の内訳（複数時給を設定している従業員のみ）",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesEmployeeMultiHourlyWageWorkRecordSummarySerializer"
+            }
+          },
+          "work_records": {
+            "type": "array",
+            "description": "日々の勤怠情報",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordSerializer"
+                },
+                {
+                  "$ref": "#/components/schemas/LegacyApiV1EmployeesWorkRecordSerializer"
+                }
+              ]
+            }
+          },
+          "total_shortage_work_mins": {
+            "type": "integer",
+            "description": "不足時間（分）",
+            "format": "int32",
+            "nullable": true
+          },
+          "total_deemed_paid_excess_statutory_work_mins": {
+            "type": "integer",
+            "description": "みなし外の法定内残業時間（分）",
+            "format": "int32",
+            "nullable": true
+          },
+          "total_deemed_paid_overtime_except_normal_work_mins": {
+            "type": "integer",
+            "description": "みなし外の時間外労働時間（分）",
+            "format": "int32",
+            "nullable": true
+          }
+        }
+      },
+      "ApiV1EmployeesWorkRecordSerializer": {
+        "type": "object",
+        "properties": {
+          "break_records": {
+            "type": "array",
+            "description": "休憩時間のリスト",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordTimeRangeResponseSerializer"
+            }
+          },
+          "work_record_segments": {
+            "type": "array",
+            "description": "出退勤のリスト\n  - 登録されている全ての出退勤時間のリストを返します。",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordTimeRangeResponseSerializer"
+            }
+          },
+          "clock_in_at": {
+            "type": "string",
+            "description": "出勤時刻\n  - 出勤時刻を返します。出退勤が複数登録されている場合は、最初の出退勤の出勤時間を返します。",
+            "format": "date-time",
+            "nullable": true
+          },
+          "clock_out_at": {
+            "type": "string",
+            "description": "退勤時刻\n  - 退勤時刻を返します。出退勤が複数登録されている場合は、最後の出退勤の退勤時間を返します。",
+            "format": "date-time",
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "description": "対象日付",
+            "format": "date-time"
+          },
+          "day_pattern": {
+            "type": "string",
+            "description": "勤務パターン\n- normal_day: 所定労働日\n- prescribed_holiday: 所定休日\n- legal_holiday: 法定休日",
+            "enum": [
+              "normal_day",
+              "prescribed_holiday",
+              "legal_holiday"
+            ]
+          },
+          "schedule_pattern": {
+            "type": "string",
+            "description": "スケジュールパターン\n- substitute_holiday_work: 振替出勤\n- substitute_holiday: 振替休日\n- compensatory_holiday_work: 代休出勤\n- compensatory_holiday: 代休\n- special_holiday: 特別休暇",
+            "enum": [
+              "",
+              "substitute_holiday_work",
+              "substitute_holiday",
+              "compensatory_holiday_work",
+              "compensatory_holiday",
+              "special_holiday"
+            ]
+          },
+          "early_leaving_mins": {
+            "type": "integer",
+            "description": "早退分の時間（分単位）",
+            "format": "int32"
+          },
+          "half_special_holiday_mins": {
+            "type": "integer",
+            "description": "特別休暇の半休を利用した時間（分単位）",
+            "format": "int32"
+          },
+          "hourly_special_holiday_mins": {
+            "type": "integer",
+            "description": "特別休暇の時間休を利用した時間（分単位）",
+            "format": "int32"
+          },
+          "is_absence": {
+            "type": "boolean",
+            "description": "欠勤かどうか",
+            "example": false
+          },
+          "is_editable": {
+            "type": "boolean",
+            "description": "勤怠データが編集可能かどうか"
+          },
+          "lateness_mins": {
+            "type": "integer",
+            "description": "遅刻分の時間（分単位）",
+            "format": "int32"
+          },
+          "normal_work_clock_in_at": {
+            "type": "string",
+            "description": "所定労働開始時刻",
+            "format": "date-time",
+            "nullable": true
+          },
+          "normal_work_clock_out_at": {
+            "type": "string",
+            "description": "所定労働終了時刻",
+            "format": "date-time",
+            "nullable": true
+          },
+          "normal_work_mins": {
+            "type": "integer",
+            "description": "所定労働時間",
+            "format": "int32"
+          },
+          "note": {
+            "type": "string",
+            "description": "勤怠メモ",
+            "maxLength": 255
+          },
+          "paid_holidays": {
+            "type": "array",
+            "description": "年次有給休暇の実績",
+            "items": {
+              "type": "object",
+              "required": [
+                "type",
+                "mins",
+                "days"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "有給休暇の種別取得単位（full:全休、half:半休、morning_off:午前休、 afternoon_off:午後休、hourly:時間休）",
+                  "enum": [
+                    "full",
+                    "half",
+                    "morning_off",
+                    "afternoon_off",
+                    "hourly"
+                  ],
+                  "nullable": false,
+                  "example": "half"
+                },
+                "mins": {
+                  "type": "integer",
+                  "description": "年次有給休暇の休暇時間（分単位）",
+                  "format": "int32",
+                  "example": 240
+                },
+                "days": {
+                  "type": "number",
+                  "description": "年次有給休暇の消化日数（全休：1, 半日単位：0.5, 時間休：0）",
+                  "format": "float",
+                  "example": 0.5
+                }
+              }
+            }
+          },
+          "special_holiday": {
+            "type": "number",
+            "description": "この日に対する特別休暇取得日数。半休の場合は0.5が入ります。時間休の場合はhourly_special_holiday_minsを所定労働時間で割った値が入るため、実際の時間を確認するにはhourly_special_holiday_minsを参照してください。",
+            "format": "float"
+          },
+          "special_holiday_setting_id": {
+            "type": "integer",
+            "description": "特別休暇設定ID",
+            "format": "int32",
+            "nullable": true
+          },
+          "use_attendance_deduction": {
+            "type": "boolean",
+            "description": "欠勤・遅刻・早退を控除対象時間に算入するかどうか"
+          },
+          "use_default_work_pattern": {
+            "type": "boolean",
+            "description": "デフォルトの勤務時間設定を使っているかどうか"
+          },
+          "use_half_compensatory_holiday": {
+            "type": "boolean",
+            "description": "代休の半休を利用したかどうか",
+            "example": false
+          },
+          "total_overtime_work_mins": {
+            "type": "integer",
+            "description": "時間外労働時間（分）（Webの勤怠登録画面にて詳細項目の「勤務時間の長さを自動で計算しない」にチェックを入れた場合0が返却されます。時間外労働時間はtotal_overtime_except_normal_work_minsを参照してください。）",
+            "format": "int32"
+          },
+          "total_holiday_work_mins": {
+            "type": "integer",
+            "description": "法定休日労働時間（分）",
+            "format": "int32"
+          },
+          "total_latenight_work_mins": {
+            "type": "integer",
+            "description": "深夜労働時間（分）",
+            "format": "int32"
+          },
+          "not_auto_calc_work_time": {
+            "type": "boolean",
+            "description": "勤怠登録時に勤務時間の長さを自動で計算しないかどうか",
+            "example": false
+          },
+          "total_excess_statutory_work_mins": {
+            "type": "integer",
+            "description": "法定内残業時間（分）",
+            "format": "int32"
+          },
+          "total_latenight_excess_statutory_work_mins": {
+            "type": "integer",
+            "description": "深夜の法定内残業時間（分）",
+            "format": "int32"
+          },
+          "total_overtime_except_normal_work_mins": {
+            "type": "integer",
+            "description": "所定外法定外労働時間（分）",
+            "format": "int32"
+          },
+          "total_latenight_overtime_except_normal_work_min": {
+            "type": "integer",
+            "description": "深夜の所定外法定外労働時間（分）",
+            "format": "int32"
+          }
+        }
+      },
+      "LegacyApiV1EmployeesWorkRecordSerializer": {
+        "type": "object",
+        "properties": {
+          "break_records": {
+            "type": "array",
+            "description": "休憩時間のリスト",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordTimeRangeResponseSerializer"
+            }
+          },
+          "work_record_segments": {
+            "type": "array",
+            "description": "出退勤のリスト\n  - 登録されている全ての出退勤時間のリストを返します。",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordTimeRangeResponseSerializer"
+            }
+          },
+          "clock_in_at": {
+            "type": "string",
+            "description": "出勤時刻\n  - 出勤時刻を返します。出退勤が複数登録されている場合は、最初の出退勤の出勤時間を返します。",
+            "format": "date-time",
+            "nullable": true
+          },
+          "clock_out_at": {
+            "type": "string",
+            "description": "退勤時刻\n  - 退勤時刻を返します。出退勤が複数登録されている場合は、最後の出退勤の退勤時間を返します。",
+            "format": "date-time",
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "description": "対象日付",
+            "format": "date-time"
+          },
+          "day_pattern": {
+            "type": "string",
+            "description": "勤務パターン\n- normal_day: 所定労働日\n- prescribed_holiday: 所定休日\n- legal_holiday: 法定休日",
+            "enum": [
+              "normal_day",
+              "prescribed_holiday",
+              "legal_holiday"
+            ]
+          },
+          "schedule_pattern": {
+            "type": "string",
+            "description": "スケジュールパターン\n- substitute_holiday_work: 振替出勤\n- substitute_holiday: 振替休日\n- compensatory_holiday_work: 代休出勤\n- compensatory_holiday: 代休\n- special_holiday: 特別休暇",
+            "enum": [
+              "",
+              "substitute_holiday_work",
+              "substitute_holiday",
+              "compensatory_holiday_work",
+              "compensatory_holiday",
+              "special_holiday"
+            ]
+          },
+          "early_leaving_mins": {
+            "type": "integer",
+            "description": "早退分の時間（分単位）",
+            "format": "int32"
+          },
+          "half_paid_holiday_mins": {
+            "type": "integer",
+            "description": "[deprecated] 有給休暇の半休を利用した時間（分単位）※ 削除予定のため paid_holidays を参照してください",
+            "format": "int32"
+          },
+          "half_special_holiday_mins": {
+            "type": "integer",
+            "description": "特別休暇の半休を利用した時間（分単位）",
+            "format": "int32"
+          },
+          "hourly_paid_holiday_mins": {
+            "type": "integer",
+            "description": "[deprecated] 有給休暇の時間休を利用した時間（分単位）※ 削除予定のため paid_holidays を参照してください",
+            "format": "int32"
+          },
+          "hourly_special_holiday_mins": {
+            "type": "integer",
+            "description": "特別休暇の時間休を利用した時間（分単位）",
+            "format": "int32"
+          },
+          "is_absence": {
+            "type": "boolean",
+            "description": "欠勤かどうか",
+            "example": false
+          },
+          "is_editable": {
+            "type": "boolean",
+            "description": "勤怠データが編集可能かどうか"
+          },
+          "lateness_mins": {
+            "type": "integer",
+            "description": "遅刻分の時間（分単位）",
+            "format": "int32"
+          },
+          "normal_work_clock_in_at": {
+            "type": "string",
+            "description": "所定労働開始時刻",
+            "format": "date-time",
+            "nullable": true
+          },
+          "normal_work_clock_out_at": {
+            "type": "string",
+            "description": "所定労働終了時刻",
+            "format": "date-time",
+            "nullable": true
+          },
+          "normal_work_mins": {
+            "type": "integer",
+            "description": "所定労働時間",
+            "format": "int32"
+          },
+          "note": {
+            "type": "string",
+            "description": "勤怠メモ",
+            "maxLength": 255
+          },
+          "paid_holiday": {
+            "type": "number",
+            "description": "[deprecated] この日に対する有給取得日数。半休の場合は0.5が入ります。時間休の場合はhourly_paid_holiday_minsを所定労働時間で割った値が入るため、実際の時間を確認するにはhourly_paid_holiday_minsを参照してください。※ 削除予定のため paid_holidays を参照してください",
+            "format": "float"
+          },
+          "special_holiday": {
+            "type": "number",
+            "description": "この日に対する特別休暇取得日数。半休の場合は0.5が入ります。時間休の場合はhourly_special_holiday_minsを所定労働時間で割った値が入るため、実際の時間を確認するにはhourly_special_holiday_minsを参照してください。",
+            "format": "float"
+          },
+          "special_holiday_setting_id": {
+            "type": "integer",
+            "description": "特別休暇設定ID",
+            "format": "int32",
+            "nullable": true
+          },
+          "use_attendance_deduction": {
+            "type": "boolean",
+            "description": "欠勤・遅刻・早退を控除対象時間に算入するかどうか"
+          },
+          "use_default_work_pattern": {
+            "type": "boolean",
+            "description": "デフォルトの勤務時間設定を使っているかどうか"
+          },
+          "use_half_compensatory_holiday": {
+            "type": "boolean",
+            "description": "代休の半休を利用したかどうか",
+            "example": false
+          },
+          "total_overtime_work_mins": {
+            "type": "integer",
+            "description": "時間外労働時間（分）（Webの勤怠登録画面にて詳細項目の「勤務時間の長さを自動で計算しない」にチェックを入れた場合0が返却されます。時間外労働時間はtotal_overtime_except_normal_work_minsを参照してください。）",
+            "format": "int32"
+          },
+          "total_holiday_work_mins": {
+            "type": "integer",
+            "description": "法定休日労働時間（分）",
+            "format": "int32"
+          },
+          "total_latenight_work_mins": {
+            "type": "integer",
+            "description": "深夜労働時間（分）",
+            "format": "int32"
+          },
+          "not_auto_calc_work_time": {
+            "type": "boolean",
+            "description": "勤怠登録時に勤務時間の長さを自動で計算しないかどうか",
+            "example": false
+          },
+          "total_excess_statutory_work_mins": {
+            "type": "integer",
+            "description": "法定内残業時間（分）",
+            "format": "int32"
+          },
+          "total_latenight_excess_statutory_work_mins": {
+            "type": "integer",
+            "description": "深夜の法定内残業時間（分）",
+            "format": "int32"
+          },
+          "total_overtime_except_normal_work_mins": {
+            "type": "integer",
+            "description": "所定外法定外労働時間（分）",
+            "format": "int32"
+          },
+          "total_latenight_overtime_except_normal_work_min": {
+            "type": "integer",
+            "description": "深夜の所定外法定外労働時間（分）",
+            "format": "int32"
+          }
+        }
+      },
+      "ApiV1EmployeesWelfarePensionInsuranceRuleUpdateRequestSerializer": {
+        "type": "object",
+        "required": [
+          "standard_monthly_remuneration"
+        ],
+        "properties": {
+          "entried": {
+            "type": "boolean",
+            "description": "厚生年金保険に加入しているかどうか null不可"
+          },
+          "welfare_pension_insurance_salary_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "給与計算時の厚生年金保険料の計算方法",
+            "example": "manual"
+          },
+          "welfare_pension_insurance_bonus_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "賞与計算時の厚生年金保険料の計算方法",
+            "example": "manual"
+          },
+          "manual_welfare_pension_insurance_amount_of_employee_salary": {
+            "type": "integer",
+            "format": "int32",
+            "description": "給与計算時の厚生年金保険料の直接指定金額（従業員負担分）",
+            "example": 1111,
+            "nullable": true,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "manual_welfare_pension_insurance_amount_of_employee_bonus": {
+            "type": "integer",
+            "format": "int32",
+            "description": "賞与計算時の厚生年金保険料の直接指定金額（従業員負担分）",
+            "example": 2222,
+            "nullable": true,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "manual_welfare_pension_insurance_amount_of_company_salary": {
+            "type": "number",
+            "format": "float",
+            "description": "給与計算時の厚生年金保険料の直接指定金額（会社負担分）",
+            "example": 3333.0001,
+            "nullable": true,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "manual_welfare_pension_insurance_amount_of_company_bonus": {
+            "type": "number",
+            "format": "float",
+            "description": "賞与計算時の厚生年金保険料の直接指定金額（会社負担分）",
+            "example": 4444.0001,
+            "nullable": true,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "child_allowance_contribution_salary_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "給与計算時の子ども・子育て拠出金の計算方法",
+            "example": "manual"
+          },
+          "child_allowance_contribution_bonus_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "賞与計算時の子ども・子育て拠出金の計算方法",
+            "example": "manual"
+          },
+          "manual_child_allowance_contribution_amount_salary": {
+            "type": "number",
+            "format": "float",
+            "description": "給与計算時の子ども・子育て拠出金の直接指定金額",
+            "nullable": true,
+            "example": 5555.0001,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "manual_child_allowance_contribution_amount_bonus": {
+            "type": "number",
+            "format": "float",
+            "description": "賞与計算時の子ども・子育て拠出金の直接指定金額",
+            "nullable": true,
+            "example": 6666.0001,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "reference_num": {
+            "type": "string",
+            "description": "厚生年金保険の被保険者整理番号",
+            "maxLength": 255,
+            "example": "0000000000"
+          },
+          "standard_monthly_remuneration": {
+            "type": "integer",
+            "description": "標準報酬月額 null不可",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 88000
+          }
+        }
+      },
+      "ApiV1EmployeesBankAccountRuleUpdateRequestSerializer": {
+        "type": "object",
+        "properties": {
+          "bank_name": {
+            "type": "string",
+            "description": "金融機関名",
+            "maxLength": 255
+          },
+          "bank_name_kana": {
+            "type": "string",
+            "description": "金融機関名カナ 英字カナのみ",
+            "maxLength": 255
+          },
+          "bank_code": {
+            "type": "string",
+            "description": "金融機関コード 数値文字列4桁",
+            "maxLength": 4,
+            "example": "0000"
+          },
+          "branch_name": {
+            "type": "string",
+            "description": "支店名",
+            "maxLength": 255
+          },
+          "branch_name_kana": {
+            "type": "string",
+            "description": "支店名カナ　英字カナのみ",
+            "maxLength": 255
+          },
+          "branch_code": {
+            "type": "string",
+            "description": "支店コード 数値文字列3桁",
+            "maxLength": 3,
+            "example": "000"
+          },
+          "account_number": {
+            "type": "string",
+            "description": "口座番号 数値文字列7桁",
+            "maxLength": 7,
+            "example": "0000000"
+          },
+          "account_name": {
+            "type": "string",
+            "description": "口座名義カナ　英字カナのみ",
+            "maxLength": 50
+          },
+          "account_type": {
+            "type": "string",
+            "description": "預金種類 ordinary: 普通預金, current: 当座預金, saving: 貯蓄預金",
+            "enum": [
+              "ordinary",
+              "current",
+              "saving"
+            ]
+          }
+        }
+      },
+      "ApiV1EmployeesBasicPayRuleUpdateRequestSerializer": {
+        "type": "object",
+        "required": [
+          "pay_calc_type",
+          "pay_amount"
+        ],
+        "properties": {
+          "pay_calc_type": {
+            "type": "string",
+            "description": "給与方式 null不可 monthly: 月給, daily: 日給, hourly: 時給",
+            "enum": [
+              "monthly",
+              "daily",
+              "hourly"
+            ],
+            "example": "monthly"
+          },
+          "pay_amount": {
+            "type": "integer",
+            "description": "基本給 null不可",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 99999999,
+            "example": 220000
+          }
+        }
+      },
+      "ApiV1EmployeesHealthInsuranceRuleSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "健康保険ルールID",
+            "format": "int32"
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32"
+          },
+          "employee_id": {
+            "type": "integer",
+            "description": "従業員ID",
+            "format": "int32"
+          },
+          "entried": {
+            "type": "boolean",
+            "description": "健康保険に加入しているかどうか"
+          },
+          "health_insurance_salary_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "給与計算時の健康保険料の計算方法",
+            "example": "manual"
+          },
+          "health_insurance_bonus_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "賞与計算時の健康保険料の計算方法",
+            "example": "manual"
+          },
+          "health_insurance_qualification_required": {
+            "type": "boolean",
+            "description": "健康保険の資格確認書の発行が必要かどうか"
+          },
+          "manual_health_insurance_amount_of_employee_salary": {
+            "type": "integer",
+            "format": "int32",
+            "description": "給与計算時の健康保険料の直接指定金額（従業員負担分）",
+            "example": 8888,
+            "nullable": true,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "manual_health_insurance_amount_of_employee_bonus": {
+            "type": "integer",
+            "format": "int32",
+            "description": "賞与計算時の健康保険料の直接指定金額（従業員負担分）",
+            "example": 7777,
+            "nullable": true,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "manual_health_insurance_amount_of_company_salary": {
+            "type": "number",
+            "format": "float",
+            "description": "給与計算時の健康保険料の直接指定金額（会社負担分）",
+            "example": 6666.0001,
+            "nullable": true,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "manual_health_insurance_amount_of_company_bonus": {
+            "type": "number",
+            "format": "float",
+            "description": "賞与計算時の健康保険料の直接指定金額（会社負担分）",
+            "example": 5555.0001,
+            "nullable": true,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "care_insurance_salary_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "給与計算時の介護保険料の計算方法",
+            "example": "manual"
+          },
+          "care_insurance_bonus_calc_type": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "manual"
+            ],
+            "description": "賞与計算時の介護保険料の計算方法",
+            "example": "manual"
+          },
+          "manual_care_insurance_amount_of_employee_salary": {
+            "type": "integer",
+            "format": "int32",
+            "description": "給与計算時の介護保険料の直接指定金額（従業員負担分）",
+            "example": 4444,
+            "nullable": true,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "manual_care_insurance_amount_of_employee_bonus": {
+            "type": "integer",
+            "format": "int32",
+            "description": "賞与計算時の介護保険料の直接指定金額（従業員負担分）",
+            "example": 3333,
+            "nullable": true,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "manual_care_insurance_amount_of_company_salary": {
+            "type": "number",
+            "format": "float",
+            "description": "給与計算時の介護保険料の直接指定金額（会社負担分）",
+            "example": 2222.0001,
+            "nullable": true,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "manual_care_insurance_amount_of_company_bonus": {
+            "type": "number",
+            "format": "float",
+            "description": "賞与計算時の介護保険料の直接指定金額（会社負担分）",
+            "example": 1111.0001,
+            "nullable": true,
+            "minimum": -999999999.9999,
+            "maximum": 999999999.9999
+          },
+          "reference_num": {
+            "type": "string",
+            "description": "健康保険の被保険者整理番号",
+            "nullable": true
+          },
+          "standard_monthly_remuneration": {
+            "type": "integer",
+            "description": "標準報酬月額",
+            "format": "int32"
+          }
+        },
+        "nullable": true
+      },
+      "ApiV1EmployeesBankAccountRuleSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "銀行口座ルールID",
+            "format": "int32"
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32"
+          },
+          "employee_id": {
+            "type": "integer",
+            "description": "従業員ID",
+            "format": "int32"
+          },
+          "bank_name": {
+            "type": "string",
+            "description": "金融機関名",
+            "nullable": true
+          },
+          "bank_name_kana": {
+            "type": "string",
+            "description": "金融機関名カナ",
+            "nullable": true
+          },
+          "bank_code": {
+            "type": "string",
+            "description": "金融機関コード",
+            "nullable": true
+          },
+          "branch_name": {
+            "type": "string",
+            "description": "支店名",
+            "nullable": true
+          },
+          "branch_name_kana": {
+            "type": "string",
+            "description": "支店名カナ",
+            "nullable": true
+          },
+          "branch_code": {
+            "type": "string",
+            "description": "支店コード",
+            "nullable": true
+          },
+          "account_number": {
+            "type": "string",
+            "description": "口座番号",
+            "nullable": true
+          },
+          "account_name": {
+            "type": "string",
+            "description": "口座名義カナ",
+            "nullable": true
+          },
+          "account_type": {
+            "type": "string",
+            "description": "預金種類 ordinary: 普通預金, current: 当座預金, saving: 貯蓄預金",
+            "nullable": true
+          }
+        },
+        "nullable": true
+      },
+      "ApiV1EmployeesDependentRuleSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "家族情報ルールID",
+            "format": "int32"
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32"
+          },
+          "employee_id": {
+            "type": "integer",
+            "description": "従業員ID",
+            "format": "int32"
+          },
+          "last_name": {
+            "type": "string",
+            "description": "姓"
+          },
+          "first_name": {
+            "type": "string",
+            "description": "名"
+          },
+          "last_name_kana": {
+            "type": "string",
+            "description": "姓カナ",
+            "nullable": true
+          },
+          "first_name_kana": {
+            "type": "string",
+            "description": "名カナ",
+            "nullable": true
+          },
+          "gender": {
+            "type": "string",
+            "description": "性別　unselected: 未選択, male: 男性, female: 女性",
+            "enum": [
+              "unselected",
+              "male",
+              "female"
+            ]
+          },
+          "relationship": {
+            "type": "string",
+            "description": "続柄 spouse: 配偶者, father: 父, mother: 母, child: 子, senior_brother: 兄, junior_brother: 弟, senior_sister: 姉, junior_sister: 妹, grandchild: 孫, grandfather: 祖父, grandmother: 祖母, father_in_law: 義父, mother_in_law: 義母, grandfather_in_law: 義祖父, grandmother_in_law: 義祖母, other: その他, great_grandfather: 曽祖父, great_grandmother: 曽祖母, spouses_child: 配偶者の連れ子"
+          },
+          "birth_date": {
+            "type": "string",
+            "description": "生年月日",
+            "format": "date"
+          },
+          "residence_type": {
+            "type": "string",
+            "description": "同居・別居 live_in: 同居, resident: 別居(国内), non_resident: 別居(国外)"
+          },
+          "zipcode1": {
+            "type": "string",
+            "description": "住民票住所の郵便番号1",
+            "nullable": true
+          },
+          "zipcode2": {
+            "type": "string",
+            "description": "住民票住所の郵便番号2",
+            "nullable": true
+          },
+          "prefecture_code": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": -1,
+            "maximum": 46,
+            "description": "住民票住所の都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄)",
+            "example": 4
+          },
+          "address": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所",
+            "nullable": true
+          },
+          "address_kana": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所カナ",
+            "nullable": true
+          },
+          "base_pension_num": {
+            "type": "string",
+            "description": "基礎年金番号",
+            "nullable": true
+          },
+          "income": {
+            "type": "integer",
+            "description": "年間所得",
+            "format": "int32"
+          },
+          "annual_revenue": {
+            "type": "integer",
+            "description": "年間収入",
+            "format": "int32"
+          },
+          "disability_type": {
+            "type": "string",
+            "description": "障害に該当するか na: 障害なし, general: 一般の障害者, heavy: 特別障害者"
+          },
+          "occupation": {
+            "type": "string",
+            "description": "職業",
+            "nullable": true
+          },
+          "annual_remittance_amount": {
+            "type": "integer",
+            "description": "一年間の送金額",
+            "format": "int32"
+          },
+          "employment_insurance_receive_status": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "unselected",
+              "receiving_employment_insurance",
+              "not_receiving_employment_insurance",
+              "pending_employment_insurance"
+            ],
+            "description": "雇用保険受給の有無\n- unselected 未選択\n- receiving_employment_insurance 雇用保険受給有り\n- not_receiving_employment_insurance 雇用保険受給無し\n- pending_employment_insurance 申請中",
+            "format": "string"
+          },
+          "employment_insurance_receives_from": {
+            "type": "string",
+            "nullable": true,
+            "description": "雇用保険受給開始年月日 employment_insurance_receive_statusが未選択、無しの場合は指定できません。",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "health_insurance_qualification_required": {
+            "type": "boolean",
+            "description": "健康保険の資格確認書の発行が必要かどうか"
+          },
+          "phone_type": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "unselected",
+              "home",
+              "office",
+              "mobile",
+              "other"
+            ],
+            "description": "電話番号の種別\n- unselected 未選択\n- home 自宅\n- office 勤務先\n- mobile 携帯\n- other その他"
+          },
+          "phone1": {
+            "type": "string",
+            "nullable": true,
+            "description": "電話番号1（先頭番号、例:03-1111-222x の03部分）",
+            "example": "000"
+          },
+          "phone2": {
+            "type": "string",
+            "nullable": true,
+            "description": "電話番号2（中間番号、例:03-1111-222x の1111部分）",
+            "example": "0000"
+          },
+          "phone3": {
+            "type": "string",
+            "nullable": true,
+            "description": "電話番号3（末尾番号、例:03-1111-222x の222x部分）",
+            "example": "0000"
+          },
+          "social_insurance_and_tax_dependent": {
+            "type": "string",
+            "description": "扶養状況 social_insurance_and_tax: 所得税・住民税と社会保険, tax_only: 所得税・住民税のみ, social_insurance_only: 社会保険のみ"
+          },
+          "social_insurance_dependent_acquisition_date": {
+            "type": "string",
+            "nullable": true,
+            "description": "社会保険の扶養加入日",
+            "format": "date"
+          },
+          "social_insurance_dependent_acquisition_reason": {
+            "type": "string",
+            "enum": [
+              "",
+              "start_working",
+              "marriage",
+              "turnover",
+              "decrease_in_income",
+              "other",
+              "birth",
+              "live_in"
+            ],
+            "description": "社会保険の扶養加入理由 配偶者の場合 \"\": 未選択, start_working: 配偶者の就職, marriage: 婚姻, turnover: 離職, decrease_in_income: 収入減少, other: その他 配偶者以外の場合 \"\": 未選択, birth: 出生, turnover: 離職, decrease_in_income: 収入減, live_in: 同居, other: その他"
+          },
+          "social_insurance_other_dependent_acquisition_reason": {
+            "type": "string",
+            "nullable": true,
+            "description": "社会保険のその他の扶養加入理由",
+            "maxLength": 255
+          },
+          "social_insurance_dependent_disqualification_date": {
+            "type": "string",
+            "nullable": true,
+            "description": "社会保険の扶養喪失日",
+            "format": "date"
+          },
+          "social_insurance_dependent_disqualification_reason": {
+            "type": "string",
+            "enum": [
+              "",
+              "death",
+              "divorce",
+              "start_working_or_increase_in_income",
+              "reach_75_years_old",
+              "disability",
+              "other",
+              "start_working",
+              "increase_in_income"
+            ],
+            "description": "社会保険の扶養喪失理由 配偶者の場合 \"\": 未選択, death: 死亡, divorce: 離婚, start_working_or_increase_in_income: 就職・収入増加, reach_75_years_old: 歳到達, disability: 障害認定, other: その他 配偶者以外の場合 \"\": 未選択, death: 死亡, start_working: 就職, increase_in_income: 収入増加, reach_75_years_old: ７５歳到達, disability: 障害認定, other: その他"
+          },
+          "social_insurance_other_dependent_disqualification_reason": {
+            "type": "string",
+            "nullable": true,
+            "description": "社会保険のその他の扶養喪失理由",
+            "maxLength": 255
+          },
+          "tax_dependent_acquisition_date": {
+            "type": "string",
+            "nullable": true,
+            "description": "税扶養の加入日",
+            "format": "date"
+          },
+          "tax_dependent_acquisition_reason": {
+            "type": "string",
+            "enum": [
+              "",
+              "start_working",
+              "marriage",
+              "turnover",
+              "decrease_in_income",
+              "other",
+              "birth",
+              "live_in"
+            ],
+            "description": "税扶養の加入理由 配偶者の場合 \"\": 未選択, start_working: 配偶者の就職, marriage: 婚姻, turnover: 離職, decrease_in_income: 収入減少, other: その他 配偶者以外の場合 \"\": birth: 出生, turnover: 離職, decrease_in_income: 収入減, live_in: 同居, other: その他"
+          },
+          "tax_other_dependent_acquisition_reason": {
+            "type": "string",
+            "nullable": true,
+            "description": "税扶養のその他の加入理由",
+            "maxLength": 255
+          },
+          "tax_dependent_disqualification_date": {
+            "type": "string",
+            "nullable": true,
+            "description": "税扶養の喪失日",
+            "format": "date"
+          },
+          "tax_dependent_disqualification_reason": {
+            "type": "string",
+            "enum": [
+              "",
+              "death",
+              "divorce",
+              "start_working_or_increase_in_income",
+              "reach_75_years_old",
+              "disability",
+              "other",
+              "start_working",
+              "increase_in_income"
+            ],
+            "description": "税扶養の喪失理由 配偶者の場合 \"\": 未選択, death: 死亡, divorce: 離婚, start_working_or_increase_in_income: 就職・収入増加, reach_75_years_old: 歳到達, disability: 障害認定, other: その他 配偶者以外の場合 \"\": 未選択, death: 死亡, start_working: 就職, increase_in_income: 収入増加, reach_75_years_old: ７５歳到達, disability: 障害認定, other: その他"
+          },
+          "tax_other_dependent_disqualification_reason": {
+            "type": "string",
+            "nullable": true,
+            "description": "税扶養のその他の喪失理由",
+            "maxLength": 255
+          },
+          "non_resident_dependents_reason": {
+            "type": "string",
+            "enum": [
+              "none",
+              "over_16_to_under_30_or_over_70",
+              "study_abroad",
+              "handicapped",
+              "over_38_man"
+            ],
+            "description": "非居住者である親族の条件 none: なし, over_16_to_under_30_or_over_70: 16歳以上30歳未満又は70歳以上, study_abroad: 留学, handicapped: 障害者, over_38_man: 38万円以上の支払",
+            "format": "string"
+          }
+        }
+      },
+      "ApiV1EmployeesBasicPayRuleSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "従業員の基本給ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647
+          },
+          "employee_id": {
+            "type": "integer",
+            "description": "従業員ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647
+          },
+          "pay_calc_type": {
+            "type": "string",
+            "description": "給与方式 monthly: 月給, daily: 日給, hourly: 時給",
+            "enum": [
+              "monthly",
+              "daily",
+              "hourly"
+            ]
+          },
+          "pay_amount": {
+            "type": "integer",
+            "description": "基本給",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 99999999
+          }
+        },
+        "nullable": true
+      },
+      "ApiV1ProfileCustomFieldGroupSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "グループID",
+            "format": "int32",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "グループ名",
+            "example": "資格取得結果"
+          },
+          "profile_custom_field_rules": {
+            "type": "array",
+            "description": "カスタム項目",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeeProfileCustomFieldSerializer"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeeProfileCustomFieldSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "カスタム項目ID",
+            "format": "int32",
+            "example": 1
+          },
+          "field_type": {
+            "type": "string",
+            "description": "項目タイプ file: ファイル, text: テキスト, number: 数値, date: 日付, selector: セレクター, time: 時間",
+            "enum": [
+              "file",
+              "text",
+              "number",
+              "date",
+              "selector",
+              "time"
+            ],
+            "example": "file"
+          },
+          "name": {
+            "type": "string",
+            "description": "項目名",
+            "example": "証明書ファイル"
+          },
+          "value": {
+            "type": "string",
+            "description": "値（項目タイプがfileの場合、nullを返します）",
+            "nullable": true,
+            "example": "null"
+          },
+          "file_name": {
+            "type": "string",
+            "description": "ファイル名（項目タイプがfile以外の場合、nullを返します）",
+            "nullable": true,
+            "example": "証明書ファイル.jpeg"
+          }
+        }
+      },
+      "ApiV1EmployeesProfileCustomFieldRulesController.index_response": {
+        "type": "object",
+        "properties": {
+          "profile_custom_field_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1ProfileCustomFieldGroupSerializer"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeesController.show_response": {
+        "type": "object",
+        "properties": {
+          "employee": {
+            "$ref": "#/components/schemas/ApiV1EmployeeSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesController.create_response": {
+        "type": "object",
+        "properties": {
+          "employee": {
+            "$ref": "#/components/schemas/ApiV1EmployeeSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesController.create_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "employee"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "作成対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647
+          },
+          "employee": {
+            "$ref": "#/components/schemas/ApiV1EmployeeCreateRequestSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesController.update_response": {
+        "type": "object",
+        "properties": {
+          "employee": {
+            "$ref": "#/components/schemas/ApiV1EmployeeSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesController.update_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "employee"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "更新対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "year": {
+            "type": "integer",
+            "description": "更新対象年\n- 給与計算対象の従業員情報の場合は必須になります。",
+            "format": "int32",
+            "minimum": 2000,
+            "maximum": 2100,
+            "example": 2021
+          },
+          "month": {
+            "type": "integer",
+            "description": "更新対象月\n- 給与計算対象の従業員情報の場合は必須になります。\n- 締め日支払い日設定が翌月払いの従業員情報の場合は、 指定したmonth + 1の値が更新されます。\n- 翌月払いの従業員の2022/01の従業員情報を更新する場合は、year=2021,month=12を指定してください。",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 12,
+            "example": 1
+          },
+          "employee": {
+            "$ref": "#/components/schemas/ApiV1EmployeeUpdateRequestSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesProfileRulesController.show_response": {
+        "type": "object",
+        "properties": {
+          "employee_profile_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesProfileRuleSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesProfileRulesController.update_response": {
+        "type": "object",
+        "properties": {
+          "employee_profile_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesProfileRuleSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesProfileRulesController.update_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "year",
+          "month",
+          "employee_profile_rule"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "description": "更新対象事業所ID（必須）",
+            "format": "int32"
+          },
+          "year": {
+            "type": "integer",
+            "minimum": 2000,
+            "maximum": 2100,
+            "description": "更新対象年（必須）",
+            "format": "int32",
+            "example": 2021
+          },
+          "month": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 12,
+            "example": 1,
+            "description": "更新対象月（必須）<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、指定したmonth + 1の値が更新されます。<br>\n翌月払いの従業員の2022/01の従業員情報を更新する場合は、year=2021,month=12を指定してください。<br>",
+            "format": "int32"
+          },
+          "employee_profile_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesProfileRuleUpdateRequestSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesHealthInsuranceRulesController.show_response": {
+        "type": "object",
+        "properties": {
+          "employee_health_insurance_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesHealthInsuranceRuleSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesHealthInsuranceRulesController.update_response": {
+        "type": "object",
+        "properties": {
+          "employee_health_insurance_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesHealthInsuranceRuleSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesHealthInsuranceRulesController.update_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "year",
+          "month",
+          "employee_health_insurance_rule"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "更新対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "year": {
+            "type": "integer",
+            "description": "更新対象年（必須）",
+            "format": "int32",
+            "minimum": 2000,
+            "maximum": 2100,
+            "example": 2021
+          },
+          "month": {
+            "type": "integer",
+            "description": "更新対象月（必須）<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、 指定したmonth + 1の値が更新されます。<br>\n翌月払いの従業員の2022/01の従業員情報を更新する場合は、year=2021,month=12を指定してください。<br>",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 12,
+            "example": 1
+          },
+          "employee_health_insurance_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesHealthInsuranceRuleUpdateRequestSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesWelfarePensionInsuranceRulesController.show_response": {
+        "type": "object",
+        "properties": {
+          "employee_welfare_pension_insurance_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesWelfarePensionInsuranceRuleSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesWelfarePensionInsuranceRulesController.update_response": {
+        "type": "object",
+        "properties": {
+          "employee_welfare_pension_insurance_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesWelfarePensionInsuranceRuleSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesWelfarePensionInsuranceRulesController.update_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "year",
+          "month",
+          "employee_welfare_pension_insurance_rule"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "更新対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647
+          },
+          "year": {
+            "type": "integer",
+            "description": "更新対象年（必須）",
+            "format": "int32",
+            "minimum": 2000,
+            "maximum": 2100,
+            "example": 2021
+          },
+          "month": {
+            "type": "integer",
+            "description": "更新対象月（必須）<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、 指定したmonth + 1の値が更新されます。<br>\n翌月払いの従業員の2022/01の従業員情報を更新する場合は、year=2021,month=12を指定してください。<br>",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 12,
+            "example": 1
+          },
+          "employee_welfare_pension_insurance_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesWelfarePensionInsuranceRuleUpdateRequestSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesDependentRulesController.index_response": {
+        "type": "object",
+        "properties": {
+          "employee_dependent_rules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesDependentRuleSerializer"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeesDependentRulesController.bulk_update_response": {
+        "type": "object",
+        "properties": {
+          "employee_dependent_rules": {
+            "type": "array",
+            "description": "家族情報ルール",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesDependentRuleSerializer"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeesDependentRulesController.bulk_update_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "year",
+          "month",
+          "employee_dependent_rules"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "更新対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647
+          },
+          "year": {
+            "type": "integer",
+            "description": "更新対象年（必須）",
+            "format": "int32",
+            "minimum": 2000,
+            "maximum": 2100,
+            "example": 2021
+          },
+          "month": {
+            "type": "integer",
+            "description": "更新対象月（必須）<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、 指定したmonth + 1の値が更新されます。<br>\n翌月払いの従業員の2022/01の従業員情報を更新する場合は、year=2021,month=12を指定してください。<br>",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 12,
+            "example": 1
+          },
+          "employee_dependent_rules": {
+            "type": "array",
+            "description": "家族情報ルール",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesDependentRuleUpdateRequestSerializer"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeesBankAccountRulesController.show_response": {
+        "type": "object",
+        "properties": {
+          "employee_bank_account_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesBankAccountRuleSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesBankAccountRulesController.update_response": {
+        "type": "object",
+        "properties": {
+          "employee_bank_account_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesBankAccountRuleSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesBankAccountRulesController.update_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "year",
+          "month",
+          "employee_bank_account_rule"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "更新対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647
+          },
+          "year": {
+            "type": "integer",
+            "description": "更新対象年（必須）",
+            "format": "int32",
+            "minimum": 2000,
+            "maximum": 2100,
+            "example": 2021
+          },
+          "month": {
+            "type": "integer",
+            "description": "更新対象月（必須）<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、 指定したmonth + 1の値が更新されます。<br>\n翌月払いの従業員の2022/01の従業員情報を更新する場合は、year=2021,month=12を指定してください。<br>",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 12,
+            "example": 1
+          },
+          "employee_bank_account_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesBankAccountRuleUpdateRequestSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesBasicPayRulesController.show_response": {
+        "type": "object",
+        "properties": {
+          "employee_basic_pay_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesBasicPayRuleSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesBasicPayRulesController.update_response": {
+        "type": "object",
+        "properties": {
+          "employee_basic_pay_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesBasicPayRuleSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesBasicPayRulesController.update_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "year",
+          "month",
+          "employee_basic_pay_rule"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "更新対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "year": {
+            "type": "integer",
+            "description": "更新対象年（必須）",
+            "format": "int32",
+            "minimum": 2000,
+            "maximum": 2100,
+            "example": 2021
+          },
+          "month": {
+            "type": "integer",
+            "description": "更新対象月（必須）<br>\n締め日支払い日設定が翌月払いの従業員情報の場合は、 指定したmonth + 1の値が更新されます<br>\n翌月払いの従業員の2022/01の従業員情報を更新する場合は、year=2021,month=12を指定してください。<br>",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 12,
+            "example": 1
+          },
+          "employee_basic_pay_rule": {
+            "$ref": "#/components/schemas/ApiV1EmployeesBasicPayRuleUpdateRequestSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesWorkRecordsController.update_body": {
+        "type": "object",
+        "required": [
+          "company_id"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647
+          },
+          "break_records": {
+            "type": "array",
+            "description": "休憩時間のリスト",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordTimeRangeSerializer"
+            }
+          },
+          "work_record_segments": {
+            "type": "array",
+            "description": "出退勤のリスト",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordTimeRangeSerializer"
+            }
+          },
+          "clock_in_at": {
+            "type": "string",
+            "description": "出勤時刻  \n\n複数の出退勤を指定できないため非推奨です。 `work_record_segments` を利用してください。",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "2018-07-31 08:00:00"
+          },
+          "clock_out_at": {
+            "type": "string",
+            "description": "退勤時刻\n\n複数の出退勤を指定できないため非推奨です。 `work_record_segments` を利用してください。",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "2018-07-31 08:00:00"
+          },
+          "day_pattern": {
+            "type": "string",
+            "description": "勤務パターン（所定労働日: normal_day, 所定休日: prescribed_holiday, 法定休日: legal_holiday）\n\nprescribed_holiday、legal_holidayを指定すると、以下のパラメータについて、指定した値が反映されず無視されます。\n- early_leaving_mins\n- lateness_mins\n- paid_holiday",
+            "enum": [
+              "normal_day",
+              "prescribed_holiday",
+              "legal_holiday"
+            ]
+          },
+          "early_leaving_mins": {
+            "type": "integer",
+            "description": "早退分の時間（分単位）",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1440
+          },
+          "is_absence": {
+            "type": "boolean",
+            "description": "欠勤かどうか\n\nis_absenceにtrueを指定すると、以下のパラーメータについて、指定した値が反映されず無視されます。\n- break_records\n  - clock_in_at\n  - clock_out_at\n- clock_in_at\n- clock_out_at\n- early_leaving_mins\n- lateness_mins\n- normal_work_clock_in_at\n- normal_work_clock_out_at\n- normal_work_mins\n- paid_holidays\n- special_holiday\n- special_holiday_setting_id\n- half_special_holiday_mins\n- hourly_special_holiday_mins"
+          },
+          "lateness_mins": {
+            "type": "integer",
+            "description": "遅刻分の時間（分単位）",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1440
+          },
+          "normal_work_clock_in_at": {
+            "type": "string",
+            "description": "所定労働開始時刻。指定しない場合はデフォルト設定が使用されます。（デフォルト設定は従業員に設定した勤務賃金設定の出退勤時刻と労働時間の設定を参照して値が決まります。）",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "2018-07-31 08:00:00"
+          },
+          "normal_work_clock_out_at": {
+            "type": "string",
+            "description": "所定労働終了時刻。指定しない場合はデフォルト設定が使用されます。（デフォルト設定は従業員に設定した勤務賃金設定の出退勤時刻と労働時間の設定を参照して値が決まります。）",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "2018-07-31 08:00:00"
+          },
+          "normal_work_mins": {
+            "type": "integer",
+            "description": "所定労働時間。指定しない場合はデフォルト設定が使用されます。（デフォルト設定は従業員に設定した勤務賃金設定の出退勤時刻と労働時間の設定を参照して値が決まります。）",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1440
+          },
+          "note": {
+            "type": "string",
+            "description": "勤怠メモ",
+            "maxLength": 255
+          },
+          "paid_holidays": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "有給休暇の種別を指定します（全休：full, 半休：half, 午前休：morning_off, 午後休：afternoon_off, 時間休：hourly）",
+                  "enum": [
+                    "full",
+                    "half",
+                    "morning_off",
+                    "afternoon_off",
+                    "hourly"
+                  ],
+                  "nullable": false,
+                  "example": "half"
+                },
+                "mins": {
+                  "type": "integer",
+                  "description": "有給休暇を利用した時間（分単位） ※ 全休の場合や午前休、午後休の場合にはこちらの値は参照されません",
+                  "format": "int32",
+                  "minimum": 0
+                }
+              }
+            }
+          },
+          "special_holiday": {
+            "type": "number",
+            "description": "この日の特別休暇取得日数。1日単位で指定します。",
+            "format": "float",
+            "enum": [
+              0,
+              1
+            ],
+            "example": "1.0"
+          },
+          "special_holiday_setting_id": {
+            "type": "integer",
+            "description": "特別休暇設定ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "nullable": true
+          },
+          "half_special_holiday_mins": {
+            "type": "integer",
+            "description": "特別休暇の半休を利用した時間（分単位）",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1440
+          },
+          "hourly_special_holiday_mins": {
+            "type": "integer",
+            "description": "特別休暇の時間休を利用した時間（分単位）",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1440
+          },
+          "use_attendance_deduction": {
+            "type": "boolean",
+            "description": "欠勤・遅刻・早退を控除対象時間に算入するかどうか"
+          },
+          "use_default_work_pattern": {
+            "type": "boolean",
+            "description": "デフォルトの勤務設定を使うかどうか。\n\ntrueを指定した場合、以下のパラメータについて、指定した値に関係なく、従業員に設定した勤務賃金設定の休日の設定を参照して値が決まります\n- day_pattern\n\ntrueを指定した場合、以下のパラメータについて、指定した値に関係なく、従業員に設定した勤務賃金設定の出退勤時刻と労働時間の設定を参照して値が決まります。\n- normal_work_clock_in_at\n- normal_work_clock_out_at\n- normal_work_mins"
+          }
+        }
+      },
+      "LegacyApiV1EmployeesWorkRecordsController.update_body": {
+        "type": "object",
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647
+          },
+          "break_records": {
+            "type": "array",
+            "description": "休憩時間のリスト",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordTimeRangeSerializer"
+            }
+          },
+          "work_record_segments": {
+            "type": "array",
+            "description": "出退勤のリスト",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesWorkRecordTimeRangeSerializer"
+            }
+          },
+          "clock_in_at": {
+            "type": "string",
+            "description": "出勤時刻  \n\n複数の出退勤を指定できないため非推奨です。 `work_record_segments` を利用してください。",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "2018-07-31 08:00:00"
+          },
+          "clock_out_at": {
+            "type": "string",
+            "description": "退勤時刻\n\n複数の出退勤を指定できないため非推奨です。 `work_record_segments` を利用してください。",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "2018-07-31 08:00:00"
+          },
+          "day_pattern": {
+            "type": "string",
+            "description": "勤務パターン（所定労働日: normal_day, 所定休日: prescribed_holiday, 法定休日: legal_holiday）\n\nprescribed_holiday、legal_holidayを指定すると、以下のパラメータについて、指定した値が反映されず無視されます。\n- early_leaving_mins\n- lateness_mins\n- paid_holiday",
+            "enum": [
+              "normal_day",
+              "prescribed_holiday",
+              "legal_holiday"
+            ]
+          },
+          "early_leaving_mins": {
+            "type": "integer",
+            "description": "早退分の時間（分単位）",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1440
+          },
+          "is_absence": {
+            "type": "boolean",
+            "description": "欠勤かどうか\n\nis_absenceにtrueを指定すると、以下のパラーメータについて、指定した値が反映されず無視されます。\n- break_records\n  - clock_in_at\n  - clock_out_at\n- clock_in_at\n- clock_out_at\n- early_leaving_mins\n- lateness_mins\n- normal_work_clock_in_at\n- normal_work_clock_out_at\n- normal_work_mins\n- paid_holiday\n- half_paid_holiday_mins\n- hourly_paid_holiday_mins\n- special_holiday\n- special_holiday_setting_id\n- half_special_holiday_mins\n- hourly_special_holiday_mins"
+          },
+          "lateness_mins": {
+            "type": "integer",
+            "description": "遅刻分の時間（分単位）",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1440
+          },
+          "normal_work_clock_in_at": {
+            "type": "string",
+            "description": "所定労働開始時刻。指定しない場合はデフォルト設定が使用されます。（デフォルト設定は従業員に設定した勤務賃金設定の出退勤時刻と労働時間の設定を参照して値が決まります。）",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "2018-07-31 08:00:00"
+          },
+          "normal_work_clock_out_at": {
+            "type": "string",
+            "description": "所定労働終了時刻。指定しない場合はデフォルト設定が使用されます。（デフォルト設定は従業員に設定した勤務賃金設定の出退勤時刻と労働時間の設定を参照して値が決まります。）",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "2018-07-31 08:00:00"
+          },
+          "normal_work_mins": {
+            "type": "integer",
+            "description": "所定労働時間。指定しない場合はデフォルト設定が使用されます。（デフォルト設定は従業員に設定した勤務賃金設定の出退勤時刻と労働時間の設定を参照して値が決まります。）",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1440
+          },
+          "note": {
+            "type": "string",
+            "description": "勤怠メモ",
+            "maxLength": 255
+          },
+          "paid_holiday": {
+            "type": "number",
+            "description": "[deprecated] この日の有休取得日数。1日単位で指定します。 ※ paid_holidays を指定する場合にはこちらの値は参照されません ※ 削除予定のため paid_holidays->type を指定してください",
+            "format": "float",
+            "enum": [
+              0,
+              1
+            ],
+            "example": "1.0"
+          },
+          "half_paid_holiday_mins": {
+            "type": "integer",
+            "description": "[deprecated] 有給休暇の半休を利用した時間（分単位） ※ paid_holidaysを指定する場合にはこちらの値は参照されません ※ 削除予定のためpaid_holidays->mins を指定してください",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1440
+          },
+          "hourly_paid_holiday_mins": {
+            "type": "integer",
+            "description": "[deprecated] morning_off または afternoon_off を指定します ※ paid_holidaysを指定する場合にはこちらの値は参照使用されません ※ 削除予定のため paid_holidays->type を指定してください",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1440
+          },
+          "special_holiday": {
+            "type": "number",
+            "description": "この日の特別休暇取得日数。1日単位で指定します。",
+            "format": "float",
+            "enum": [
+              0,
+              1
+            ],
+            "example": "1.0"
+          },
+          "special_holiday_setting_id": {
+            "type": "integer",
+            "description": "特別休暇設定ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "nullable": true
+          },
+          "half_special_holiday_mins": {
+            "type": "integer",
+            "description": "特別休暇の半休を利用した時間（分単位）",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1440
+          },
+          "hourly_special_holiday_mins": {
+            "type": "integer",
+            "description": "特別休暇の時間休を利用した時間（分単位）",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 1440
+          },
+          "use_attendance_deduction": {
+            "type": "boolean",
+            "description": "欠勤・遅刻・早退を控除対象時間に算入するかどうか"
+          },
+          "use_default_work_pattern": {
+            "type": "boolean",
+            "description": "デフォルトの勤務設定を使うかどうか。\n\ntrueを指定した場合、以下のパラメータについて、指定した値に関係なく、従業員に設定した勤務賃金設定の休日の設定を参照して値が決まります\n- day_pattern\n\ntrueを指定した場合、以下のパラメータについて、指定した値に関係なく、従業員に設定した勤務賃金設定の出退勤時刻と労働時間の設定を参照して値が決まります。\n- normal_work_clock_in_at\n- normal_work_clock_out_at\n- normal_work_mins"
+          }
+        }
+      },
+      "ApiV1EmployeesWorkRecordSummaryController.update_body": {
+        "type": "object",
+        "required": [
+          "company_id"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "work_days": {
+            "type": "number",
+            "description": "総勤務日数",
+            "format": "float",
+            "minimum": 0,
+            "maximum": 31
+          },
+          "work_days_on_weekdays": {
+            "type": "number",
+            "description": "所定労働日の勤務日数",
+            "format": "float",
+            "minimum": 0,
+            "maximum": 31
+          },
+          "work_days_on_prescribed_holidays": {
+            "type": "number",
+            "description": "所定休日の勤務日数",
+            "format": "float",
+            "minimum": 0,
+            "maximum": 31
+          },
+          "work_days_on_legal_holidays": {
+            "type": "number",
+            "description": "法定休日の勤務日数",
+            "format": "float",
+            "minimum": 0,
+            "maximum": 31
+          },
+          "total_work_mins": {
+            "type": "integer",
+            "description": "労働時間（分）",
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "total_normal_work_mins": {
+            "type": "integer",
+            "description": "所定労働時間（分）",
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "total_excess_statutory_work_mins": {
+            "type": "integer",
+            "description": "給与計算に用いられる法定内残業時間（分）",
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "total_holiday_work_mins": {
+            "type": "integer",
+            "description": "法定休日労働時間（分）",
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "total_latenight_work_mins": {
+            "type": "integer",
+            "description": "深夜労働時間（分）",
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "total_actual_excess_statutory_work_mins": {
+            "type": "integer",
+            "description": "実労働時間ベースの法定内残業時間（分）",
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "total_overtime_work_mins": {
+            "type": "integer",
+            "description": "時間外労働時間（分）",
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "num_absences": {
+            "type": "number",
+            "description": "欠勤日数",
+            "format": "float",
+            "minimum": 0,
+            "maximum": 31
+          },
+          "num_absences_for_deduction": {
+            "type": "number",
+            "description": "控除対象の欠勤日数\n\nフレックスタイム制の場合は、指定した値が反映されず無視されます。",
+            "format": "float",
+            "minimum": 0,
+            "maximum": 9999.999
+          },
+          "total_lateness_mins": {
+            "type": "integer",
+            "description": "遅刻時間（分）",
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "total_lateness_mins_for_deduction": {
+            "type": "integer",
+            "description": "控除対象の遅刻時間（分）\n\nフレックスタイム制と裁量労働制の場合は、指定した値が反映されず無視されます。",
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "total_early_leaving_mins": {
+            "type": "integer",
+            "description": "早退時間（分）",
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "total_early_leaving_mins_for_deduction": {
+            "type": "integer",
+            "description": "控除対象の早退時間（分）\n\nフレックスタイム制と裁量労働制の場合は、指定した値が反映されず無視されます。",
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "num_paid_holidays": {
+            "type": "number",
+            "description": "有給取得日数",
+            "format": "float",
+            "minimum": 0,
+            "maximum": 31
+          },
+          "total_shortage_work_mins": {
+            "type": "integer",
+            "description": "不足時間（分）（フレックスタイム制でのみ使用）",
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "total_deemed_paid_excess_statutory_work_mins": {
+            "type": "integer",
+            "description": "みなし外の法定内残業時間（分）（裁量労働制でのみ使用）",
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "total_deemed_paid_overtime_except_normal_work_mins": {
+            "type": "integer",
+            "description": "みなし外の時間外労働時間（分）（裁量労働制でのみ使用）",
+            "minimum": 0,
+            "maximum": 2147483647
+          }
+        }
+      },
+      "ApiV1EmployeesTimeClocksController.index_response": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ApiV1EmployeesTimeClockSerializer"
+        }
+      },
+      "ApiV1EmployeesTimeClocksController.show_response": {
+        "type": "object",
+        "properties": {
+          "employee_time_clock": {
+            "$ref": "#/components/schemas/ApiV1EmployeesTimeClockSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesTimeClocksController.available_types_response": {
+        "type": "object",
+        "properties": {
+          "available_types": {
+            "type": "array",
+            "description": "打刻可能種別(clock_in:出勤, break_begin:休憩開始, break_end:休憩終了, clock_out:退勤)",
+            "items": {
+              "type": "string",
+              "enum": [
+                "clock_in",
+                "break_begin",
+                "break_end",
+                "clock_out"
+              ],
+              "example": "clock_in"
+            }
+          },
+          "base_date": {
+            "type": "string",
+            "description": "打刻基準日",
+            "format": "date",
+            "example": "2018-07-31"
+          }
+        }
+      },
+      "ApiV1EmployeesTimeClocksController.create_response": {
+        "type": "object",
+        "properties": {
+          "employee_time_clock": {
+            "$ref": "#/components/schemas/ApiV1EmployeesTimeClockSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeesTimeClocksController.create_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "type"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "(required)",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647
+          },
+          "type": {
+            "type": "string",
+            "description": "打刻種別（required）[clock_in:出勤, break_begin:休憩開始, break_end:休憩終了, clock_out:退勤]の何れか",
+            "enum": [
+              "clock_in",
+              "break_begin",
+              "break_end",
+              "clock_out"
+            ]
+          },
+          "base_date": {
+            "type": "string",
+            "description": "打刻日。打刻が日をまたぐ場合に、前日の日付を指定します。(YYYY-MM-DD)(例:2018-07-31)",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "example": "2018-07-31"
+          },
+          "datetime": {
+            "type": "string",
+            "description": "打刻時刻。(YYYY-MM-DD&nbsp;HH:MM:SS)(例:2018-07-31&nbsp;08:00:00)",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "2018-07-31 08:00:00"
+          }
+        }
+      },
+      "ApiV1SalariesEmployeePayrollStatementsController.index_response": {
+        "type": "object",
+        "properties": {
+          "employee_payroll_statements": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1SalariesEmployeePayrollStatementSerializer"
+            }
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "指定した年月に支払いのある給与明細の合計件数",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1SalariesEmployeePayrollStatementsController.show_response": {
+        "type": "object",
+        "properties": {
+          "employee_payroll_statement": {
+            "$ref": "#/components/schemas/ApiV1SalariesEmployeePayrollStatementSerializer"
+          }
+        }
+      },
+      "ApiV1BonusesEmployeePayrollStatementsController.show_response": {
+        "type": "object",
+        "properties": {
+          "employee_payroll_statement": {
+            "$ref": "#/components/schemas/ApiV1BonusesEmployeePayrollStatementSerializer"
+          }
+        }
+      },
+      "ApiV1GroupCreateRequest": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "group"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "作成対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "group": {
+            "$ref": "#/components/schemas/ApiV1GroupCreateRequestParams"
+          }
+        }
+      },
+      "ApiV1GroupResponse": {
+        "type": "object",
+        "required": [
+          "group"
+        ],
+        "properties": {
+          "group": {
+            "$ref": "#/components/schemas/ApiV1GroupResponseParams"
+          }
+        }
+      },
+      "ApiV1GroupUpdateRequest": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "group"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "作成対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "group": {
+            "$ref": "#/components/schemas/ApiV1GroupUpdateRequestParams"
+          }
+        }
+      },
+      "ApiV1PositionResponse": {
+        "type": "object",
+        "required": [
+          "position"
+        ],
+        "properties": {
+          "position": {
+            "$ref": "#/components/schemas/ApiV1PositionResponseParams"
+          }
+        }
+      },
+      "ApiV1PositionRequest": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "position"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "作成対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "position": {
+            "$ref": "#/components/schemas/ApiV1PositionRequestParams"
+          }
+        }
+      },
+      "ApiV1MonthlyAttendanceIndexResponse": {
+        "type": "object",
+        "required": [
+          "monthly_attendances",
+          "total_count"
+        ],
+        "properties": {
+          "monthly_attendances": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1MonthlyAttendanceIndexResponseParams"
+            }
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "合計件数",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1MonthlyAttendanceResponse": {
+        "type": "object",
+        "required": [
+          "monthly_attendance"
+        ],
+        "properties": {
+          "monthly_attendance": {
+            "$ref": "#/components/schemas/ApiV1MonthlyAttendanceResponseParams"
+          }
+        }
+      },
+      "ApiV1MonthlyAttendanceCreateRequest": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "target_year",
+          "target_month",
+          "approval_flow_route_id"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "target_year": {
+            "type": "integer",
+            "description": "対象年（必須）",
+            "format": "int32",
+            "minimum": 2000,
+            "maximum": 2100,
+            "example": 2022
+          },
+          "target_month": {
+            "type": "integer",
+            "description": "対象月（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 12,
+            "example": 1
+          },
+          "approval_flow_route_id": {
+            "type": "integer",
+            "description": "申請経路ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_id": {
+            "type": "integer",
+            "description": "承認者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1MonthlyAttendanceUpdateRequest": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "approval_flow_route_id"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approval_flow_route_id": {
+            "type": "integer",
+            "description": "申請経路ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_id": {
+            "type": "integer",
+            "description": "承認者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1WorkTimeIndexResponseParams": {
+        "type": "object",
+        "required": [
+          "id",
+          "company_id",
+          "application_number",
+          "applicant_id",
+          "target_date",
+          "clear_work_time",
+          "lateness_mins",
+          "early_leaving_mins",
+          "issue_date",
+          "status",
+          "passed_auto_check"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "申請ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "application_number": {
+            "type": "integer",
+            "description": "申請No",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "applicant_id": {
+            "type": "integer",
+            "description": "申請者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_ids": {
+            "description": "承認者のユーザーID配列\n次の場合、空配列になります。\n- 指定なしの申請経路を利用した、申請ステータスが承認済み以外の申請\n- 申請が差戻された",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "承認者のユーザーID",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "nullable": true,
+              "example": 1
+            }
+          },
+          "target_date": {
+            "type": "string",
+            "description": "対象日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "clear_work_time": {
+            "type": "boolean",
+            "description": "勤務時間削除フラグ（false:勤務時間を修正する、true:勤務時間を削除する）"
+          },
+          "clock_in_at": {
+            "type": "string",
+            "description": "勤務開始時間\n  - 勤務時間が複数登録されている場合は、最初の勤務の出勤時間を返します。",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "nullable": true,
+            "example": "12:00"
+          },
+          "clock_out_at": {
+            "type": "string",
+            "description": "勤務終了時間\n  - 勤務時間が複数登録されている場合は、最後の勤務の退勤時間を返します。",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "nullable": true,
+            "example": "23:59"
+          },
+          "work_records": {
+            "type": "array",
+            "description": "勤務時間のリスト\n  - 登録されている全ての勤務時間のリストを返します。",
+            "items": {
+              "type": "object",
+              "required": [
+                "clock_in_at",
+                "clock_out_at"
+              ],
+              "properties": {
+                "clock_in_at": {
+                  "type": "string",
+                  "description": "開始時刻",
+                  "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+                  "example": "12:00"
+                },
+                "clock_out_at": {
+                  "type": "string",
+                  "description": "終了時刻",
+                  "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+                  "example": "23:59"
+                }
+              }
+            }
+          },
+          "lateness_mins": {
+            "type": "integer",
+            "description": "遅刻分の時間（分単位）",
+            "format": "int32"
+          },
+          "early_leaving_mins": {
+            "type": "integer",
+            "description": "早退分の時間（分単位）",
+            "format": "int32"
+          },
+          "break_records": {
+            "type": "array",
+            "description": "休憩時間のリスト",
+            "items": {
+              "type": "object",
+              "required": [
+                "clock_in_at",
+                "clock_out_at"
+              ],
+              "properties": {
+                "clock_in_at": {
+                  "type": "string",
+                  "description": "開始時刻",
+                  "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+                  "example": "12:00"
+                },
+                "clock_out_at": {
+                  "type": "string",
+                  "description": "終了時刻",
+                  "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+                  "example": "23:59"
+                }
+              }
+            }
+          },
+          "issue_date": {
+            "type": "string",
+            "description": "申請日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "comment": {
+            "type": "string",
+            "description": "申請理由",
+            "maxLength": 255,
+            "nullable": true,
+            "example": "申請理由"
+          },
+          "status": {
+            "type": "string",
+            "description": "申請ステータス。（draft:下書き、in_progress:申請中、approved:承認済、feedback:差戻し）",
+            "enum": [
+              "draft",
+              "in_progress",
+              "approved",
+              "feedback"
+            ],
+            "example": "in_progress"
+          },
+          "passed_auto_check": {
+            "type": "boolean",
+            "description": "自動チェック結果",
+            "example": true
+          }
+        }
+      },
+      "ApiV1WorkTimeResponseParams": {
+        "type": "object",
+        "required": [
+          "id",
+          "company_id",
+          "application_number",
+          "applicant_id",
+          "target_date",
+          "clear_work_time",
+          "lateness_mins",
+          "early_leaving_mins",
+          "issue_date",
+          "status",
+          "passed_auto_check",
+          "approval_flow_route_id",
+          "approval_flow_route_name",
+          "approval_flow_logs",
+          "current_round"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "申請ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "application_number": {
+            "type": "integer",
+            "description": "申請No",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "applicant_id": {
+            "type": "integer",
+            "description": "申請者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_ids": {
+            "description": "承認者のユーザーID配列\n次の場合、空配列になります。\n- 指定なしの申請経路を利用した、申請ステータスが承認済み以外の申請\n- 申請が差戻された",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "承認者のユーザーID",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "nullable": true,
+              "example": 1
+            }
+          },
+          "target_date": {
+            "type": "string",
+            "description": "対象日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "clear_work_time": {
+            "type": "boolean",
+            "description": "勤務時間削除フラグ（false:勤務時間を修正する、true:勤務時間を削除する）",
+            "example": false
+          },
+          "clock_in_at": {
+            "type": "string",
+            "description": "勤務開始時間\n  - 勤務が複数登録されている場合は、最初の勤務の出勤時間を返します。",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "nullable": true,
+            "example": "12:00"
+          },
+          "clock_out_at": {
+            "type": "string",
+            "description": "勤務終了時間\n  - 勤務が複数登録されている場合は、最後の勤務の退勤時間を返します。",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "nullable": true,
+            "example": "23:59"
+          },
+          "work_records": {
+            "type": "array",
+            "description": "勤務時間のリスト\n  - 登録されている全ての勤務時間のリストを返します。",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1WorkTimeIndexResponseParams/properties/work_records/items"
+            }
+          },
+          "lateness_mins": {
+            "type": "integer",
+            "description": "遅刻分の時間（分単位）",
+            "format": "int32"
+          },
+          "early_leaving_mins": {
+            "type": "integer",
+            "description": "早退分の時間（分単位）",
+            "format": "int32"
+          },
+          "break_records": {
+            "type": "array",
+            "description": "休憩時間のリスト",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1WorkTimeIndexResponseParams/properties/break_records/items"
+            }
+          },
+          "issue_date": {
+            "type": "string",
+            "description": "申請日",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "comment": {
+            "type": "string",
+            "description": "申請理由",
+            "maxLength": 255,
+            "nullable": true,
+            "example": "申請理由"
+          },
+          "status": {
+            "type": "string",
+            "description": "申請ステータス。（draft:下書き、in_progress:申請中、approved:承認済、feedback:差戻し）",
+            "enum": [
+              "draft",
+              "in_progress",
+              "approved",
+              "feedback"
+            ],
+            "example": "in_progress"
+          },
+          "passed_auto_check": {
+            "type": "boolean",
+            "description": "自動チェック結果",
+            "example": true
+          },
+          "approval_flow_route_id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "description": "申請経路ID",
+            "example": 1
+          },
+          "approval_flow_route_name": {
+            "type": "string",
+            "description": "申請経路名",
+            "example": "申請経路"
+          },
+          "approval_flow_logs": {
+            "type": "array",
+            "description": "承認履歴",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1ApprovalFlowLogsParams"
+            }
+          },
+          "current_step_id": {
+            "type": "integer",
+            "description": "現在承認ステップID<br>\n申請を差戻した場合、nullになります。",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1,
+            "nullable": true
+          },
+          "current_round": {
+            "type": "integer",
+            "description": "現在のround。差戻し等により申請がstepの最初からやり直しになるとroundの値が増えます。",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1PaidHolidayIndexResponse": {
+        "type": "object",
+        "required": [
+          "paid_holidays",
+          "total_count"
+        ],
+        "properties": {
+          "paid_holidays": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ApiV1PaidHolidayIndexResponseParams"
+                },
+                {
+                  "$ref": "#/components/schemas/LegacyApiV1PaidHolidayIndexResponseParams"
+                }
+              ]
+            }
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "合計件数",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1PaidHolidayResponse": {
+        "type": "object",
+        "required": [
+          "paid_holiday"
+        ],
+        "properties": {
+          "paid_holiday": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ApiV1PaidHolidayResponseParams"
+              },
+              {
+                "$ref": "#/components/schemas/LegacyApiV1PaidHolidayResponseParams"
+              }
+            ]
+          }
+        }
+      },
+      "ApiV1PaidHolidayRequest": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "target_date",
+          "approval_flow_route_id",
+          "values"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "target_date": {
+            "type": "string",
+            "description": "対象日（必須）",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "example": "2018-07-31"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "取得単位。（full:全休、half:半休、morning:午前休、 afternoon:午後休、hourly:時間休）",
+                  "enum": [
+                    "full",
+                    "half",
+                    "morning",
+                    "afternoon",
+                    "hourly"
+                  ],
+                  "nullable": false,
+                  "example": "half"
+                },
+                "start_at": {
+                  "type": "string",
+                  "description": "取得予定開始時間 ※ 全休の場合や午前休、午後休の場合にはこちらの値は参照されません",
+                  "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+                  "nullable": true,
+                  "example": "12:00"
+                },
+                "end_at": {
+                  "type": "string",
+                  "description": "取得予定終了時間 ※ 全休の場合や午前休、午後休の場合にはこちらの値は参照されません",
+                  "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+                  "nullable": true,
+                  "example": "23:59"
+                }
+              }
+            }
+          },
+          "comment": {
+            "type": "string",
+            "description": "申請理由",
+            "maxLength": 255,
+            "example": "申請理由"
+          },
+          "approval_flow_route_id": {
+            "type": "integer",
+            "description": "申請経路ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_id": {
+            "type": "integer",
+            "description": "承認者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "LegacyApiV1PaidHolidayRequest": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "target_date",
+          "holiday_type",
+          "approval_flow_route_id"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "target_date": {
+            "type": "string",
+            "description": "対象日（必須）",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "example": "2018-07-31"
+          },
+          "holiday_type": {
+            "type": "string",
+            "description": "[deprecated] 取得単位。（full:全休、half:半休、morning:午前休、 afternoon:午後休、hour:時間休） ※ paid_holidays->values を指定している場合にはこちらの値は参照されません ※ 削除予定のためvalues->type を指定してください",
+            "enum": [
+              "full",
+              "half",
+              "morning",
+              "afternoon",
+              "hour"
+            ],
+            "example": "half"
+          },
+          "start_at": {
+            "type": "string",
+            "description": "[deprecated] 取得予定開始時間 ※ paid_holidays->values を指定している場合にはこちらの値は参照されません ※ 削除予定のため values->start_at を指定してください",
+            "pattern": "^[0-9]{2}:[0-9]{2}?$",
+            "example": "12:00"
+          },
+          "end_at": {
+            "type": "string",
+            "description": "[deprecated] 取得予定終了時間 ※ paid_holidays->values を指定している場合にはこちらの値は参照されません ※ 削除予定のため values->end_at を指定してください",
+            "pattern": "^[0-9]{2}:[0-9]{2}?$",
+            "example": "23:59"
+          },
+          "comment": {
+            "type": "string",
+            "description": "申請理由",
+            "maxLength": 255,
+            "example": "申請理由"
+          },
+          "approval_flow_route_id": {
+            "type": "integer",
+            "description": "申請経路ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_id": {
+            "type": "integer",
+            "description": "承認者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1specialHolidayIndexResponse": {
+        "type": "object",
+        "required": [
+          "special_holidays",
+          "total_count"
+        ],
+        "properties": {
+          "special_holidays": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "company_id",
+                "application_number",
+                "applicant_id",
+                "target_date",
+                "special_holiday_setting_id",
+                "special_holiday_name",
+                "holiday_type",
+                "issue_date",
+                "status",
+                "revoke_status",
+                "passed_auto_check"
+              ],
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "description": "申請ID",
+                  "format": "int32",
+                  "minimum": 1,
+                  "maximum": 2147483647,
+                  "example": 1
+                },
+                "company_id": {
+                  "type": "integer",
+                  "description": "事業所ID",
+                  "format": "int32",
+                  "minimum": 1,
+                  "maximum": 2147483647,
+                  "example": 1
+                },
+                "application_number": {
+                  "type": "integer",
+                  "description": "申請No",
+                  "format": "int32",
+                  "minimum": 1,
+                  "maximum": 2147483647,
+                  "example": 1
+                },
+                "applicant_id": {
+                  "type": "integer",
+                  "description": "申請者のユーザーID",
+                  "format": "int32",
+                  "minimum": 1,
+                  "maximum": 2147483647,
+                  "example": 1
+                },
+                "approver_ids": {
+                  "description": "承認者のユーザーID配列<br>\n次の場合、空配列になります。\n- 指定なしの申請経路を利用した、申請ステータスが承認済み以外の申請\n- 申請が差戻された",
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "description": "承認者のユーザーID",
+                    "format": "int32",
+                    "minimum": 1,
+                    "maximum": 2147483647,
+                    "nullable": true,
+                    "example": 1
+                  }
+                },
+                "target_date": {
+                  "type": "string",
+                  "description": "対象日",
+                  "format": "date",
+                  "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+                },
+                "special_holiday_setting_id": {
+                  "type": "integer",
+                  "description": "特別休暇設定ID",
+                  "format": "int32",
+                  "minimum": 1,
+                  "maximum": 2147483647,
+                  "example": 1
+                },
+                "special_holiday_name": {
+                  "type": "string",
+                  "description": "特別休暇名称",
+                  "maxLength": 255,
+                  "nullable": false,
+                  "example": "特別休暇名称"
+                },
+                "holiday_type": {
+                  "type": "string",
+                  "description": "取得単位。（full:全休、half:半休、morning:午前休、afternoon:午後休、hour:時間休）",
+                  "enum": [
+                    "full",
+                    "half",
+                    "morning",
+                    "afternoon",
+                    "hour"
+                  ],
+                  "example": "half"
+                },
+                "start_at": {
+                  "type": "string",
+                  "description": "取得予定開始時間",
+                  "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+                  "nullable": true,
+                  "example": "12:00"
+                },
+                "end_at": {
+                  "type": "string",
+                  "description": "取得予定終了時間",
+                  "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+                  "nullable": true,
+                  "example": "23:59"
+                },
+                "issue_date": {
+                  "type": "string",
+                  "description": "申請日",
+                  "format": "date",
+                  "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+                },
+                "comment": {
+                  "type": "string",
+                  "description": "申請理由",
+                  "maxLength": 255,
+                  "nullable": true,
+                  "example": "申請理由"
+                },
+                "status": {
+                  "type": "string",
+                  "description": "申請ステータス。（draft:下書き、in_progress:申請中、approved:承認済、feedback:差戻し）",
+                  "enum": [
+                    "draft",
+                    "in_progress",
+                    "approved",
+                    "feedback"
+                  ],
+                  "example": "in_progress"
+                },
+                "revoke_status": {
+                  "type": "string",
+                  "description": "取消申請ステータス。（null:取消申請されてない、revoking:取消中、revoked:取消済）",
+                  "enum": [
+                    "revoking",
+                    "revoked"
+                  ],
+                  "nullable": true,
+                  "example": null
+                },
+                "passed_auto_check": {
+                  "type": "boolean",
+                  "description": "自動チェック結果",
+                  "example": true
+                }
+              }
+            }
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "合計件数",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1specialHolidayResponse": {
+        "type": "object",
+        "required": [
+          "special_holiday"
+        ],
+        "properties": {
+          "special_holiday": {
+            "type": "object",
+            "required": [
+              "id",
+              "company_id",
+              "application_number",
+              "applicant_id",
+              "target_date",
+              "special_holiday_setting_id",
+              "special_holiday_name",
+              "holiday_type",
+              "issue_date",
+              "status",
+              "revoke_status",
+              "passed_auto_check",
+              "approval_flow_route_id",
+              "approval_flow_route_name",
+              "approval_flow_logs",
+              "current_round"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "申請ID",
+                "format": "int32",
+                "minimum": 1,
+                "maximum": 2147483647,
+                "example": 1
+              },
+              "company_id": {
+                "type": "integer",
+                "description": "事業所ID",
+                "format": "int32",
+                "minimum": 1,
+                "maximum": 2147483647,
+                "example": 1
+              },
+              "application_number": {
+                "type": "integer",
+                "description": "申請No",
+                "format": "int32",
+                "minimum": 1,
+                "maximum": 2147483647,
+                "example": 1
+              },
+              "applicant_id": {
+                "type": "integer",
+                "description": "申請者のユーザーID",
+                "format": "int32",
+                "minimum": 1,
+                "maximum": 2147483647,
+                "example": 1
+              },
+              "approver_ids": {
+                "description": "承認者のユーザーID配列<br>\n次の場合、空配列になります。\n- 指定なしの申請経路を利用した、申請ステータスが承認済み以外の申請\n- 申請が差戻された",
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "description": "承認者のユーザーID",
+                  "format": "int32",
+                  "minimum": 1,
+                  "maximum": 2147483647,
+                  "nullable": true,
+                  "example": 1
+                }
+              },
+              "target_date": {
+                "type": "string",
+                "description": "対象日",
+                "format": "date",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+              },
+              "special_holiday_setting_id": {
+                "type": "integer",
+                "description": "特別休暇設定ID",
+                "format": "int32",
+                "minimum": 1,
+                "maximum": 2147483647,
+                "example": 1
+              },
+              "special_holiday_name": {
+                "type": "string",
+                "description": "特別休暇名称",
+                "maxLength": 255,
+                "nullable": false,
+                "example": "特別休暇名称"
+              },
+              "holiday_type": {
+                "type": "string",
+                "description": "取得単位。（full:全休、half:半休、morning:午前休、afternoon:午後休、hour:時間休）",
+                "enum": [
+                  "full",
+                  "half",
+                  "morning",
+                  "afternoon",
+                  "hour"
+                ],
+                "example": "half"
+              },
+              "start_at": {
+                "type": "string",
+                "description": "取得予定開始時間",
+                "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+                "nullable": true,
+                "example": "12:00"
+              },
+              "end_at": {
+                "type": "string",
+                "description": "取得予定終了時間",
+                "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+                "nullable": true,
+                "example": "23:59"
+              },
+              "issue_date": {
+                "type": "string",
+                "description": "申請日",
+                "format": "date",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+              },
+              "comment": {
+                "type": "string",
+                "description": "申請理由",
+                "maxLength": 255,
+                "nullable": true,
+                "example": "申請理由"
+              },
+              "status": {
+                "type": "string",
+                "description": "申請ステータス。（draft:下書き、in_progress:申請中、approved:承認済、feedback:差戻し）",
+                "enum": [
+                  "draft",
+                  "in_progress",
+                  "approved",
+                  "feedback"
+                ],
+                "example": "in_progress"
+              },
+              "revoke_status": {
+                "type": "string",
+                "description": "取消申請ステータス。（null:取消申請されてない、revoking:取消中、revoked:取消済）",
+                "enum": [
+                  "revoking",
+                  "revoked"
+                ],
+                "nullable": true,
+                "example": null
+              },
+              "passed_auto_check": {
+                "type": "boolean",
+                "description": "自動チェック結果",
+                "example": true
+              },
+              "approval_flow_route_id": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 2147483647,
+                "description": "申請経路ID",
+                "example": 1
+              },
+              "approval_flow_route_name": {
+                "type": "string",
+                "description": "申請経路名",
+                "example": "申請経路"
+              },
+              "approval_flow_logs": {
+                "type": "array",
+                "description": "承認履歴",
+                "items": {
+                  "$ref": "#/components/schemas/ApiV1ApprovalFlowLogsParams"
+                }
+              },
+              "current_step_id": {
+                "type": "integer",
+                "description": "現在承認ステップID<br>\n申請を差戻した場合、nullになります。",
+                "format": "int32",
+                "minimum": 1,
+                "maximum": 2147483647,
+                "example": 1,
+                "nullable": true
+              },
+              "current_round": {
+                "type": "integer",
+                "description": "現在のround。差戻し等により申請がstepの最初からやり直しになるとroundの値が増えます。",
+                "format": "int32",
+                "minimum": 0,
+                "maximum": 2147483647,
+                "example": 1
+              }
+            }
+          }
+        }
+      },
+      "ApiV1specialHolidayRequest": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "target_date",
+          "special_holiday_setting_id",
+          "holiday_type",
+          "approval_flow_route_id"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "target_date": {
+            "type": "string",
+            "description": "対象日（必須）",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "example": "2018-07-31"
+          },
+          "special_holiday_setting_id": {
+            "type": "integer",
+            "description": "特別休暇設定ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "holiday_type": {
+            "type": "string",
+            "description": "取得単位（必須）（full:全休、half:半休、morning:午前休、 afternoon:午後休、hour:時間休）",
+            "enum": [
+              "full",
+              "half",
+              "morning",
+              "afternoon",
+              "hour"
+            ],
+            "example": "half"
+          },
+          "start_at": {
+            "type": "string",
+            "description": "取得予定開始時間（条件付き必須）\n取得単位が半休、時間休の場合は必須",
+            "pattern": "^[0-9]{2}:[0-9]{2}?$",
+            "example": "12:00"
+          },
+          "end_at": {
+            "type": "string",
+            "description": "取得予定終了時間（条件付き必須）\n取得単位が半休、時間休の場合は必須",
+            "pattern": "^[0-9]{2}:[0-9]{2}?$",
+            "example": "23:59"
+          },
+          "comment": {
+            "type": "string",
+            "description": "申請理由",
+            "maxLength": 255,
+            "example": "申請理由"
+          },
+          "approval_flow_route_id": {
+            "type": "integer",
+            "description": "申請経路ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_id": {
+            "type": "integer",
+            "description": "承認者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1OvertimeWorkIndexResponse": {
+        "type": "object",
+        "required": [
+          "overtime_works",
+          "total_count"
+        ],
+        "properties": {
+          "overtime_works": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1OvertimeWorkIndexResponseParams"
+            }
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "合計件数",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1OvertimeWorkResponse": {
+        "type": "object",
+        "required": [
+          "overtime_work"
+        ],
+        "properties": {
+          "overtime_work": {
+            "$ref": "#/components/schemas/ApiV1OvertimeWorkResponseParams"
+          }
+        }
+      },
+      "ApiV1OvertimeWorkRequest": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "target_date",
+          "approval_flow_route_id"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "target_date": {
+            "type": "string",
+            "description": "対象日（必須）",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          },
+          "start_at": {
+            "type": "string",
+            "description": "取得予定開始時間",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "12:00"
+          },
+          "end_at": {
+            "type": "string",
+            "description": "取得予定終了時間",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "example": "23:59"
+          },
+          "early_work_start_at": {
+            "type": "string",
+            "description": "実績反映ありの早出申請の開始予定時刻  \n実績反映ありの早出申請する場合は必須",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "nullable": true,
+            "example": "12:00"
+          },
+          "early_work_end_at": {
+            "type": "string",
+            "description": "実績反映ありの早出申請の終了予定時刻  \n実績反映ありの早出申請する場合は必須",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "nullable": true,
+            "example": "23:59"
+          },
+          "overtime_work_start_at": {
+            "type": "string",
+            "description": "実績反映ありの残業申請の開始予定時刻  \n実績反映ありの残業申請する場合は必須",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "nullable": true,
+            "example": "12:00"
+          },
+          "overtime_work_end_at": {
+            "type": "string",
+            "description": "実績反映ありの残業申請の終了予定時刻  \n実績反映ありの残業申請する場合は必須",
+            "pattern": "^[0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "nullable": true,
+            "example": "23:59"
+          },
+          "comment": {
+            "type": "string",
+            "description": "申請理由",
+            "maxLength": 255,
+            "example": "申請理由"
+          },
+          "approval_flow_route_id": {
+            "type": "integer",
+            "description": "申請経路ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approver_id": {
+            "type": "integer",
+            "description": "承認者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1ApprovalActionRequest": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "approval_action",
+          "target_round",
+          "target_step_id"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "approval_action": {
+            "type": "string",
+            "description": "申請操作。（approve:承認、cancel:取り消し、feedback:差戻し、force_feedback:承認取り消し）",
+            "enum": [
+              "approve",
+              "cancel",
+              "feedback",
+              "force_feedback"
+            ],
+            "example": "approve"
+          },
+          "target_round": {
+            "type": "integer",
+            "description": "対象round。差戻し等により申請がstepの最初からやり直しになるとroundの値が増えます。取得APIレスポンス.current_roundを送信してください。",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "nullable": true,
+            "example": 1
+          },
+          "target_step_id": {
+            "type": "integer",
+            "description": "対象承認ステップID。取得APIレスポンス.current_step_idを送信してください。",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "nullable": true,
+            "example": 1
+          },
+          "next_approver_id": {
+            "type": "integer",
+            "description": "次のステップの承認者のユーザーID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "nullable": true,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1ApprovalFlowRoutesIndexResponse": {
+        "type": "object",
+        "required": [
+          "approval_flow_routes"
+        ],
+        "properties": {
+          "approval_flow_routes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1ApprovalFlowRouteIndexResponseParams"
+            }
+          }
+        }
+      },
+      "ApiV1ApprovalFlowRouteIndexResponseParams": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "description": "申請経路ID",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "申請経路名",
+            "example": "申請経路"
+          },
+          "description": {
+            "type": "string",
+            "description": "申請経路の説明",
+            "example": "申請経路の説明"
+          },
+          "user_id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "description": "更新したユーザーのユーザーID",
+            "example": 1,
+            "nullable": true
+          },
+          "definition_system": {
+            "type": "boolean",
+            "description": "システム作成の申請経路かどうか",
+            "example": true
+          },
+          "first_step_id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "description": "最初の承認ステップのID",
+            "example": 1
+          },
+          "usages": {
+            "type": "array",
+            "description": "申請種別（申請経路を使用できる申請種別を示します。例えば、AttendanceWorkflow の場合は、勤怠申請で使用できる申請経路です。）\n- AttendanceWorkflow - 勤怠申請\n- PersonalDataWorkflow - 身上変更申請",
+            "items": {
+              "type": "string",
+              "enum": [
+                "AttendanceWorkflow",
+                "PersonalDataWorkflow"
+              ],
+              "example": "AttendanceWorkflow"
+            }
+          }
+        }
+      },
+      "ApiV1ApprovalFlowRouteResponse": {
+        "type": "object",
+        "required": [
+          "approval_flow_route"
+        ],
+        "properties": {
+          "approval_flow_route": {
+            "$ref": "#/components/schemas/ApiV1ApprovalFlowRouteResponseParams"
+          }
+        }
+      },
+      "ApiV1ApprovalFlowRouteResponseParams": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "description": "申請経路ID",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "申請経路名",
+            "example": "申請経路"
+          },
+          "description": {
+            "type": "string",
+            "description": "申請経路の説明",
+            "example": "申請経路の説明"
+          },
+          "user_id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "description": "更新したユーザーのユーザーID",
+            "example": 1,
+            "nullable": true
+          },
+          "definition_system": {
+            "type": "boolean",
+            "description": "システム作成の申請経路かどうか",
+            "example": true
+          },
+          "first_step_id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "description": "最初の承認ステップのID",
+            "example": 1
+          },
+          "usages": {
+            "type": "array",
+            "description": "申請種別（申請経路を使用できる申請種別を示します。例えば、AttendanceWorkflow の場合は、勤怠申請で使用できる申請経路です。）\n- AttendanceWorkflow - 勤怠申請\n- PersonalDataWorkflow - 身上変更申請",
+            "items": {
+              "type": "string",
+              "enum": [
+                "AttendanceWorkflow",
+                "PersonalDataWorkflow"
+              ],
+              "example": "AttendanceWorkflow"
+            }
+          },
+          "steps": {
+            "$ref": "#/components/schemas/ApiV1FlowRouteStepSrializer"
+          }
+        }
+      },
+      "ApiV1FlowRouteStepSrializer": {
+        "type": "array",
+        "description": "承認ステップ（配列）",
+        "items": {
+          "type": "object",
+          "required": [
+            "id",
+            "next_step_id",
+            "resource_type"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "description": "承認ステップID",
+              "example": 1
+            },
+            "next_step_id": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2147483647,
+              "description": "次の承認ステップID",
+              "nullable": true,
+              "example": 2
+            },
+            "resource_type": {
+              "type": "string",
+              "description": "承認方法( predefined_user: メンバー指定 (1人), selected_user: 申請時にメンバー指定,unspecified: 指定なし, and_resource: メンバー指定 (複数、全員の承認), or_resource: メンバー指定 (複数、1人の承認), and_position: 役職指定 (複数、全員の承認), or_position: 役職指定 (複数、1人の承認) ) ",
+              "enum": [
+                "predefined_user",
+                "selected_user",
+                "unspecified",
+                "and_resource",
+                "or_resource",
+                "and_position",
+                "or_position"
+              ],
+              "example": "predefined_user"
+            },
+            "user_ids": {
+              "type": "array",
+              "description": "承認者のユーザーID (配列)",
+              "items": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 2147483647,
+                "description": "承認者のユーザーID",
+                "example": 3
+              }
+            }
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentController.index_response": {
+        "type": "object",
+        "properties": {
+          "employees": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentParams"
+            }
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "合計件数",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 2147483647
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentParams": {
+        "type": "object",
+        "properties": {
+          "employee_id": {
+            "type": "integer",
+            "description": "従業員ID",
+            "format": "int32"
+          },
+          "num": {
+            "type": "string",
+            "description": "従業員番号",
+            "nullable": true
+          },
+          "employee_display_name": {
+            "type": "string",
+            "description": "従業員名"
+          },
+          "is_not_adjust": {
+            "type": "boolean",
+            "description": "年末調整対象外\n- true - 年末調整対象外\n- false - 年末調整対象"
+          },
+          "status": {
+            "type": "string",
+            "description": "年末調整ステータス\n- initialized - 入力依頼前\n- in_employee_progress - 従業員入力中\n- submitted - 従業員入力済\n- fixed - 確定",
+            "enum": [
+              "initialized",
+              "in_employee_progress",
+              "submitted",
+              "fixed"
+            ]
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentController.update_employee_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "employee"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "更新対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "employee": {
+            "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentEmployeeUpdateRequestSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentEmployeeUpdateRequestSerializer": {
+        "type": "object",
+        "required": [
+          "last_name",
+          "first_name",
+          "last_name_kana",
+          "first_name_kana",
+          "zipcode1",
+          "zipcode2",
+          "prefecture_code",
+          "address"
+        ],
+        "properties": {
+          "last_name": {
+            "type": "string",
+            "description": "姓 null不可",
+            "maxLength": 255,
+            "example": "山田"
+          },
+          "first_name": {
+            "type": "string",
+            "description": "名 null不可",
+            "maxLength": 255,
+            "example": "太郎"
+          },
+          "last_name_kana": {
+            "type": "string",
+            "description": "姓カナ",
+            "maxLength": 255,
+            "example": "ヤマダ"
+          },
+          "first_name_kana": {
+            "type": "string",
+            "description": "名カナ",
+            "maxLength": 255,
+            "example": "タロウ"
+          },
+          "zipcode1": {
+            "type": "string",
+            "description": "住民票住所の郵便番号1",
+            "maxLength": 3,
+            "example": "141"
+          },
+          "zipcode2": {
+            "type": "string",
+            "description": "住民票住所の郵便番号2",
+            "maxLength": 4,
+            "example": "0031"
+          },
+          "prefecture_code": {
+            "type": "integer",
+            "minimum": -1,
+            "maximum": 46,
+            "description": "住民票住所の都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄)",
+            "example": 12
+          },
+          "address": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所",
+            "maxLength": 255,
+            "example": "品川区大崎1-2-2"
+          },
+          "address_kana": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所カナ",
+            "maxLength": 255,
+            "example": "シナガワクオオサキ1-2-2"
+          },
+          "payer_type": {
+            "type": "string",
+            "description": "所得税納税者区分 kou: 甲, otsu: 乙, hei: 丙",
+            "enum": [
+              "kou",
+              "otsu",
+              "hei"
+            ]
+          },
+          "widow_type": {
+            "type": "string",
+            "description": "寡夫／寡婦かどうか null不可 na: 空白, widow: 寡婦, one_parent: ひとり親",
+            "enum": [
+              "na",
+              "widow",
+              "one_parent"
+            ]
+          },
+          "disability_type": {
+            "type": "string",
+            "description": "障害者かどうか null不可 na: 空白, general: 障害者, heavy: 特別障害者",
+            "enum": [
+              "na",
+              "general",
+              "heavy"
+            ]
+          },
+          "married": {
+            "type": "boolean",
+            "description": "配偶者の有無 null不可"
+          },
+          "is_working_student": {
+            "type": "boolean",
+            "description": "勤労学生かどうか null不可"
+          },
+          "is_foreigner": {
+            "type": "boolean",
+            "description": "外国人かどうか null不可"
+          },
+          "other_company_revenue": {
+            "type": "integer",
+            "description": "その他の事業所の給与収入",
+            "example": 1000000,
+            "minimum": 0,
+            "maximum": 1999999999,
+            "nullable": true
+          },
+          "all_other_income": {
+            "type": "integer",
+            "description": "給与以外の所得",
+            "example": 1000000,
+            "minimum": 0,
+            "maximum": 1999999999,
+            "nullable": true
+          },
+          "householder": {
+            "type": "string",
+            "description": "世帯主の続柄 myself: 本人, husband: 夫, wife: 妻, father: 父, mother: 母, child: 子, senior_brother: 兄, junior_brother: 弟, senior_sister: 姉, junior_sister: 妹, grandchild: 孫, grandfather: 祖父, grandmother: 祖母, father_in_law: 義父, mother_in_law: 義母, grandfather_in_law: 義祖父, grandmother_in_law: 義祖母, other: その他",
+            "enum": [
+              "myself",
+              "husband",
+              "wife",
+              "father",
+              "mother",
+              "child",
+              "senior_brother",
+              "junior_brother",
+              "senior_sister",
+              "junior_sister",
+              "grandchild",
+              "grandfather",
+              "grandmother",
+              "father_in_law",
+              "mother_in_law",
+              "grandfather_in_law",
+              "grandmother_in_law",
+              "other"
+            ]
+          },
+          "householder_name": {
+            "type": "string",
+            "description": "世帯主の名前",
+            "maxLength": 255,
+            "example": "山田 太郎"
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentController.update_employee_response": {
+        "type": "object",
+        "properties": {
+          "employees": {
+            "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentEmployeeSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentEmployeeSerializer": {
+        "type": "object",
+        "properties": {
+          "employee_id": {
+            "type": "integer",
+            "description": "従業員ID",
+            "format": "int32"
+          },
+          "num": {
+            "type": "string",
+            "description": "従業員番号<br>\n従業員を判別しやすいよう管理することができます。（例: 1人目の正社員を A-001 と入力）",
+            "example": "A-001",
+            "nullable": true
+          },
+          "last_name": {
+            "type": "string",
+            "description": "姓 null不可",
+            "maxLength": 255,
+            "example": "山田"
+          },
+          "first_name": {
+            "type": "string",
+            "description": "名 null不可",
+            "maxLength": 255,
+            "example": "太郎"
+          },
+          "last_name_kana": {
+            "type": "string",
+            "description": "姓カナ",
+            "maxLength": 255,
+            "example": "ヤマダ"
+          },
+          "first_name_kana": {
+            "type": "string",
+            "description": "名カナ",
+            "maxLength": 255,
+            "example": "タロウ"
+          },
+          "birth_date": {
+            "type": "string",
+            "description": "生年月日",
+            "format": "date"
+          },
+          "entry_date": {
+            "type": "string",
+            "description": "入社日",
+            "format": "date"
+          },
+          "retire_date": {
+            "type": "string",
+            "description": "退職日",
+            "format": "date",
+            "nullable": true
+          },
+          "employment_type": {
+            "type": "string",
+            "description": "雇用形態 board-member: 役員, regular: 正社員, fixed-term: 契約社員, part-time: アルバイト・パート, temporary: 派遣社員, (空文字列): その他",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "description": "肩書",
+            "nullable": true
+          },
+          "zipcode1": {
+            "type": "string",
+            "description": "住民票住所の郵便番号1",
+            "maxLength": 3,
+            "nullable": true,
+            "example": "141"
+          },
+          "zipcode2": {
+            "type": "string",
+            "description": "住民票住所の郵便番号2",
+            "maxLength": 4,
+            "nullable": true,
+            "example": "0031"
+          },
+          "prefecture_code": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": -1,
+            "maximum": 46,
+            "description": "住民票住所の都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄)",
+            "example": 12
+          },
+          "address": {
+            "type": "string",
+            "nullable": true,
+            "description": "住民票住所の市区町村以降の住所",
+            "maxLength": 255,
+            "example": "品川区大崎1-2-2"
+          },
+          "address_kana": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所カナ",
+            "maxLength": 255,
+            "example": "シナガワクオオサキ1-2-2"
+          },
+          "payer_type": {
+            "type": "string",
+            "description": "所得税納税者区分 kou: 甲, otsu: 乙, hei: 丙",
+            "enum": [
+              "kou",
+              "otsu",
+              "hei"
+            ]
+          },
+          "widow_type": {
+            "type": "string",
+            "description": "寡夫／寡婦かどうか null不可 na: 空白, widow: 寡婦, one_parent: ひとり親",
+            "enum": [
+              "na",
+              "widow",
+              "one_parent"
+            ]
+          },
+          "disability_type": {
+            "type": "string",
+            "description": "障害者かどうか na: 空白, general: 障害者, heavy: 特別障害者",
+            "enum": [
+              "na",
+              "general",
+              "heavy"
+            ]
+          },
+          "married": {
+            "type": "boolean",
+            "description": "配偶者の有無"
+          },
+          "is_working_student": {
+            "type": "boolean",
+            "description": "勤労学生かどうか"
+          },
+          "is_foreigner": {
+            "type": "boolean",
+            "description": "外国人かどうか"
+          },
+          "other_company_revenue": {
+            "type": "integer",
+            "description": "その他の事業所の給与収入",
+            "example": 1000000,
+            "minimum": 0,
+            "maximum": 1999999999,
+            "nullable": true
+          },
+          "all_other_income": {
+            "type": "integer",
+            "description": "給与以外の所得",
+            "example": 1000000,
+            "minimum": 0,
+            "maximum": 1999999999,
+            "nullable": true
+          },
+          "householder": {
+            "type": "string",
+            "description": "世帯主の続柄 myself: 本人, husband: 夫, wife: 妻, father: 父, mother: 母, child: 子, senior_brother: 兄, junior_brother: 弟, senior_sister: 姉, junior_sister: 妹, grandchild: 孫, grandfather: 祖父, grandmother: 祖母, father_in_law: 義父, mother_in_law: 義母, grandfather_in_law: 義祖父, grandmother_in_law: 義祖母, other: その他",
+            "enum": [
+              "myself",
+              "husband",
+              "wife",
+              "father",
+              "mother",
+              "child",
+              "senior_brother",
+              "junior_brother",
+              "senior_sister",
+              "junior_sister",
+              "grandchild",
+              "grandfather",
+              "grandmother",
+              "father_in_law",
+              "mother_in_law",
+              "grandfather_in_law",
+              "grandmother_in_law",
+              "other"
+            ]
+          },
+          "householder_name": {
+            "type": "string",
+            "description": "世帯主の名前",
+            "maxLength": 255,
+            "example": "山田 太郎"
+          },
+          "is_calc_income_tax": {
+            "type": "boolean",
+            "description": "所得税の計算対象かどうか"
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentController.show_response": {
+        "type": "object",
+        "properties": {
+          "employee": {
+            "description": "本人情報",
+            "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentEmployeeSerializer"
+          },
+          "dependents": {
+            "type": "array",
+            "description": "家族情報(年末調整対象外の場合は取得できません。)",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentDependentSerializer"
+            }
+          },
+          "insurances": {
+            "type": "array",
+            "description": "保険料情報(年末調整対象外の場合は取得できません。)",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentInsuranceSerializer"
+            }
+          },
+          "housing_loan_deduction": {
+            "type": "integer",
+            "description": "住宅借入金等特別控除(年末調整対象外の場合は取得できません。)",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999,
+            "example": 500000
+          },
+          "housing_loans": {
+            "type": "array",
+            "description": "住宅ローン(年末調整対象外の場合は取得できません。)",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentHousingLoanSerializer"
+            }
+          },
+          "payroll_and_bonus": {
+            "description": "給与・賞与",
+            "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentPayrollAndBonusSerializer"
+          },
+          "previous_job": {
+            "description": "前職情報",
+            "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentPreviousJobSerializer",
+            "nullable": true
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentPayrollAndBonusSerializer": {
+        "type": "object",
+        "properties": {
+          "fixed_payroll": {
+            "type": "integer",
+            "description": "確定給与額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 10000000
+          },
+          "fixed_payroll_deduction": {
+            "type": "integer",
+            "description": "確定給与控除額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 1000000
+          },
+          "fixed_payroll_income_tax": {
+            "type": "integer",
+            "description": "確定給与所得税額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 1000000
+          },
+          "fixed_bonus": {
+            "type": "integer",
+            "description": "確定賞与額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 10000000
+          },
+          "fixed_bonus_deduction": {
+            "type": "integer",
+            "description": "確定賞与控除額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 1000000
+          },
+          "fixed_bonus_income_tax": {
+            "type": "integer",
+            "description": "確定賞与所得税額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 1000000
+          },
+          "unentered_payroll_amount": {
+            "type": "integer",
+            "description": "未入力給与額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 500000
+          },
+          "unentered_payroll_deduction_amount": {
+            "type": "integer",
+            "description": "未入力給与控除額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 500000
+          },
+          "unentered_payroll_income_tax_amount": {
+            "type": "integer",
+            "description": "未入力給与所得税額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 500000
+          },
+          "unentered_bonus_amount": {
+            "type": "integer",
+            "description": "未入力賞与額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 500000
+          },
+          "unentered_bonus_deduction_amount": {
+            "type": "integer",
+            "description": "未入力賞与控除額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 500000
+          },
+          "unentered_bonus_income_tax_amount": {
+            "type": "integer",
+            "description": "未入力賞与所得税額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 500000
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentPayrollAndBonusUpdateRequestSerializer": {
+        "type": "object",
+        "properties": {
+          "unentered_payroll_amount": {
+            "type": "integer",
+            "description": "未入力給与額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 1000000
+          },
+          "unentered_payroll_deduction_amount": {
+            "type": "integer",
+            "description": "未入力給与控除額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 1000000
+          },
+          "unentered_payroll_income_tax_amount": {
+            "type": "integer",
+            "description": "未入力給与所得税額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 1000000
+          },
+          "unentered_bonus_amount": {
+            "type": "integer",
+            "description": "未入力賞与額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 1000000
+          },
+          "unentered_bonus_deduction_amount": {
+            "type": "integer",
+            "description": "未入力賞与控除額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 1000000
+          },
+          "unentered_bonus_income_tax_amount": {
+            "type": "integer",
+            "description": "未入力賞与所得税額",
+            "format": "int32",
+            "minimum": -999999999,
+            "maximum": 999999999,
+            "example": 1000000
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentController.update_payroll_and_bonus_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "payroll_and_bonus"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "更新対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "payroll_and_bonus": {
+            "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentPayrollAndBonusUpdateRequestSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentController.update_payroll_and_bonus_response": {
+        "type": "object",
+        "properties": {
+          "payroll_and_bonus": {
+            "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentPayrollAndBonusSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentController.update_dependents_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "dependents"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "更新対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "dependents": {
+            "type": "array",
+            "description": "家族情報",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentDependentUpdateRequestSerializer"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentDependentUpdateRequestSerializer": {
+        "type": "object",
+        "required": [
+          "last_name",
+          "first_name",
+          "relationship",
+          "birth_date",
+          "social_insurance_and_tax_dependent",
+          "disability_type",
+          "residence_type"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "家族情報ID（idがない場合は新規作成になる)",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "destroy": {
+            "type": "boolean",
+            "description": "家族情報を削除するか true: 削除する, false: 削除しない",
+            "example": false
+          },
+          "last_name": {
+            "type": "string",
+            "description": "姓 null不可",
+            "maxLength": 255,
+            "example": "山田"
+          },
+          "first_name": {
+            "type": "string",
+            "description": "名 null不可",
+            "maxLength": 255,
+            "example": "花子"
+          },
+          "last_name_kana": {
+            "type": "string",
+            "description": "姓カナ",
+            "maxLength": 255,
+            "example": "ヤマダ"
+          },
+          "first_name_kana": {
+            "type": "string",
+            "description": "名カナ",
+            "maxLength": 255,
+            "example": "ハナコ"
+          },
+          "relationship": {
+            "type": "string",
+            "description": "続柄 null不可 spouse: 配偶者, father: 父, mother: 母, child: 子, senior_brother: 兄, junior_brother: 弟, senior_sister: 姉, junior_sister: 妹, grandchild: 孫, grandfather: 祖父, grandmother: 祖母, father_in_law: 義父, mother_in_law: 義母, grandfather_in_law: 義祖父, grandmother_in_law: 義祖母, other: その他, great_grandfather: 曽祖父, great_grandmother: 曽祖母, spouses_child: 配偶者の連れ子",
+            "enum": [
+              "spouse",
+              "father",
+              "mother",
+              "child",
+              "senior_brother",
+              "junior_brother",
+              "senior_sister",
+              "junior_sister",
+              "grandchild",
+              "grandfather",
+              "grandmother",
+              "father_in_law",
+              "mother_in_law",
+              "grandfather_in_law",
+              "grandmother_in_law",
+              "other",
+              "great_grandfather",
+              "great_grandmother",
+              "spouses_child"
+            ]
+          },
+          "birth_date": {
+            "type": "string",
+            "description": "生年月日 null不可 1900年1月1日から現在年+5の12月31日まで登録可能",
+            "format": "date",
+            "example": "1999-01-01",
+            "pattern": "^[1-9][0-9]{3}-[0-9]{2}-[0-9]{2}$"
+          },
+          "social_insurance_and_tax_dependent": {
+            "type": "string",
+            "description": "扶養状況 social_insurance_and_tax: 所得税・住民税と社会保険, tax_only: 所得税・住民税のみ, social_insurance_only: 社会保険のみ, not_dependent: 扶養していない",
+            "enum": [
+              "social_insurance_and_tax",
+              "tax_only",
+              "social_insurance_only",
+              "not_dependent"
+            ]
+          },
+          "income": {
+            "type": "integer",
+            "description": "所得 配偶者は「扶養状況」がsocial_insurance_only又はnot_dependentの場合のみ更新可能。配偶者以外は更新可能。 配偶者で「扶養状況」がsocial_insurance_and_tax又はtax_onlyの場合、「給与収入」、「給与以外の所得」から自動で「所得」が計算されます。",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999
+          },
+          "employment_revenue": {
+            "type": "integer",
+            "description": "給与収入 配偶者は「扶養状況」がsocial_insurance_and_tax又はtax_onlyの場合のみ更新可能。配偶者以外は更新不可。更新不可の場合は0となります。",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999
+          },
+          "all_other_income": {
+            "type": "integer",
+            "description": "給与以外の所得 配偶者は「扶養状況」がsocial_insurance_and_tax又はtax_onlyの場合のみ更新可能。配偶者以外は更新不可。更新不可の場合は0となります。",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999
+          },
+          "disability_type": {
+            "type": "string",
+            "description": "障害に該当するか null不可 na: 障害なし, general: 一般の障害者, heavy: 特別障害者",
+            "enum": [
+              "na",
+              "general",
+              "heavy"
+            ]
+          },
+          "residence_type": {
+            "type": "string",
+            "description": "同居・別居 null不可 live_in: 同居, resident: 別居(国内), non_resident: 別居(国外)",
+            "enum": [
+              "live_in",
+              "resident",
+              "non_resident"
+            ]
+          },
+          "zipcode1": {
+            "type": "string",
+            "description": "住民票住所の郵便番号1 「同居・別居」が「同居」の場合は「年末調整従業員情報」の「住民票住所の郵便番号1」を登録",
+            "maxLength": 3,
+            "nullable": true,
+            "example": "141"
+          },
+          "zipcode2": {
+            "type": "string",
+            "description": "住民票住所の郵便番号2 「同居・別居」が「同居」の場合は「年末調整従業員情報」の「住民票住所の郵便番号2」を登録",
+            "maxLength": 4,
+            "nullable": true,
+            "example": "0031"
+          },
+          "prefecture_code": {
+            "type": "integer",
+            "minimum": -1,
+            "maximum": 46,
+            "description": "住民票住所の都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄)  「同居・別居」が「同居」の場合は「年末調整従業員情報」の「住民票住所の都道府県コード」を登録",
+            "example": 12
+          },
+          "address": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所 「同居・別居」が「同居」の場合は「年末調整従業員情報」の「住民票住所の市区町村以降の住所」を登録",
+            "maxLength": 255,
+            "example": "品川区大崎1-2-2"
+          },
+          "address_kana": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所カナ 「同居・別居」が「同居」の場合は「年末調整従業員情報」の「住民票住所の市区町村以降の住所カナ」を登録",
+            "maxLength": 255,
+            "example": "シナガワクオオサキ1-2-2"
+          },
+          "annual_remittance_amount": {
+            "type": "integer",
+            "description": "国外居住親族への年間の送金額 「同居・別居」が「同居」、「別居(国内)」の場合は登録不可",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999
+          },
+          "non_resident_dependents_reason": {
+            "type": "string",
+            "enum": [
+              "none",
+              "over_16_to_under_30_or_over_70",
+              "study_abroad",
+              "handicapped",
+              "over_38_man"
+            ],
+            "description": "非居住者である親族の条件 none: なし, over_16_to_under_30_or_over_70: 16歳以上30歳未満又は70歳以上, study_abroad: 留学, handicapped: 障害者, over_38_man: 38万円以上の支払 続柄が「配偶者」または「同居・別居」が「同居」、「別居(国内)」の場合は登録不可",
+            "format": "string"
+          },
+          "is_resident_tax_only_deduction": {
+            "type": "boolean",
+            "description": "住民税のみの控除対象かどうか"
+          },
+          "retirement_income": {
+            "type": "integer",
+            "description": "退職所得",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentController.update_dependents_response": {
+        "type": "object",
+        "properties": {
+          "dependents": {
+            "type": "array",
+            "description": "家族情報",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentDependentSerializer"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentDependentSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "家族情報ID",
+            "format": "int32",
+            "example": 1
+          },
+          "last_name": {
+            "type": "string",
+            "description": "姓 null不可",
+            "maxLength": 255,
+            "example": "山田"
+          },
+          "first_name": {
+            "type": "string",
+            "description": "名 null不可",
+            "maxLength": 255,
+            "example": "花子"
+          },
+          "last_name_kana": {
+            "type": "string",
+            "description": "姓カナ",
+            "maxLength": 255,
+            "example": "ヤマダ"
+          },
+          "first_name_kana": {
+            "type": "string",
+            "description": "名カナ",
+            "maxLength": 255,
+            "example": "ハナコ"
+          },
+          "relationship": {
+            "type": "string",
+            "description": "続柄 null不可 spouse: 配偶者, father: 父, mother: 母, child: 子, senior_brother: 兄, junior_brother: 弟, senior_sister: 姉, junior_sister: 妹, grandchild: 孫, grandfather: 祖父, grandmother: 祖母, father_in_law: 義父, mother_in_law: 義母, grandfather_in_law: 義祖父, grandmother_in_law: 義祖母, other: その他, great_grandfather: 曽祖父, great_grandmother: 曽祖母, spouses_child: 配偶者の連れ子",
+            "enum": [
+              "spouse",
+              "father",
+              "mother",
+              "child",
+              "senior_brother",
+              "junior_brother",
+              "senior_sister",
+              "junior_sister",
+              "grandchild",
+              "grandfather",
+              "grandmother",
+              "father_in_law",
+              "mother_in_law",
+              "grandfather_in_law",
+              "grandmother_in_law",
+              "other",
+              "great_grandfather",
+              "great_grandmother",
+              "spouses_child"
+            ]
+          },
+          "birth_date": {
+            "type": "string",
+            "description": "生年月日 null不可 1900年1月1日から現在年+5年12月31日まで登録可能",
+            "format": "date",
+            "example": "1999-01-01"
+          },
+          "social_insurance_and_tax_dependent": {
+            "type": "string",
+            "description": "扶養状況 social_insurance_and_tax: 所得税・住民税と社会保険, tax_only: 所得税・住民税のみ, social_insurance_only: 社会保険のみ, not_dependent: 扶養していない",
+            "enum": [
+              "social_insurance_and_tax",
+              "tax_only",
+              "social_insurance_only",
+              "not_dependent"
+            ]
+          },
+          "income": {
+            "type": "integer",
+            "description": "所得 配偶者は「扶養状況」がsocial_insurance_only又はnot_dependentの場合のみ更新可能。配偶者以外は更新可能。 配偶者で「扶養状況」がsocial_insurance_and_tax又はtax_onlyの場合、「給与収入」、「給与以外の所得」から自動で「所得」が計算されます。",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999
+          },
+          "employment_revenue": {
+            "type": "integer",
+            "description": "給与収入 配偶者は「扶養状況」がsocial_insurance_and_tax又はtax_onlyの場合のみ更新可能。配偶者以外は更新不可。更新不可の場合は0となります。",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999
+          },
+          "all_other_income": {
+            "type": "integer",
+            "description": "給与以外の所得 配偶者は「扶養状況」がsocial_insurance_and_tax又はtax_onlyの場合のみ更新可能。配偶者以外は更新不可。更新不可の場合は0となります。",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999
+          },
+          "disability_type": {
+            "type": "string",
+            "description": "障害に該当するか null不可 na: 障害なし, general: 一般の障害者, heavy: 特別障害者",
+            "enum": [
+              "na",
+              "general",
+              "heavy"
+            ]
+          },
+          "residence_type": {
+            "type": "string",
+            "description": "同居・別居 null不可 live_in: 同居, resident: 別居(国内), non_resident: 別居(国外)",
+            "enum": [
+              "live_in",
+              "resident",
+              "non_resident"
+            ]
+          },
+          "zipcode1": {
+            "type": "string",
+            "description": "住民票住所の郵便番号1 「同居・別居」が「同居」の場合は「年末調整従業員情報」の「住民票住所の郵便番号1」を登録",
+            "maxLength": 3,
+            "nullable": true,
+            "example": "141"
+          },
+          "zipcode2": {
+            "type": "string",
+            "description": "住民票住所の郵便番号2 「同居・別居」が「同居」の場合は「年末調整従業員情報」の「住民票住所の郵便番号2」を登録",
+            "maxLength": 4,
+            "nullable": true,
+            "example": "0031"
+          },
+          "prefecture_code": {
+            "type": "integer",
+            "minimum": -1,
+            "maximum": 46,
+            "description": "住民票住所の都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄)  「同居・別居」が「同居」の場合は「年末調整従業員情報」の「住民票住所の都道府県コード」を登録",
+            "example": 12
+          },
+          "address": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所 「同居・別居」が「同居」の場合は「年末調整従業員情報」の「住民票住所の市区町村以降の住所」を登録",
+            "maxLength": 255,
+            "example": "品川区大崎1-2-2"
+          },
+          "address_kana": {
+            "type": "string",
+            "description": "住民票住所の市区町村以降の住所カナ 「同居・別居」が「同居」の場合は「年末調整従業員情報」の「住民票住所の市区町村以降の住所カナ」を登録",
+            "maxLength": 255,
+            "example": "シナガワクオオサキ1-2-2"
+          },
+          "annual_remittance_amount": {
+            "type": "integer",
+            "description": "国外居住親族への年間の送金額 「同居・別居」が「同居」、「別居(国内)」の場合は登録不可",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999
+          },
+          "non_resident_dependents_reason": {
+            "type": "string",
+            "enum": [
+              "none",
+              "over_16_to_under_30_or_over_70",
+              "study_abroad",
+              "handicapped",
+              "over_38_man"
+            ],
+            "description": "非居住者である親族の条件 none: なし, over_16_to_under_30_or_over_70: 16歳以上30歳未満又は70歳以上, study_abroad: 留学, handicapped: 障害者, over_38_man: 38万円以上の支払 続柄が「配偶者」または「同居・別居」が「同居」、「別居(国内)」の場合は登録不可",
+            "format": "string"
+          },
+          "is_resident_tax_only_deduction": {
+            "type": "boolean",
+            "description": "住民税のみの控除対象かどうか"
+          },
+          "retirement_income": {
+            "type": "integer",
+            "description": "退職所得",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentController.update_previous_job_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "previous_job"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "更新対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "previous_job": {
+            "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentPreviousJobUpdateRequestSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentPreviousJobUpdateRequestSerializer": {
+        "type": "object",
+        "required": [
+          "income",
+          "deduction",
+          "withholding_tax_amount",
+          "company_name",
+          "company_address",
+          "retire_date"
+        ],
+        "properties": {
+          "income": {
+            "type": "integer",
+            "description": "前職の支払金額",
+            "example": 5000000,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "deduction": {
+            "type": "integer",
+            "description": "前職の社会保険料等の金額",
+            "example": 1200000,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "withholding_tax_amount": {
+            "type": "integer",
+            "description": "前職の源泉徴収額",
+            "example": 100000,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "company_name": {
+            "type": "string",
+            "description": "前職の社名",
+            "maxLength": 255,
+            "example": "株式会社 前職"
+          },
+          "company_address": {
+            "type": "string",
+            "description": "前職の事業所住所",
+            "maxLength": 255,
+            "example": "品川区大崎1-2-2"
+          },
+          "retire_date": {
+            "type": "string",
+            "description": "前職の退職日 現在年-10年1月1日から現在年+5年12月31日まで登録可能",
+            "format": "date",
+            "example": "2022-03-31"
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentController.update_previous_job_response": {
+        "type": "object",
+        "properties": {
+          "previous_job": {
+            "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentPreviousJobSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentPreviousJobSerializer": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "income": {
+            "type": "integer",
+            "description": "前職の支払金額",
+            "example": 5000000,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "deduction": {
+            "type": "integer",
+            "description": "前職の社会保険料等の金額",
+            "example": 1200000,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "withholding_tax_amount": {
+            "type": "integer",
+            "description": "前職の源泉徴収額",
+            "example": 100000,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "company_name": {
+            "type": "string",
+            "description": "前職の社名",
+            "maxLength": 255,
+            "example": "株式会社 前職"
+          },
+          "company_address": {
+            "type": "string",
+            "description": "前職の事業所住所",
+            "maxLength": 255,
+            "example": "品川区大崎1-2-2"
+          },
+          "retire_date": {
+            "type": "string",
+            "description": "前職の退職日 現在年-10年1月1日から現在年+5年12月31日まで登録可能",
+            "format": "date",
+            "example": "2022-03-31"
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentController.update_insurance_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "insurance"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "更新対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "insurance": {
+            "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentInsuranceUpdateRequestSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentInsuranceUpdateRequestSerializer": {
+        "type": "object",
+        "required": [
+          "type",
+          "category",
+          "new_or_old",
+          "amount"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "保険の種類 life_care_pension_insurance: 生命保険・介護医療保険・個人年金保険, earthquake_non_life_insurance: 地震保険・旧長期損害保険, social_insurance: 社会保険, other_insurance: その他の保険（小規模企業共済等）",
+            "enum": [
+              "life_care_pension_insurance",
+              "earthquake_non_life_insurance",
+              "social_insurance",
+              "other_insurance"
+            ]
+          },
+          "category": {
+            "type": "string",
+            "description": "区分<br>\n保険会社等が発行する証明書類に基づいて区分を設定してください。<br>\n保険の種類によって設定可能な値が変わります。<br>\n・life_care_pension_insurance<br>\n　life: 生命保険<br>\n　care: 介護保険<br>\n　pension: 個人年金保険<br>\n・earthquake_non_life_insurance<br>\n　earthquake: 地震保険<br>\n　old_long_term_non_life: 旧長期損害保険<br>\n・social_insurance<br>\n　national_pension: 国民年金<br>\n　national_pension_fund_premium: 国民年金基金<br>\n　national_health: 国民健康保険<br>\n　health: 健康保険<br>\n　care_insurance_deduction_of_pension: 介護保険<br>\n　employee_pension: 厚生年金<br>\n　advanced_elderly_medical: 後期高齢者医療保険<br>\n　none: その他（印刷後に手書き）<br>\n・other_insurance<br>\n　sema: 独立行政法人中小企業基盤整備機構の共済契約の掛金<br>\n　idc: 個人型確定拠出年金（iDeCo）<br>\n　cdc: 企業型確定拠出年金<br>\n　dsma: 心身障害者扶養共済制度に関する契約の掛金<br>",
+            "enum": [
+              "life",
+              "care",
+              "pension",
+              "earthquake",
+              "old_long_term_non_life",
+              "national_pension",
+              "national_pension_fund_premium",
+              "national_health",
+              "care_insurance_deduction_of_pension",
+              "health",
+              "employee_pension",
+              "advanced_elderly_medical",
+              "sema",
+              "idc",
+              "cdc",
+              "dsma",
+              "none"
+            ],
+            "example": "life"
+          },
+          "new_or_old": {
+            "type": "string",
+            "description": "新旧区分<br>\n区分が生命保険または個人年金保険の時のみ、新制度なら new を、旧制度なら old を指定します。<br>\n上記以外の保険では none を指定してください。",
+            "enum": [
+              "new",
+              "old",
+              "none"
+            ]
+          },
+          "company_name": {
+            "type": "string",
+            "description": "保険会社等の名称<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険または地震保険・旧長期損害保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "maxLength": 255,
+            "example": "freee生命保険株式会社",
+            "nullable": true
+          },
+          "kind_of_purpose": {
+            "type": "string",
+            "description": "保険等の種類（目的）<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険または地震保険・旧長期損害保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "maxLength": 255,
+            "example": "利差配当付終身",
+            "nullable": true
+          },
+          "period": {
+            "type": "string",
+            "description": "保険期間又は年金支払期間<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険または地震保険・旧長期損害保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "example": "終身",
+            "nullable": true,
+            "enum": [
+              "終身",
+              "0年",
+              "1年",
+              "2年",
+              "3年",
+              "4年",
+              "5年",
+              "6年",
+              "7年",
+              "8年",
+              "9年",
+              "10年",
+              "11年",
+              "12年",
+              "13年",
+              "14年",
+              "15年",
+              "16年",
+              "17年",
+              "18年",
+              "19年",
+              "20年",
+              "21年",
+              "22年",
+              "23年",
+              "24年",
+              "25年",
+              "26年",
+              "27年",
+              "28年",
+              "29年",
+              "30年",
+              "31年",
+              "32年",
+              "33年",
+              "34年",
+              "35年",
+              "36年",
+              "37年",
+              "38年",
+              "39年",
+              "40年",
+              "41年",
+              "42年",
+              "43年",
+              "44年",
+              "45年",
+              "46年",
+              "47年",
+              "48年",
+              "49年",
+              "50年",
+              "51年",
+              "52年",
+              "53年",
+              "54年",
+              "55年",
+              "56年",
+              "57年",
+              "58年",
+              "59年",
+              "60年",
+              "61年",
+              "62年",
+              "63年",
+              "64年",
+              "65年",
+              "66年",
+              "67年",
+              "68年",
+              "69年",
+              "70年",
+              "71年",
+              "72年",
+              "73年",
+              "74年",
+              "75年",
+              "76年",
+              "77年",
+              "78年",
+              "79年",
+              "80年",
+              "81年",
+              "82年",
+              "83年",
+              "84年",
+              "85年",
+              "86年",
+              "87年",
+              "88年",
+              "89年",
+              "90年",
+              "91年",
+              "92年",
+              "93年",
+              "94年",
+              "95年",
+              "96年",
+              "97年",
+              "98年",
+              "99年",
+              "100年",
+              ""
+            ]
+          },
+          "policyholder_last_name": {
+            "type": "string",
+            "description": "保険等の契約者 姓<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険または地震保険・旧長期損害保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "maxLength": 255,
+            "example": "契約",
+            "nullable": true
+          },
+          "policyholder_first_name": {
+            "type": "string",
+            "description": "保険等の契約者 名<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険または地震保険・旧長期損害保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "maxLength": 255,
+            "example": "太郎",
+            "nullable": true
+          },
+          "recipient_last_name": {
+            "type": "string",
+            "description": "保険金等の受取人 姓<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険、地震保険・旧長期損害保険または社会保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "maxLength": 255,
+            "example": "受取",
+            "nullable": true
+          },
+          "recipient_first_name": {
+            "type": "string",
+            "description": "保険金等の受取人 名<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険、地震保険・旧長期損害保険または社会保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "maxLength": 255,
+            "nullable": true,
+            "example": "太郎"
+          },
+          "recipient_relationship": {
+            "type": "string",
+            "description": "保険金等の受取人 あなたとの続柄 myself: 本人, husband: 夫, wife: 妻, father: 父, mother: 母, child: 子, senior_brother: 兄, junior_brother: 弟, senior_sister: 姉, junior_sister: 妹, grandchild: 孫, grandfather: 祖父, grandmother: 祖母, father_in_law: 義父, mother_in_law: 義母, grandfather_in_law: 義祖父, grandmother_in_law: 義祖母, other: その他, \"\": 空欄<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険、地震保険・旧長期損害保険または社会保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "enum": [
+              "myself",
+              "husband",
+              "wife",
+              "father",
+              "mother",
+              "child",
+              "senior_brother",
+              "junior_brother",
+              "senior_sister",
+              "junior_sister",
+              "grandchild",
+              "grandfather",
+              "grandmother",
+              "father_in_law",
+              "mother_in_law",
+              "grandfather_in_law",
+              "grandmother_in_law",
+              "other",
+              ""
+            ],
+            "example": "child",
+            "nullable": true
+          },
+          "payment_start_date": {
+            "type": "string",
+            "description": "年金の支払開始日 1900年1月1日から現在年+100の12月31日まで登録可能。<br>\n区分が個人年金保険の時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "pattern": "^([1-2][0-9]{3}-[0-9]{2}-[0-9]{2})?$",
+            "example": "2000-04-01",
+            "nullable": true
+          },
+          "amount": {
+            "type": "integer",
+            "description": "保険料額",
+            "example": 1000000,
+            "minimum": 0,
+            "maximum": 99999999
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentController.update_insurance_response": {
+        "type": "object",
+        "properties": {
+          "insurances": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentInsuranceSerializer"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentInsuranceSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "保険料id",
+            "minimum": 1,
+            "maximum": 2147483647
+          },
+          "type": {
+            "type": "string",
+            "description": "保険の種類 life_care_pension_insurance: 生命保険・介護医療保険・個人年金保険, earthquake_non_life_insurance: 地震保険・旧長期損害保険, social_insurance: 社会保険, other_insurance: その他の保険（小規模企業共済等）",
+            "enum": [
+              "life_care_pension_insurance",
+              "earthquake_non_life_insurance",
+              "social_insurance",
+              "other_insurance"
+            ]
+          },
+          "category": {
+            "type": "string",
+            "description": "区分<br>\n保険会社等が発行する証明書類に基づいて区分を設定してください。<br>\n保険の種類によって設定可能な値が変わります。<br>\n・life_care_pension_insurance<br>\n　life: 生命保険<br>\n　care: 介護保険<br>\n　pension: 個人年金保険<br>\n・earthquake_non_life_insurance<br>\n　earthquake: 地震保険<br>\n　old_long_term_non_life: 旧長期損害保険<br>\n・social_insurance<br>\n　national_pension: 国民年金<br>\n　national_pension_fund_premium: 国民年金基金<br>\n　national_health: 国民健康保険<br>\n　health: 健康保険<br>\n　care_insurance_deduction_of_pension: 介護保険<br>\n　employee_pension: 厚生年金<br>\n　advanced_elderly_medical: 後期高齢者医療保険<br>\n　none: その他（印刷後に手書き）<br>\n・other_insurance<br>\n　sema: 独立行政法人中小企業基盤整備機構の共済契約の掛金<br>\n　idc: 個人型確定拠出年金（iDeCo）<br>\n　cdc: 企業型確定拠出年金<br>\n　dsma: 心身障害者扶養共済制度に関する契約の掛金<br>",
+            "enum": [
+              "life",
+              "care",
+              "pension",
+              "earthquake",
+              "old_long_term_non_life",
+              "national_pension",
+              "national_pension_fund_premium",
+              "national_health",
+              "care_insurance_deduction_of_pension",
+              "health",
+              "employee_pension",
+              "advanced_elderly_medical",
+              "sema",
+              "idc",
+              "cdc",
+              "dsma",
+              "none"
+            ],
+            "example": "life"
+          },
+          "new_or_old": {
+            "type": "string",
+            "description": "新旧区分<br>\n区分が生命保険または個人年金保険の時のみ、新制度なら new を、旧制度なら old を指定します。<br>\n上記以外の保険では none を指定してください。",
+            "enum": [
+              "new",
+              "old",
+              "none"
+            ]
+          },
+          "company_name": {
+            "type": "string",
+            "description": "保険会社等の名称<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険または地震保険・旧長期損害保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "maxLength": 255,
+            "example": "freee生命保険株式会社",
+            "nullable": true
+          },
+          "kind_of_purpose": {
+            "type": "string",
+            "description": "保険等の種類（目的）<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険または地震保険・旧長期損害保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "maxLength": 255,
+            "example": "利差配当付終身",
+            "nullable": true
+          },
+          "period": {
+            "type": "string",
+            "description": "保険期間又は年金支払期間<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険または地震保険・旧長期損害保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "example": "終身",
+            "nullable": true,
+            "enum": [
+              "終身",
+              "0年",
+              "1年",
+              "2年",
+              "3年",
+              "4年",
+              "5年",
+              "6年",
+              "7年",
+              "8年",
+              "9年",
+              "10年",
+              "11年",
+              "12年",
+              "13年",
+              "14年",
+              "15年",
+              "16年",
+              "17年",
+              "18年",
+              "19年",
+              "20年",
+              "21年",
+              "22年",
+              "23年",
+              "24年",
+              "25年",
+              "26年",
+              "27年",
+              "28年",
+              "29年",
+              "30年",
+              "31年",
+              "32年",
+              "33年",
+              "34年",
+              "35年",
+              "36年",
+              "37年",
+              "38年",
+              "39年",
+              "40年",
+              "41年",
+              "42年",
+              "43年",
+              "44年",
+              "45年",
+              "46年",
+              "47年",
+              "48年",
+              "49年",
+              "50年",
+              "51年",
+              "52年",
+              "53年",
+              "54年",
+              "55年",
+              "56年",
+              "57年",
+              "58年",
+              "59年",
+              "60年",
+              "61年",
+              "62年",
+              "63年",
+              "64年",
+              "65年",
+              "66年",
+              "67年",
+              "68年",
+              "69年",
+              "70年",
+              "71年",
+              "72年",
+              "73年",
+              "74年",
+              "75年",
+              "76年",
+              "77年",
+              "78年",
+              "79年",
+              "80年",
+              "81年",
+              "82年",
+              "83年",
+              "84年",
+              "85年",
+              "86年",
+              "87年",
+              "88年",
+              "89年",
+              "90年",
+              "91年",
+              "92年",
+              "93年",
+              "94年",
+              "95年",
+              "96年",
+              "97年",
+              "98年",
+              "99年",
+              "100年",
+              ""
+            ]
+          },
+          "policyholder_last_name": {
+            "type": "string",
+            "description": "保険等の契約者 姓<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険または地震保険・旧長期損害保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "maxLength": 255,
+            "example": "契約",
+            "nullable": true
+          },
+          "policyholder_first_name": {
+            "type": "string",
+            "description": "保険等の契約者 名<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険または地震保険・旧長期損害保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "maxLength": 255,
+            "example": "太郎",
+            "nullable": true
+          },
+          "recipient_last_name": {
+            "type": "string",
+            "description": "保険金等の受取人 姓<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険、地震保険・旧長期損害保険または社会保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "maxLength": 255,
+            "example": "受取",
+            "nullable": true
+          },
+          "recipient_first_name": {
+            "type": "string",
+            "description": "保険金等の受取人 名<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険、地震保険・旧長期損害保険または社会保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "maxLength": 255,
+            "nullable": true,
+            "example": "太郎"
+          },
+          "recipient_relationship": {
+            "type": "string",
+            "description": "保険金等の受取人 あなたとの続柄 myself: 本人, husband: 夫, wife: 妻, father: 父, mother: 母, child: 子, senior_brother: 兄, junior_brother: 弟, senior_sister: 姉, junior_sister: 妹, grandchild: 孫, grandfather: 祖父, grandmother: 祖母, father_in_law: 義父, mother_in_law: 義母, grandfather_in_law: 義祖父, grandmother_in_law: 義祖母, other: その他, \"\": 空欄<br>\n保険の種類にて、生命保険・介護医療保険・個人年金保険、地震保険・旧長期損害保険または社会保険を選択している時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "enum": [
+              "myself",
+              "husband",
+              "wife",
+              "father",
+              "mother",
+              "child",
+              "senior_brother",
+              "junior_brother",
+              "senior_sister",
+              "junior_sister",
+              "grandchild",
+              "grandfather",
+              "grandmother",
+              "father_in_law",
+              "mother_in_law",
+              "grandfather_in_law",
+              "grandmother_in_law",
+              "other",
+              ""
+            ],
+            "example": "child",
+            "nullable": true
+          },
+          "payment_start_date": {
+            "type": "string",
+            "description": "年金の支払開始日 1900年1月1日から現在年+100の12月31日まで登録可能。<br>\n区分が個人年金保険の時のみ、入力した値が反映されます。<br>\n上記以外の保険では入力した値は反映されません。",
+            "pattern": "^([1-2][0-9]{3}-[0-9]{2}-[0-9]{2})?$",
+            "example": "2000-04-01",
+            "nullable": true
+          },
+          "amount": {
+            "type": "integer",
+            "description": "保険料額",
+            "example": 1000000,
+            "minimum": 0,
+            "maximum": 99999999
+          },
+          "certification_type": {
+            "type": "string",
+            "description": "電子的控除証明書などの認証方法を利用した場合、その認証方法が反映されます。<br>\nxml: 電子的控除証明書を利用。証明書画像データの提出が免除されます。またrecipient_first_name、recipient_last_name、recipient_relationship以外のカラムが更新不可となります。",
+            "enum": [
+              "xml"
+            ],
+            "nullable": true
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentController.update_housing_loan_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "housing_loan"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "更新対象事業所ID（必須）",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "housing_loan": {
+            "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentHousingLoanUpdateRequestSerializer"
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentHousingLoanUpdateRequestSerializer": {
+        "type": "object",
+        "required": [
+          "residence_start_date",
+          "remaining_balance_at_yearend",
+          "category",
+          "specific_case_type"
+        ],
+        "properties": {
+          "residence_start_date": {
+            "type": "string",
+            "description": "居住開始の年月日 2000年1月1日から現在年+5の12月31日まで登録可能",
+            "format": "date",
+            "pattern": "^[2-9][0-9]{3}-[0-9]{2}-[0-9]{2}$",
+            "example": "2022-03-31"
+          },
+          "remaining_balance_at_yearend": {
+            "type": "integer",
+            "description": "住宅借入金等年末残高",
+            "example": 5000000,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "category": {
+            "type": "string",
+            "description": "住宅借入金等特別控除区分 general: 住: 一般の住宅借入金等, qualified: 認: 認定住宅の新築等, extension: 増: 特定増改築等, earthquake: 震: 震災特例法による特別控除",
+            "enum": [
+              "general",
+              "qualified",
+              "extension",
+              "earthquake"
+            ]
+          },
+          "specific_case_type": {
+            "type": "string",
+            "description": "特定取得/特別特定取得 not_qualified: 該当しない, specified: 特定取得, special_specified_or_special_exception: 特別特定取得または特別特例取得, exception_special_exception: 特例特別特例取得 special_residential_house 特家",
+            "enum": [
+              "not_qualified",
+              "specified",
+              "special_specified_or_special_exception",
+              "exception_special_exception",
+              "special_residential_house"
+            ]
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentController.update_housing_loan_response": {
+        "type": "object",
+        "properties": {
+          "housing_loan_deduction": {
+            "type": "integer",
+            "description": "住宅借入金等特別控除",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999999999,
+            "example": 500000
+          },
+          "housing_loans": {
+            "type": "array",
+            "description": "住宅ローン",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeeYearendAdjustmentHousingLoanSerializer"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeeYearendAdjustmentHousingLoanSerializer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "住宅ローンID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "residence_start_date": {
+            "type": "string",
+            "description": "居住開始の年月日",
+            "format": "date",
+            "example": "2022-03-31"
+          },
+          "remaining_balance_at_yearend": {
+            "type": "integer",
+            "description": "住宅借入金等年末残高",
+            "example": 5000000,
+            "minimum": -999999999,
+            "maximum": 999999999
+          },
+          "category": {
+            "type": "string",
+            "description": "住宅借入金等特別控除区分 general: 住: 一般の住宅借入金等, qualified: 認: 認定住宅の新築等, extension: 増: 特定増改築等, earthquake: 震: 震災特例法による特別控除",
+            "enum": [
+              "general",
+              "qualified",
+              "extension",
+              "earthquake"
+            ]
+          },
+          "specific_case_type": {
+            "type": "string",
+            "description": "特定取得/特別特定取得 not_qualified: 該当しない, specified: 特定取得, special_specified_or_special_exception: 特別特定取得または特別特例取得, exception_special_exception: 特例特別特例取得 special_residential_house 特家",
+            "enum": [
+              "not_qualified",
+              "specified",
+              "special_specified_or_special_exception",
+              "exception_special_exception",
+              "special_residential_house"
+            ]
+          }
+        }
+      },
+      "ApiV1EmployeesAssignedAttendanceTagSerializer": {
+        "type": "object",
+        "required": [
+          "attendance_tag",
+          "amount"
+        ],
+        "properties": {
+          "attendance_tag": {
+            "type": "object",
+            "required": [
+              "id",
+              "company_id",
+              "name",
+              "description",
+              "max_amount",
+              "published",
+              "is_employee_usable"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "勤怠タグID",
+                "format": "int32",
+                "minimum": 1,
+                "maximum": 2147483647,
+                "example": 1
+              },
+              "company_id": {
+                "type": "integer",
+                "description": "事業所ID",
+                "format": "int32",
+                "minimum": 1,
+                "maximum": 2147483647,
+                "example": 1
+              },
+              "name": {
+                "type": "string",
+                "description": "勤怠タグ名称",
+                "example": "勤怠タグの名称"
+              },
+              "description": {
+                "type": "string",
+                "description": "勤怠タグ備考",
+                "example": "勤怠タグの備考"
+              },
+              "max_amount": {
+                "type": "integer",
+                "description": "勤怠タグ回数上限",
+                "format": "int32",
+                "minimum": 1,
+                "maximum": 999,
+                "example": 1
+              },
+              "published": {
+                "type": "boolean",
+                "description": "勤怠タグ公開ステータス",
+                "example": true
+              },
+              "is_employee_usable": {
+                "type": "boolean",
+                "description": "対象従業員が利用可能かどうか",
+                "example": true
+              }
+            }
+          },
+          "amount": {
+            "type": "integer",
+            "description": "勤怠タグ回数",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1EmployeesAttendanceTagsController.index_response": {
+        "type": "object",
+        "properties": {
+          "employee_attendance_tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesAttendanceTagSerializer"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeesAttendanceTagsController.show_response": {
+        "type": "object",
+        "properties": {
+          "employee_attendance_tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesAssignedAttendanceTagSerializer"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeesAttendanceTagsController.update_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "employee_attendance_tags"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "employee_attendance_tags": {
+            "type": "array",
+            "description": "更新対象の勤怠タグのリスト",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesAttendanceTagUpdateRequestSerializer"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeesAttendanceTagSerializer": {
+        "type": "object",
+        "required": [
+          "id",
+          "company_id",
+          "name",
+          "description",
+          "max_amount",
+          "published",
+          "is_employee_usable"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "勤怠タグID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "勤怠タグ名称",
+            "example": "勤怠タグの名称"
+          },
+          "description": {
+            "type": "string",
+            "description": "勤怠タグ備考",
+            "example": "勤怠タグの備考"
+          },
+          "max_amount": {
+            "type": "integer",
+            "description": "勤怠タグ回数上限",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 999,
+            "example": 1
+          },
+          "published": {
+            "type": "boolean",
+            "description": "勤怠タグ公開ステータス",
+            "example": true
+          },
+          "is_employee_usable": {
+            "type": "boolean",
+            "description": "対象従業員が利用可能かどうか",
+            "example": true
+          }
+        }
+      },
+      "ApiV1EmployeesAttendanceTagUpdateRequestSerializer": {
+        "type": "object",
+        "required": [
+          "attendance_tag_id",
+          "amount"
+        ],
+        "properties": {
+          "attendance_tag_id": {
+            "type": "integer",
+            "description": "勤怠タグID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "amount": {
+            "type": "integer",
+            "description": "勤怠タグ回数",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 999,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1EmployeesAttendanceTagSummariesController.show_response": {
+        "type": "object",
+        "properties": {
+          "employee_attendance_tag_summaries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesAttendanceTagSummary"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeesAttendanceTagSummariesController.update_body": {
+        "type": "object",
+        "required": [
+          "company_id",
+          "employee_attendance_tag_summaries"
+        ],
+        "properties": {
+          "company_id": {
+            "type": "integer",
+            "description": "事業所ID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "employee_attendance_tag_summaries": {
+            "type": "array",
+            "description": "更新対象の勤怠タグサマリのリスト",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesAttendanceTagSummaryUpdateRequestSerializer"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeesAttendanceTagSummariesController.update_response": {
+        "type": "object",
+        "properties": {
+          "employee_attendance_tag_summaries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiV1EmployeesAttendanceTagSummary"
+            }
+          }
+        }
+      },
+      "ApiV1EmployeesAttendanceTagSummary": {
+        "type": "object",
+        "required": [
+          "attendance_tag",
+          "amount"
+        ],
+        "properties": {
+          "attendance_tag": {
+            "type": "object",
+            "required": [
+              "id",
+              "company_id",
+              "name",
+              "description",
+              "max_amount",
+              "published",
+              "is_employee_usable"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "勤怠タグID",
+                "format": "int32",
+                "minimum": 1,
+                "maximum": 2147483647,
+                "example": 1
+              },
+              "company_id": {
+                "type": "integer",
+                "description": "事業所ID",
+                "format": "int32",
+                "minimum": 1,
+                "maximum": 2147483647,
+                "example": 1
+              },
+              "name": {
+                "type": "string",
+                "description": "勤怠タグ名称",
+                "example": "勤怠タグの名称"
+              },
+              "description": {
+                "type": "string",
+                "description": "勤怠タグ備考",
+                "example": "勤怠タグの備考"
+              },
+              "max_amount": {
+                "type": "integer",
+                "description": "勤怠タグ回数上限",
+                "format": "int32",
+                "minimum": 1,
+                "maximum": 999,
+                "example": 1
+              },
+              "published": {
+                "type": "boolean",
+                "description": "勤怠タグ公開ステータス",
+                "example": true
+              },
+              "is_employee_usable": {
+                "type": "boolean",
+                "description": "対象従業員が利用可能かどうか",
+                "example": true
+              }
+            }
+          },
+          "amount": {
+            "type": "integer",
+            "description": "勤怠タグ回数",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 99999,
+            "example": 1
+          }
+        }
+      },
+      "ApiV1EmployeesAttendanceTagSummaryUpdateRequestSerializer": {
+        "type": "object",
+        "required": [
+          "attendance_tag_id",
+          "amount"
+        ],
+        "properties": {
+          "attendance_tag_id": {
+            "type": "integer",
+            "description": "勤怠タグID",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 2147483647,
+            "example": 1
+          },
+          "amount": {
+            "type": "integer",
+            "description": "勤怠タグ回数",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 99999,
+            "example": 1
+          }
+        }
+      },
+      "error": {
+        "type": "object",
+        "properties": {
+          "status_code": {
+            "type": "integer",
+            "example": 400
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "messages": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "example": "リクエストの形式が不正です。"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "unauthorizedError": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "ログインをしてください。"
+          },
+          "messages": {
+            "type": "string"
+          }
+        }
+      },
+      "forbiddenError": {
+        "type": "object",
+        "properties": {
+          "status_code": {
+            "type": "integer",
+            "example": 403
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "messages": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "example": "アクセス権限がありません。"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "accessDeniedError": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "example": "access_denied"
+          },
+          "message": {
+            "type": "string",
+            "example": "アクセスする権限がありません"
+          },
+          "code": {
+            "type": "string",
+            "example": "expired_access_token"
+          }
+        }
+      },
+      "notfoundError": {
+        "type": "object",
+        "properties": {
+          "status_code": {
+            "type": "integer",
+            "example": 404
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "example": "not_found"
+                },
+                "messages": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "example": "存在しないか既に削除されたレコードです。"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "internalServerError": {
+        "type": "object",
+        "properties": {
+          "status_code": {
+            "type": "integer",
+            "example": 500
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "example": "internal_server_error"
+                },
+                "messages": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "example": "エラーが発生しました。再試行しても解消しない場合は、サポートセンターまでご連絡ください。"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "bearer": {
+        "type": "apiKey",
+        "name": "Authorization",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/openapi/invoice-api-schema.json
+++ b/openapi/invoice-api-schema.json
@@ -1,0 +1,7164 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "contact": {
+      "name": "freee請求書問い合わせ",
+      "url": "https://freee.my.site.com/HelpCenter/s"
+    },
+    "description": "\n<p>freee請求書のAPI仕様です。</p>\n\n<b>freee請求書APIを利用するには、freee請求書への登録が必要です。\n\n登録は<a href=\"https://www.freee.co.jp/invoice/\" target=\"_blank\">freee請求書</a>より行ってください。</b>\n\n</br>\n\n<h3 id=\"about_authorize\">認証について</h3>\n\n<p>OAuth2.0を利用します。<a href=\"https://developer.freee.co.jp/reference/#%e8%aa%8d%e8%a8%bc\" target=\"_blank\">詳細はリファレンスの認証に関する記載を参照してください。</a></p>\n\n<h3 id=\"api_endpoint\">エンドポイント</h3>\n\n<p>https://api.freee.co.jp/iv</p>\n\n\n<h3 id=\"compatibility\">後方互換性ありの変更</h3>\n\n<p>freeeでは、APIを改善していくために以下のような変更は後方互換性ありとして通知なく変更を入れることがあります。アプリケーション実装者は以下を踏まえて開発を行ってください。</p>\n\n<ul>\n<li>新しいAPIリソース・エンドポイントの追加</li>\n<li>既存のAPIに対して必須ではない新しいリクエストパラメータの追加</li>\n<li>既存のAPIレスポンスに対する新しいプロパティの追加</li>\n<li>既存のAPIレスポンスに対するプロパティの順番の入れ変え</li>\n<li>keyとなっているidやcodeの長さの変更（長くする）</li>\n</ul>\n\n<h3 id=\"error_response\">エラーレスポンス</h3>\n\n<p>APIリクエストでエラーが発生した場合は、エラー原因に応じたステータスコードおよびメッセージを返します。</p>\n\n  <table border=\"1\">\n  <tbody>\n    <tr>\n      <th style=\"padding: 10px\"><strong>ステータスコード</strong></th>\n      <th style=\"padding: 10px\"><strong>原因</strong></th>\n    </tr>\n    <tr><td style=\"padding: 10px\">400</td><td style=\"padding: 10px\">リクエストパラメータが不正</td></tr>\n    <tr><td style=\"padding: 10px\">401</td><td style=\"padding: 10px\">アクセストークンが無効</td></tr>\n    <tr><td style=\"padding: 10px\">403</td><td style=\"padding: 10px\">アクセス権限がない</td></tr>\n    <tr><td style=\"padding: 10px\">404</td><td style=\"padding: 10px\">リソースが存在しない</td></tr>\n    <tr><td style=\"padding: 10px\">429</td><td style=\"padding: 10px\">リクエスト回数制限を超えた</td></tr>\n    <tr><td style=\"padding: 10px\">503</td><td style=\"padding: 10px\">システム内で予期しないエラーが発生</td></tr>\n  </tbody>\n</table>\n\n<p>メッセージボディ内の <code>messages</code> にはエラー内容を説明する文字列が入ります。</p>\n<pre><code>  {\n    &quot;status_code&quot; : 400,\n    &quot;errors&quot; : [\n      {\n        &quot;type&quot; : &quot;bad_request&quot;,\n        &quot;messages&quot; : [\n          &quot;リクエストの形式が不正です。&quot;\n        ]\n      }\n    ]\n  }  </code></pre>\n\n</br>\n\n<h3 id=\"api_rate_limit\">API使用制限</h3>\n<p>APIリクエストは、全プラン共通で1時間あたり1500回、1分あたり30回を上限としています。また、契約プランに応じて1日あたりの上限が設定されています。</p>\n\n<table border=\"1\">\n  <tbody>\n    <tr>\n      <th style=\"padding: 10px\"><strong>freee会計プラン名</strong></th>\n      <th style=\"padding: 10px\"><strong>事業所とアプリケーション毎に、1日のAPIコール数の上限</strong></th>\n    </tr>\n    <tr><td style=\"padding: 10px\">法人エンタープライズプラン</td><td style=\"padding: 10px\">10,000</td></tr>\n    <tr><td style=\"padding: 10px\">法人アドバンスプラン（および旧法人プロフェッショナルプラン）</td><td style=\"padding: 10px\">5,000</td></tr>\n    <tr><td style=\"padding: 10px\">上記以外</td><td style=\"padding: 10px\">3,000</td></tr>\n  </tbody>\n</table>\n\n<p>API使用ステータスはレスポンスヘッダに付与されます。</p>\n\n<pre><code>X-RateLimit-Limit:1500\nX-RateLimit-Remaining:1498\nX-RateLimit-Reset:2018-01-01T12:00:00.000000Z\nX-Ratelimit-Limit-Minute:30\nX-Ratelimit-Remaining-Minute:29\nX-Ratelimit-Reset-Minute:2018-01-01T12:00:00.000000Z\nX-RateLimit-Limit-Day:3000\nX-RateLimit-Remaining-Day:2991\nX-RateLimit-Reset-Day:2018-01-02T00:00:00.000000Z\n</code></pre>\n\n<br> 各ヘッダの意味は次のとおりです。</p>\n\n <table border=\"1\">\n  <tbody>\n    <tr>\n      <th style=\"padding: 10px\"><strong>ヘッダ名</strong></th>\n      <th style=\"padding: 10px\"><strong>説明</strong></th>\n    </tr>\n    <tr><td style=\"padding: 10px\">X-RateLimit-Limit</td><td style=\"padding: 10px\">1時間の使用回数の上限</td></tr>\n    <tr><td style=\"padding: 10px\">X-RateLimit-Remaining</td><td style=\"padding: 10px\">1時間の残り使用回数</td></tr>\n    <tr><td style=\"padding: 10px\">X-RateLimit-Reset</td><td style=\"padding: 10px\">1時間の使用回数がリセットされる時刻</td></tr>\n    <tr><td style=\"padding: 10px\">X-Ratelimit-Limit-Minute</td><td style=\"padding: 10px\">1分間の使用回数の上限</td></tr>\n    <tr><td style=\"padding: 10px\">X-Ratelimit-Remaining-Minute</td><td style=\"padding: 10px\">1分間の残り使用回数</td></tr>\n    <tr><td style=\"padding: 10px\">X-Ratelimit-Reset-Minute</td><td style=\"padding: 10px\">1分間の使用回数がリセットされる時刻</td></tr>\n    <tr><td style=\"padding: 10px\">X-RateLimit-Limit-Day</td><td style=\"padding: 10px\">1日間の使用回数の上限</td></tr>\n    <tr><td style=\"padding: 10px\">X-RateLimit-Remaining-Day</td><td style=\"padding: 10px\">1日間の残り使用回数</td></tr>\n    <tr><td style=\"padding: 10px\">X-Ratelimit-Reset-Day</td><td style=\"padding: 10px\">1日間の使用回数がリセットされる時刻</td></tr>\n  </tbody>\n</table>\n\n<p>上記に加え、freeeは一定期間に過度のアクセスを検知した場合、APIアクセスをコントロールする場合があります。<br> その際のhttp status codeは403となります。制限がかかってから10分程度が過ぎると再度使用することができるようになります。</p>\n\n</br>\n\n<h3 id=\"accounting_master_items\">会計マスタ項目</h3>\n\n<p>freee請求書APIのリクエストパラメータに、会計マスタ項目（例：<a href=\"https://developer.freee.co.jp/reference/iv/reference#operations-tag-Invoices\">POST/invoices請求書の作成</a> 取引先ID）があります。会計マスタ項目の詳細は<a href=\"https://developer.freee.co.jp/guideline/master-guideline\">会計マスタガイドラインを参照ください</a>。</p>\n\n<p>会計のマスタ項目はfreee会計APIのエンドポイントにて取得可能です（例：<a href=\"https://developer.freee.co.jp/reference/accounting/reference#operations-tag-Partners\">Partners 取引先</a>）。freee会計APIのエンドポイントの詳細は<a href=\"https://developer.freee.co.jp/reference/accounting/reference\">会計APIリファレンスを参照ください</a>。</p>\n\n</br>\n",
+    "license": {
+      "name": "© 2023 freee K.K."
+    },
+    "title": "freee請求書 API",
+    "version": "v1"
+  },
+  "servers": [
+    {
+      "url": "https://api.freee.co.jp/iv"
+    }
+  ],
+  "security": [
+    {
+      "oauth2": [
+        "write",
+        "read"
+      ]
+    }
+  ],
+  "tags": [
+    {
+      "description": "請求書",
+      "name": "Invoices"
+    },
+    {
+      "description": "見積書",
+      "name": "Quotations"
+    },
+    {
+      "description": "納品書",
+      "name": "DeliverySlips"
+    }
+  ],
+  "paths": {
+    "/invoices": {
+      "get": {
+        "description": "請求書の一覧を返します。",
+        "operationId": "invoices/index",
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "example": 1,
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "請求書番号",
+            "example": "INV-0000000001",
+            "in": "query",
+            "name": "invoice_number",
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "in": "query",
+            "name": "subject",
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "取引先ID（半角数字のidを半角カンマ区切りスペースなしで指定してください。最大3件まで指定できます。）",
+            "example": 12,
+            "in": "query",
+            "name": "partner_ids",
+            "schema": {
+              "maxLength": 255,
+              "type": "string"
+            }
+          },
+          {
+            "description": "入金ステータス（unsettled: 入金待ち, settled: 入金済み）",
+            "example": "settled",
+            "in": "query",
+            "name": "payment_status",
+            "schema": {
+              "enum": [
+                "settled",
+                "unsettled"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "取引ステータス（registered: 登録済み、 unregistered: 登録待ち）",
+            "example": "registered",
+            "in": "query",
+            "name": "deal_status",
+            "schema": {
+              "enum": [
+                "registered",
+                "unregistered"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "送付ステータス（sent: 送付済み、 unsent: 送付待ち）",
+            "example": "sent",
+            "in": "query",
+            "name": "sending_status",
+            "schema": {
+              "enum": [
+                "sent",
+                "unsent"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "取消済み（canceled: 該当する、 uncanceled: 該当しない）",
+            "example": "canceled",
+            "in": "query",
+            "name": "cancel_status",
+            "schema": {
+              "enum": [
+                "canceled",
+                "uncanceled"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "請求日の開始日",
+            "example": "2023-04-01",
+            "in": "query",
+            "name": "start_billing_date",
+            "schema": {
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "請求日の終了日",
+            "example": "2023-04-01",
+            "in": "query",
+            "name": "end_billing_date",
+            "schema": {
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "入金期日の開始日",
+            "example": "2023-04-01",
+            "in": "query",
+            "name": "start_payment_date",
+            "schema": {
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "入金期日の終了日",
+            "example": "2023-04-01",
+            "in": "query",
+            "name": "end_payment_date",
+            "schema": {
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "取得レコードの件数 (デフォルト: 20, 最小: 1, 最大: 100)",
+            "example": 20,
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "example": 0,
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceIndexResponse"
+                }
+              }
+            },
+            "description": "successful operation"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "請求書一覧の取得\n",
+        "tags": [
+          "Invoices"
+        ]
+      },
+      "post": {
+        "description": "\n請求書の作成をします。\n\nissue_date, account_item_id, tax_code, item_id, section_id, tag_ids, segment_1_tag_id, segment_2_tag_id, segment_3_tag_id は、取引登録の下書き保存で利用されます。\n\ntag_idsは10個まで設定可能です。",
+        "operationId": "invoices/create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvoiceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceResponse"
+                }
+              }
+            },
+            "description": "successful operation\n"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "請求書の作成\n",
+        "tags": [
+          "Invoices"
+        ]
+      }
+    },
+    "/invoices/{id}": {
+      "get": {
+        "description": "指定されたIDの請求書を返します。",
+        "operationId": "invoices/show",
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "example": 1,
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "請求書ID",
+            "example": 1,
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceShowResponse"
+                }
+              }
+            },
+            "description": "successful operation\n"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "請求書の取得\n",
+        "tags": [
+          "Invoices"
+        ]
+      },
+      "put": {
+        "description": "\n請求書の更新をします。\n\nissue_date, account_item_id, tax_code, item_id, section_id, tag_ids, segment_1_tag_id, segment_2_tag_id, segment_3_tag_id は、取引登録の下書き保存で利用されます。\n\ntag_idsは10個まで設定可能です。",
+        "operationId": "invoices/update",
+        "parameters": [
+          {
+            "description": "請求書ID",
+            "example": 1,
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvoiceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceResponse"
+                }
+              }
+            },
+            "description": "successful operation\n"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "請求書の更新\n",
+        "tags": [
+          "Invoices"
+        ]
+      }
+    },
+    "/invoices/templates": {
+      "get": {
+        "description": "使用可能な請求書の帳票テンプレート一覧を返します。",
+        "operationId": "invoices/templates/index",
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "example": 1,
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateIndexResponse"
+                }
+              }
+            },
+            "description": "successful operation"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "使用可能な請求書の帳票テンプレート一覧の取得\n",
+        "tags": [
+          "Invoices"
+        ]
+      }
+    },
+    "/quotations": {
+      "get": {
+        "description": "見積書の一覧を返します。",
+        "operationId": "quotations/index",
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "example": 1,
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "見積書番号",
+            "example": "Q-0000000001",
+            "in": "query",
+            "name": "quotation_number",
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "in": "query",
+            "name": "subject",
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "取引先ID（半角数字のidを半角カンマ区切りスペースなしで指定してください。最大3件まで指定できます。）",
+            "example": 12,
+            "in": "query",
+            "name": "partner_ids",
+            "schema": {
+              "maxLength": 255,
+              "type": "string"
+            }
+          },
+          {
+            "description": "送付ステータス（sent: 送付済み、 unsent: 送付待ち）",
+            "example": "sent",
+            "in": "query",
+            "name": "sending_status",
+            "schema": {
+              "enum": [
+                "sent",
+                "unsent"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "取消済み（canceled: 該当する、 uncanceled: 該当しない）",
+            "example": "canceled",
+            "in": "query",
+            "name": "cancel_status",
+            "schema": {
+              "enum": [
+                "canceled",
+                "uncanceled"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "見積日の開始日",
+            "example": "2023-04-01",
+            "in": "query",
+            "name": "start_quotation_date",
+            "schema": {
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "見積日の終了日",
+            "example": "2023-04-01",
+            "in": "query",
+            "name": "end_quotation_date",
+            "schema": {
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "有効期限の開始日",
+            "example": "2023-04-01",
+            "in": "query",
+            "name": "start_expiration_date",
+            "schema": {
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "有効期限の終了日",
+            "example": "2023-04-01",
+            "in": "query",
+            "name": "end_expiration_date",
+            "schema": {
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "取得レコードの件数 (デフォルト: 20, 最小: 1, 最大: 100)",
+            "example": 20,
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "example": 0,
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuotationIndexResponse"
+                }
+              }
+            },
+            "description": "successful operation"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "見積書一覧の取得\n",
+        "tags": [
+          "Quotations"
+        ]
+      },
+      "post": {
+        "description": "\n見積書の作成をします。",
+        "operationId": "quotations/create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QuotationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuotationResponse"
+                }
+              }
+            },
+            "description": "successful operation\n"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "見積書の作成\n",
+        "tags": [
+          "Quotations"
+        ]
+      }
+    },
+    "/quotations/{id}": {
+      "get": {
+        "description": "指定されたIDの見積書を返します。",
+        "operationId": "quotations/show",
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "example": 1,
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "見積書ID",
+            "example": 1,
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuotationShowResponse"
+                }
+              }
+            },
+            "description": "successful operation"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "見積書の取得\n",
+        "tags": [
+          "Quotations"
+        ]
+      },
+      "put": {
+        "description": "\n見積書の更新をします。",
+        "operationId": "quotations/update",
+        "parameters": [
+          {
+            "description": "見積書ID",
+            "example": 1,
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QuotationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuotationResponse"
+                }
+              }
+            },
+            "description": "successful operation\n"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "見積書の更新\n",
+        "tags": [
+          "Quotations"
+        ]
+      }
+    },
+    "/quotations/templates": {
+      "get": {
+        "description": "使用可能な見積書の帳票テンプレート一覧を返します。",
+        "operationId": "quotations/templates/index",
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "example": 1,
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateIndexResponse"
+                }
+              }
+            },
+            "description": "successful operation"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "使用可能な見積書の帳票テンプレート一覧の取得\n",
+        "tags": [
+          "Quotations"
+        ]
+      }
+    },
+    "/delivery_slips": {
+      "get": {
+        "description": "納品書の一覧を返します。",
+        "operationId": "delivery_slips/index",
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "example": 1,
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "納品書番号",
+            "example": "DEL-0000000001",
+            "in": "query",
+            "name": "delivery_slip_number",
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "in": "query",
+            "name": "subject",
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "取引先ID（半角数字のidを半角カンマ区切りスペースなしで指定してください。最大3件まで指定できます。）",
+            "example": 12,
+            "in": "query",
+            "name": "partner_ids",
+            "schema": {
+              "maxLength": 255,
+              "type": "string"
+            }
+          },
+          {
+            "description": "入金ステータス（unsettled: 入金待ち, settled: 入金済み）",
+            "example": "settled",
+            "in": "query",
+            "name": "payment_status",
+            "schema": {
+              "enum": [
+                "settled",
+                "unsettled"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "取引ステータス（registered: 登録済み、 unregistered: 登録待ち）",
+            "example": "registered",
+            "in": "query",
+            "name": "deal_status",
+            "schema": {
+              "enum": [
+                "registered",
+                "unregistered"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "送付ステータス（sent: 送付済み、 unsent: 送付待ち）",
+            "example": "sent",
+            "in": "query",
+            "name": "sending_status",
+            "schema": {
+              "enum": [
+                "sent",
+                "unsent"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "取消済み（canceled: 該当する、 uncanceled: 該当しない）",
+            "example": "canceled",
+            "in": "query",
+            "name": "cancel_status",
+            "schema": {
+              "enum": [
+                "canceled",
+                "uncanceled"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "納品日の開始日",
+            "example": "2023-04-01",
+            "in": "query",
+            "name": "start_delivery_slip_date",
+            "schema": {
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "納品日の開始日",
+            "example": "2023-04-01",
+            "in": "query",
+            "name": "end_delivery_slip_date",
+            "schema": {
+              "format": "date",
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "取得レコードの件数 (デフォルト: 20, 最小: 1, 最大: 100)",
+            "example": 20,
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "取得レコードのオフセット (デフォルト: 0)",
+            "example": 0,
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeliverySlipIndexResponse"
+                }
+              }
+            },
+            "description": "successful operation"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "納品書一覧の取得\n",
+        "tags": [
+          "DeliverySlips"
+        ]
+      },
+      "post": {
+        "description": "\n納品書の作成をします。\n\nissue_date, account_item_id, tax_code, item_id, section_id, tag_ids, segment_1_tag_id, segment_2_tag_id, segment_3_tag_id は、取引登録の下書き保存で利用されます。\n\ntag_idsは10個まで設定可能です。",
+        "operationId": "delivery_slips/create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeliverySlipRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeliverySlipResponse"
+                }
+              }
+            },
+            "description": "successful operation\n"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "納品書の作成\n",
+        "tags": [
+          "DeliverySlips"
+        ]
+      }
+    },
+    "/delivery_slips/{id}": {
+      "get": {
+        "description": "指定されたIDの納品書を返します。",
+        "operationId": "delivery_slips/show",
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "example": 1,
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "納品書ID",
+            "example": 1,
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeliverySlipShowResponse"
+                }
+              }
+            },
+            "description": "successful operation\n"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "納品書の取得\n",
+        "tags": [
+          "DeliverySlips"
+        ]
+      },
+      "put": {
+        "description": "\n納品書の更新をします。\n\nissue_date, account_item_id, tax_code, item_id, section_id, tag_ids, segment_1_tag_id, segment_2_tag_id, segment_3_tag_id は、取引登録の下書き保存で利用されます。\n\ntag_idsは10個まで設定可能です。",
+        "operationId": "delivery_slips/update",
+        "parameters": [
+          {
+            "description": "納品書ID",
+            "example": 1,
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeliverySlipRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeliverySlipResponse"
+                }
+              }
+            },
+            "description": "successful operation\n"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/notfoundError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "納品書の更新\n",
+        "tags": [
+          "DeliverySlips"
+        ]
+      }
+    },
+    "/delivery_slips/templates": {
+      "get": {
+        "description": "使用可能な納品書の帳票テンプレート一覧を返します。",
+        "operationId": "delivery_slips/templates/index",
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "example": 1,
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "maximum": 9223372036854775807,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateIndexResponse"
+                }
+              }
+            },
+            "description": "successful operation"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/badRequest"
+                }
+              }
+            },
+            "description": ""
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/unauthorizedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/forbiddenError"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/accessDeniedError"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/internalServerError"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "summary": "使用可能な納品書の帳票テンプレート一覧の取得\n",
+        "tags": [
+          "DeliverySlips"
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "InvoiceIndexResponse": {
+        "properties": {
+          "invoices": {
+            "items": {
+              "$ref": "#/components/schemas/InvoiceIndexResponse_invoices"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "invoices"
+        ],
+        "type": "object"
+      },
+      "badRequest": {
+        "properties": {
+          "status_code": {
+            "example": 400,
+            "type": "integer"
+          },
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/badRequest_errors"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "unauthorizedError": {
+        "properties": {
+          "message": {
+            "example": "ログインをして下さい",
+            "type": "string"
+          },
+          "messages": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "forbiddenError": {
+        "properties": {
+          "status_code": {
+            "example": 403,
+            "type": "integer"
+          },
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/forbiddenError_errors"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "accessDeniedError": {
+        "properties": {
+          "error": {
+            "example": "access_denied",
+            "type": "string"
+          },
+          "message": {
+            "example": "アクセスする権限がありません",
+            "type": "string"
+          },
+          "code": {
+            "example": "expired_access_token",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "internalServerError": {
+        "properties": {
+          "status_code": {
+            "example": 500,
+            "type": "integer"
+          },
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/internalServerError_errors"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "InvoiceRequest": {
+        "properties": {
+          "company_id": {
+            "description": "事業所ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "template_id": {
+            "description": "帳票テンプレートID（指定しない場合、事業所の既定のテンプレートが指定されます。）",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "invoice_number": {
+            "description": "請求書番号<br>\n- 採番の設定が、[自動採番する]の場合、指定できません。\n- 採番の設定が、[自動採番する]以外の場合、必須になります。\n",
+            "example": "INV-0000000001",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "branch_no": {
+            "description": "枝番",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "billing_date": {
+            "description": "請求日",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "issue_date": {
+            "description": "発生日（取引登録の下書き保存で利用されます。）\n- 入力がない場合、請求日が補完されます。\n",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "payment_date": {
+            "description": "期日\n- payment_typeがtransferの場合、入金期日に該当します。\n- payment_typeがdirect_debitの場合、振替日に該当します。\n",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "payment_type": {
+            "default": "transfer",
+            "description": "入金方法 (振込: transfer, 振替: direct_debit)",
+            "enum": [
+              "transfer",
+              "direct_debit"
+            ],
+            "example": "transfer",
+            "type": "string"
+          },
+          "subject": {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "tax_entry_method": {
+            "description": "消費税の内税・外税区分（in: 税込表示（内税）、out: 税別表示（外税））",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "type": "string"
+          },
+          "tax_fraction": {
+            "description": "消費税端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "omit",
+            "type": "string"
+          },
+          "line_amount_fraction": {
+            "description": "金額端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "round_up",
+            "nullable": true,
+            "type": "string"
+          },
+          "withholding_tax_entry_method": {
+            "description": "源泉徴収の計算方法（in: 税込み価格で計算、out: 税別価格で計算）",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "type": "string"
+          },
+          "include_amount_brought_forward": {
+            "default": false,
+            "description": "繰越金額を含めるかどうか（true: 含める、false: 含めない）<br>\n- 含める場合は、amount_brought_forwardに繰越金額を指定することができます。\n- 含める場合でamount_brought_forwardの指定がない場合は、 帳票に指定されたpartner_id, partner_codeに紐づく未決済残高が繰越金額として利用されます。\n",
+            "example": false,
+            "type": "boolean"
+          },
+          "amount_brought_forward": {
+            "description": "繰越金額<br>\ninclude_amount_brought_forward に true を指定する場合のみ、指定できます。\n",
+            "example": 10000,
+            "format": "int64",
+            "maximum": 999999999999,
+            "minimum": -999999999999,
+            "type": "integer"
+          },
+          "invoice_note": {
+            "description": "備考",
+            "example": "備考\n- 入力がない場合、freee請求書Webで設定した、帳票種別ごとの既定のテンプレートの内容が適用されます。\n",
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string"
+          },
+          "memo": {
+            "description": "社内メモ",
+            "example": "社内メモ",
+            "maxLength": 2000,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_id": {
+            "description": "取引先ID<br>\n取引先IDと取引先コードはどちらか一方を必ず指定してください。<br>\n<a href='https://support.freee.co.jp/hc/ja/articles/12515437008409-取引先を登録する#:~:text=確認ください。-,取引先役割,-種別' target='_blank'>取引先役割に関してはヘルプページを御覧ください。</a>\n",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "partner_code": {
+            "description": "取引先コード<br>\n取引先コードと取引先IDはどちらか一方を必ず指定してください。<br>\n<a href='https://support.freee.co.jp/hc/ja/articles/12515437008409-取引先を登録する#:~:text=確認ください。-,取引先役割,-種別' target='_blank'>取引先役割に関してはヘルプページを御覧ください。</a>\n",
+            "example": "code001",
+            "type": "string"
+          },
+          "partner_title": {
+            "description": "敬称（御中、様、(空白)の3つから選択）\n- [非推奨]全角カッコの（空白）は削除予定です。\n- 全角カッコの（空白）を指定した場合、はレスポンスは、半角カッコの(空白)になります。\n",
+            "enum": [
+              "御中",
+              "様",
+              "(空白)",
+              "（空白）"
+            ],
+            "example": "御中",
+            "type": "string"
+          },
+          "partner_address_zipcode": {
+            "description": "郵便番号\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく郵便番号が利用されます。\n",
+            "example": "1410032",
+            "maxLength": 10,
+            "minLength": 1,
+            "pattern": "^[0-9]{3}[\\-]?[0-9]{4}$",
+            "type": "string"
+          },
+          "partner_address_prefecture_code": {
+            "description": "都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄）\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく都道府県コードが利用されます。\n",
+            "example": 4,
+            "maximum": 46,
+            "minimum": -1,
+            "type": "integer"
+          },
+          "partner_address_street_name1": {
+            "description": "取引先 市区町村・番地\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先 市区町村・番地が利用されます。\n",
+            "example": "東京都ＸＸ区ＹＹ１−１−１",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_address_street_name2": {
+            "description": "取引先 建物名・部屋番号など\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先 建物名・部屋番号などが利用されます。\n",
+            "example": "ビル 1F",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_contact_department": {
+            "description": "取引先部署\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先部署が利用されます。\n",
+            "example": "営業部",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_contact_email_cc": {
+            "description": "取引先担当者メールアドレス（CC）\n- 入力がない場合、メールテンプレートに指定されたCCが利用されます。\n- カンマ区切りで複数メールアドレスに送付可能です。\n",
+            "example": "tantosha1@example.com,tantosha2@example.com",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_contact_email_to": {
+            "description": "取引先担当者メールアドレス（TO）\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先担当者メールアドレスが利用されます。\n- カンマ区切りで複数メールアドレスに送付可能です。\n",
+            "example": "tantosha1@example.com,tantosha2@example.com",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_contact_name": {
+            "description": "取引先担当者名\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先担当者名が利用されます。\n",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_display_name": {
+            "description": "取引先宛名\n- 帳票の宛名に利用されます。\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先名称が利用されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_sending_method": {
+            "description": "取引先への送付方法\n- 一括送付時に取引先マスタに登録された送付方法以外を利用したい場合に指定します。\n- 入力がない場合、取引先マスタに登録された送付方法で一括送付を行います。\n",
+            "enum": [
+              "email",
+              "posting",
+              "email_and_posting"
+            ],
+            "example": "email",
+            "nullable": true,
+            "type": "string"
+          },
+          "partner_bank_account": {
+            "description": "取引先口座\n- payment_typeがdirect_debitの場合に指定可能です。\n- 入力がない場合またはpayment_typeがtransferの場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先口座が利用されます。\n",
+            "example": "freee銀行 freee支店 普通 1234567 freee",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_contact_name": {
+            "description": "自社担当者(デフォルトは表示ユーザー名が補完されます)",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_name": {
+            "description": "自社名を上書きする場合に指定します。",
+            "example": "freee株式会社",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_description": {
+            "description": "自社説明を上書きする場合に指定します。",
+            "example": "freee株式会社",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "bank_account_to_transfer": {
+            "description": "振込先を上書きする場合に指定します。",
+            "example": "freee銀行 freee支店 普通 1234567 freee",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "lines": {
+            "description": "請求書の明細行",
+            "items": {
+              "$ref": "#/components/schemas/InvoiceRequest_lines"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "billing_date",
+          "company_id",
+          "lines",
+          "partner_title",
+          "tax_entry_method",
+          "tax_fraction",
+          "withholding_tax_entry_method"
+        ],
+        "type": "object"
+      },
+      "InvoiceResponse": {
+        "properties": {
+          "invoice": {
+            "$ref": "#/components/schemas/InvoiceResponse_invoice"
+          }
+        },
+        "required": [
+          "invoice"
+        ],
+        "type": "object"
+      },
+      "InvoiceShowResponse": {
+        "properties": {
+          "invoice": {
+            "$ref": "#/components/schemas/InvoiceShowResponse_invoice"
+          }
+        },
+        "required": [
+          "invoice"
+        ],
+        "type": "object"
+      },
+      "notfoundError": {
+        "properties": {
+          "status_code": {
+            "example": 404,
+            "type": "integer"
+          },
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/notfoundError_errors"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "TemplateIndexResponse": {
+        "properties": {
+          "templates": {
+            "items": {
+              "$ref": "#/components/schemas/TemplateIndexResponse_templates"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "templates"
+        ],
+        "type": "object"
+      },
+      "QuotationIndexResponse": {
+        "properties": {
+          "quotations": {
+            "items": {
+              "$ref": "#/components/schemas/QuotationIndexResponse_quotations"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "quotations"
+        ],
+        "type": "object"
+      },
+      "QuotationRequest": {
+        "properties": {
+          "company_id": {
+            "description": "事業所ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "template_id": {
+            "description": "帳票テンプレートID（指定しない場合、事業所の既定のテンプレートが指定されます。）",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "quotation_number": {
+            "description": "見積書番号<br>\n- 採番の設定が、[自動採番する]の場合、指定できません。\n- 採番の設定が、[自動採番する]以外の場合、必須になります。\n",
+            "example": "Q-0000000001",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "branch_no": {
+            "description": "枝番",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "quotation_date": {
+            "description": "見積日",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "expiration_date": {
+            "description": "有効期限",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "delivery_deadline": {
+            "description": "納品期限",
+            "example": "2023年12月31日",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "delivery_location": {
+            "description": "納品場所",
+            "example": "納品場所",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "subject": {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "tax_entry_method": {
+            "description": "消費税の内税・外税区分（in: 税込表示（内税）、out: 税別表示（外税））",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "type": "string"
+          },
+          "tax_fraction": {
+            "description": "消費税端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "omit",
+            "type": "string"
+          },
+          "line_amount_fraction": {
+            "description": "金額端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "round_up",
+            "nullable": true,
+            "type": "string"
+          },
+          "withholding_tax_entry_method": {
+            "description": "源泉徴収の計算方法（in: 税込み価格で計算、out: 税別価格で計算）",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "type": "string"
+          },
+          "quotation_note": {
+            "description": "備考",
+            "example": "備考\n- 入力がない場合、freee請求書Webで設定した、帳票種別ごとの既定のテンプレートの内容が適用されます。\n",
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string"
+          },
+          "memo": {
+            "description": "社内メモ",
+            "example": "社内メモ",
+            "maxLength": 2000,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_id": {
+            "description": "取引先ID<br>\n取引先IDと取引先コードはどちらか一方を必ず指定してください。<br>\n<a href='https://support.freee.co.jp/hc/ja/articles/12515437008409-取引先を登録する#:~:text=確認ください。-,取引先役割,-種別' target='_blank'>取引先役割に関してはヘルプページを御覧ください。</a>\n",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "partner_code": {
+            "description": "取引先コード<br>\n取引先コードと取引先IDはどちらか一方を必ず指定してください。<br>\n<a href='https://support.freee.co.jp/hc/ja/articles/12515437008409-取引先を登録する#:~:text=確認ください。-,取引先役割,-種別' target='_blank'>取引先役割に関してはヘルプページを御覧ください。</a>\n",
+            "example": "code001",
+            "type": "string"
+          },
+          "partner_title": {
+            "description": "敬称（御中、様、(空白)の3つから選択）\n- [非推奨]全角カッコの（空白）は削除予定です。\n- 全角カッコの（空白）を指定した場合、はレスポンスは、半角カッコの(空白)になります。\n",
+            "enum": [
+              "御中",
+              "様",
+              "(空白)",
+              "（空白）"
+            ],
+            "example": "御中",
+            "type": "string"
+          },
+          "partner_address_zipcode": {
+            "description": "郵便番号\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく郵便番号が利用されます。\n",
+            "example": "1410032",
+            "maxLength": 10,
+            "minLength": 1,
+            "pattern": "^[0-9]{3}[\\-]?[0-9]{4}$",
+            "type": "string"
+          },
+          "partner_address_prefecture_code": {
+            "description": "都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄）\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく都道府県コードが利用されます。\n",
+            "example": 4,
+            "maximum": 46,
+            "minimum": -1,
+            "type": "integer"
+          },
+          "partner_address_street_name1": {
+            "description": "取引先 市区町村・番地\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先 市区町村・番地が利用されます。\n",
+            "example": "東京都ＸＸ区ＹＹ１−１−１",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_address_street_name2": {
+            "description": "取引先 建物名・部屋番号など\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先 建物名・部屋番号などが利用されます。\n",
+            "example": "ビル 1F",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_contact_department": {
+            "description": "取引先部署\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先部署が利用されます。\n",
+            "example": "営業部",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_contact_email_cc": {
+            "description": "取引先担当者メールアドレス（CC）\n- 入力がない場合、メールテンプレートに指定されたCCが利用されます。\n- カンマ区切りで複数メールアドレスに送付可能です。\n",
+            "example": "tantosha1@example.com,tantosha2@example.com",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_contact_email_to": {
+            "description": "取引先担当者メールアドレス（TO）\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先担当者メールアドレスが利用されます。\n- カンマ区切りで複数メールアドレスに送付可能です。\n",
+            "example": "tantosha1@example.com,tantosha2@example.com",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_contact_name": {
+            "description": "取引先担当者名\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先担当者名が利用されます。\n",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_display_name": {
+            "description": "取引先宛名\n- 帳票の宛名に利用されます。\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先名称が利用されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_sending_method": {
+            "description": "取引先への送付方法\n- 一括送付時に取引先マスタに登録された送付方法以外を利用したい場合に指定します。\n- 入力がない場合、取引先マスタに登録された送付方法で一括送付を行います。\n",
+            "enum": [
+              "email",
+              "posting",
+              "email_and_posting"
+            ],
+            "example": "email",
+            "nullable": true,
+            "type": "string"
+          },
+          "company_contact_name": {
+            "description": "自社担当者(デフォルトは操作者の表示ユーザー名が補完されます)",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_name": {
+            "description": "自社名を上書きする場合に指定します。",
+            "example": "freee株式会社",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_description": {
+            "description": "自社説明を上書きする場合に指定します。。",
+            "example": "freee株式会社",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "lines": {
+            "description": "請求書の明細行",
+            "items": {
+              "$ref": "#/components/schemas/QuotationRequest_lines"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "company_id",
+          "lines",
+          "partner_title",
+          "quotation_date",
+          "tax_entry_method",
+          "tax_fraction",
+          "withholding_tax_entry_method"
+        ],
+        "type": "object"
+      },
+      "QuotationResponse": {
+        "properties": {
+          "quotation": {
+            "$ref": "#/components/schemas/QuotationResponse_quotation"
+          }
+        },
+        "required": [
+          "quotation"
+        ],
+        "type": "object"
+      },
+      "QuotationShowResponse": {
+        "properties": {
+          "quotation": {
+            "$ref": "#/components/schemas/QuotationShowResponse_quotation"
+          }
+        },
+        "required": [
+          "quotation"
+        ],
+        "type": "object"
+      },
+      "DeliverySlipIndexResponse": {
+        "properties": {
+          "delivery_slips": {
+            "items": {
+              "$ref": "#/components/schemas/DeliverySlipIndexResponse_delivery_slips"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "delivery_slips"
+        ],
+        "type": "object"
+      },
+      "DeliverySlipRequest": {
+        "properties": {
+          "company_id": {
+            "description": "事業所ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "template_id": {
+            "description": "帳票テンプレートID（指定しない場合、事業所の既定のテンプレートが指定されます。）",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "delivery_slip_number": {
+            "description": "納品書番号<br>\n- 採番の設定が、[自動採番する]の場合、指定できません。\n- 採番の設定が、[自動採番する]以外の場合、必須になります。\n",
+            "example": "DEL-0000000001",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "branch_no": {
+            "description": "枝番",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "delivery_slip_date": {
+            "description": "納品日",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "issue_date": {
+            "description": "発生日（取引登録の下書き保存で利用されます。）\n- 入力がない場合、納品日が補完されます。\n",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "subject": {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "tax_entry_method": {
+            "description": "消費税の内税・外税区分（in: 税込表示（内税）、out: 税別表示（外税））",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "type": "string"
+          },
+          "tax_fraction": {
+            "description": "消費税端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "omit",
+            "type": "string"
+          },
+          "line_amount_fraction": {
+            "description": "金額端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "round_up",
+            "nullable": true,
+            "type": "string"
+          },
+          "withholding_tax_entry_method": {
+            "description": "源泉徴収の計算方法（in: 税込み価格で計算、out: 税別価格で計算）",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "type": "string"
+          },
+          "delivery_slip_note": {
+            "description": "備考",
+            "example": "備考\n- 入力がない場合、freee請求書Webで設定した、帳票種別ごとの既定のテンプレートの内容が適用されます。\n",
+            "maxLength": 4000,
+            "minLength": 0,
+            "type": "string"
+          },
+          "memo": {
+            "description": "社内メモ",
+            "example": "社内メモ",
+            "maxLength": 2000,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_id": {
+            "description": "取引先ID<br>\n取引先IDと取引先コードはどちらか一方を必ず指定してください。<br>\n<a href='https://support.freee.co.jp/hc/ja/articles/12515437008409-取引先を登録する#:~:text=確認ください。-,取引先役割,-種別' target='_blank'>取引先役割に関してはヘルプページを御覧ください。</a>\n",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "partner_code": {
+            "description": "取引先コード<br>\n取引先コードと取引先IDはどちらか一方を必ず指定してください。<br>\n<a href='https://support.freee.co.jp/hc/ja/articles/12515437008409-取引先を登録する#:~:text=確認ください。-,取引先役割,-種別' target='_blank'>取引先役割に関してはヘルプページを御覧ください。</a>\n",
+            "example": "code001",
+            "type": "string"
+          },
+          "partner_title": {
+            "description": "敬称（御中、様、(空白)の3つから選択）\n- [非推奨]全角カッコの（空白）は削除予定です。\n- 全角カッコの（空白）を指定した場合、はレスポンスは、半角カッコの(空白)になります。\n",
+            "enum": [
+              "御中",
+              "様",
+              "(空白)",
+              "（空白）"
+            ],
+            "example": "御中",
+            "type": "string"
+          },
+          "partner_address_zipcode": {
+            "description": "郵便番号\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく郵便番号が利用されます。\n",
+            "example": "1410032",
+            "maxLength": 10,
+            "minLength": 1,
+            "pattern": "^[0-9]{3}[\\-]?[0-9]{4}$",
+            "type": "string"
+          },
+          "partner_address_prefecture_code": {
+            "description": "都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄）\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく都道府県コードが利用されます。\n",
+            "example": 4,
+            "maximum": 46,
+            "minimum": -1,
+            "type": "integer"
+          },
+          "partner_address_street_name1": {
+            "description": "取引先 市区町村・番地\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先 市区町村・番地が利用されます。\n",
+            "example": "東京都ＸＸ区ＹＹ１−１−１",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_address_street_name2": {
+            "description": "取引先 建物名・部屋番号など\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先 建物名・部屋番号などが利用されます。\n",
+            "example": "ビル 1F",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_contact_department": {
+            "description": "取引先部署\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先部署が利用されます。\n",
+            "example": "営業部",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_contact_email_cc": {
+            "description": "取引先担当者メールアドレス（CC）\n- 入力がない場合、メールテンプレートに指定されたCCが利用されます。\n- カンマ区切りで複数メールアドレスに送付可能です。\n",
+            "example": "tantosha1@example.com,tantosha2@example.com",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_contact_email_to": {
+            "description": "取引先担当者メールアドレス（TO）\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先担当者メールアドレスが利用されます。\n- カンマ区切りで複数メールアドレスに送付可能です。\n",
+            "example": "tantosha1@example.com,tantosha2@example.com",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_contact_name": {
+            "description": "取引先担当者名\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先担当者名が利用されます。\n",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "partner_display_name": {
+            "description": "取引先宛名\n- 帳票の宛名に利用されます。\n- 入力がない場合、帳票に指定されたpartner_id, partner_codeに紐づく取引先名称が利用されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_sending_method": {
+            "description": "取引先への送付方法",
+            "enum": [
+              "email",
+              "posting",
+              "email_and_posting"
+            ],
+            "example": "email",
+            "nullable": true,
+            "type": "string"
+          },
+          "company_contact_name": {
+            "description": "自社担当者(デフォルトは表示ユーザー名が補完されます)",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_name": {
+            "description": "自社名を上書きする場合に指定します。",
+            "example": "freee K.K.",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_description": {
+            "description": "自社説明を上書きする場合に指定します。",
+            "example": "freee K.K.",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "lines": {
+            "description": "納品書の明細行",
+            "items": {
+              "$ref": "#/components/schemas/DeliverySlipRequest_lines"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "company_id",
+          "delivery_slip_date",
+          "lines",
+          "partner_title",
+          "tax_entry_method",
+          "tax_fraction",
+          "withholding_tax_entry_method"
+        ],
+        "type": "object"
+      },
+      "DeliverySlipResponse": {
+        "properties": {
+          "delivery_slip": {
+            "$ref": "#/components/schemas/DeliverySlipResponse_delivery_slip"
+          }
+        },
+        "required": [
+          "delivery_slip"
+        ],
+        "type": "object"
+      },
+      "DeliverySlipShowResponse": {
+        "properties": {
+          "delivery_slip": {
+            "$ref": "#/components/schemas/DeliverySlipShowResponse_delivery_slip"
+          }
+        },
+        "required": [
+          "delivery_slip"
+        ],
+        "type": "object"
+      },
+      "InvoiceIndexResponse_invoices": {
+        "properties": {
+          "id": {
+            "description": "請求書ID",
+            "example": 101,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "company_id": {
+            "description": "事業所ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "invoice_number": {
+            "description": "請求書番号",
+            "example": "INV-0000000001",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "subject": {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "template_id": {
+            "description": "帳票テンプレートID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "billing_date": {
+            "description": "請求日",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "issue_date": {
+            "description": "発生日",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "payment_date": {
+            "description": "期日\n- payment_typeがtransferの場合、入金期日に該当します。\n- payment_typeがdirect_debitの場合、振替日に該当します。\n",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "payment_type": {
+            "description": "入金方法 (振込: transfer, 振替: direct_debit)",
+            "enum": [
+              "transfer",
+              "direct_debit"
+            ],
+            "example": "transfer",
+            "type": "string"
+          },
+          "memo": {
+            "description": "社内メモ",
+            "example": "社内メモ",
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "sending_status": {
+            "description": "送付ステータス（sent: 送付済み、 unsent: 送付待ち）",
+            "enum": [
+              "sent",
+              "unsent"
+            ],
+            "example": "sent",
+            "type": "string"
+          },
+          "payment_status": {
+            "description": "入金ステータス（unsettled: 入金待ち, settled: 入金済み）",
+            "enum": [
+              "settled",
+              "unsettled"
+            ],
+            "example": "settled",
+            "type": "string"
+          },
+          "cancel_status": {
+            "description": "取消済み（canceled: 該当する、 uncanceled: 該当しない）",
+            "enum": [
+              "canceled",
+              "uncanceled"
+            ],
+            "example": "canceled",
+            "type": "string"
+          },
+          "deal_status": {
+            "description": "取引ステータス（registered: 登録済み、 unregistered: 登録待ち）",
+            "enum": [
+              "registered",
+              "unregistered"
+            ],
+            "example": "registered",
+            "type": "string"
+          },
+          "deal_id": {
+            "description": "取引ID （deal_statusがunregisteredの場合、nullになります。）",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "total_amount": {
+            "description": "合計金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "amount_withholding_tax": {
+            "description": "源泉所得税",
+            "example": 1000,
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax": {
+            "description": "税込金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "amount_excluding_tax": {
+            "description": "小計（税別）",
+            "example": 10000,
+            "type": "number"
+          },
+          "amount_tax": {
+            "description": "消費税額",
+            "example": 1000,
+            "type": "number"
+          },
+          "amount_brought_forward": {
+            "description": "繰越金額",
+            "example": 10000,
+            "format": "double",
+            "maximum": 999999999999,
+            "minimum": -999999999999,
+            "nullable": true,
+            "type": "number"
+          },
+          "partner_id": {
+            "description": "取引先ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "partner_code": {
+            "description": "取引先コード",
+            "example": "code001",
+            "nullable": true,
+            "type": "string"
+          },
+          "partner_name": {
+            "description": "取引先名\n- partner_nameに空文字が戻る場合は、対象レコードをweb画面から更新するか、freee請求書APIから更新すると解消されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_display_name": {
+            "description": "取引先宛名\n- 帳票の宛名に利用されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_contact_name": {
+            "description": "自社担当者 (デフォルト: 表示ユーザー名)\n",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "email_url_file_downloaded_at": {
+            "description": "URL共有で送付された送付先のメールのダウンロード時刻",
+            "example": "1994-10-06 12:00:00",
+            "format": "string",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "type": "string"
+          },
+          "email_url_file_downloaded_status": {
+            "description": "URL共有で送付された送付先のメールのダウンロードステータス",
+            "enum": [
+              "downloaded",
+              "undownloaded"
+            ],
+            "example": "downloaded",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount_brought_forward",
+          "amount_excluding_tax",
+          "amount_including_tax",
+          "amount_tax",
+          "billing_date",
+          "cancel_status",
+          "company_id",
+          "deal_status",
+          "id",
+          "invoice_number",
+          "memo",
+          "partner_id",
+          "payment_status",
+          "sending_status",
+          "subject",
+          "total_amount"
+        ],
+        "type": "object"
+      },
+      "badRequest_errors": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "messages": {
+            "items": {
+              "example": "リクエストの形式が不正です。",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "forbiddenError_errors": {
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "messages": {
+            "items": {
+              "example": "アクセス権限がありません。",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "internalServerError_errors": {
+        "properties": {
+          "type": {
+            "example": "internal_server_error",
+            "type": "string"
+          },
+          "messages": {
+            "items": {
+              "example": "エラーが発生しました。再試行しても解消しない場合は、サポートセンターまでご連絡ください。",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "InvoiceRequest_lines": {
+        "properties": {
+          "type": {
+            "default": "item",
+            "description": "明細の種類\n- item: 品目行\n  - tax_rate、quantityは必須になります。\n- text: テキスト行\n  - descriptionのみ入力可能です。\n- 入力がない場合、itemが利用されます。\n",
+            "enum": [
+              "item",
+              "text"
+            ],
+            "example": "item",
+            "type": "string"
+          },
+          "description": {
+            "description": "摘要（品名）",
+            "example": "切手代",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "sales_date": {
+            "description": "取引日",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "unit": {
+            "description": "明細の単位名",
+            "example": "個",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "quantity": {
+            "description": "明細の数量 (整数部は8桁まで、小数部は3桁まで)",
+            "example": 1,
+            "maximum": 99999999.999,
+            "minimum": -99999999.999,
+            "type": "number"
+          },
+          "unit_price": {
+            "description": "明細の単価 (整数部は13桁まで、小数部は3桁まで)",
+            "example": "1234567890123.123",
+            "pattern": "^\\-?[0-9]{0,13}(\\.[0-9]{1,3})?$",
+            "type": "string"
+          },
+          "tax_rate": {
+            "description": "税率（%）（帳票の税額計算に用います。）",
+            "enum": [
+              0,
+              8,
+              10
+            ],
+            "example": 8,
+            "type": "integer"
+          },
+          "reduced_tax_rate": {
+            "default": false,
+            "description": "軽減税率対象（true: 対象、 false: 対象外）trueはtax_rate:8の時のみ指定可能です。",
+            "example": false,
+            "type": "boolean"
+          },
+          "withholding": {
+            "description": "源泉徴収対象",
+            "example": true,
+            "type": "boolean"
+          },
+          "account_item_id": {
+            "description": "勘定科目ID（取引登録の下書き保存で利用されます。）",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "tax_code": {
+            "description": "税区分コード（取引登録の下書き保存で利用されます。）",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "item_id": {
+            "description": "品目ID（取引登録の下書き保存で利用されます。）",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "section_id": {
+            "description": "部門ID<br>\n- 取引登録の下書き保存で利用されます。\n- 親部門は利用できません。\n- グループ管理で制限された部門は利用できません。\n<br>\n<a href=\"https://support.freee.co.jp/hc/ja/articles/215225263\" target=\"_blank\">グループ管理の設定はヘルプページを御覧ください。</a>\n",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "tag_ids": {
+            "items": {
+              "description": "メモタグID（10個まで設定可能です。）（取引登録の下書き保存で利用されます。）",
+              "example": 1,
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "segment_1_tag_id": {
+            "description": "セグメント１ID<br>\n- 取引登録の下書き保存で利用されます。\n- freee会計法人向け プロフェッショナルプラン以上で利用可能です。\n<br>\n<a href=\"https://support.freee.co.jp/hc/ja/articles/360020679611\" target=\"_blank\">セグメント（分析用タグ）の設定はヘルプページを御覧ください。</a>\n",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "segment_2_tag_id": {
+            "description": "セグメント２ID<br>\n- 取引登録の下書き保存で利用されます。\n- freee会計法人向け エンタープライズプランで利用可能です。\n<br>\n<a href=\"https://support.freee.co.jp/hc/ja/articles/360020679611\" target=\"_blank\">セグメント（分析用タグ）の設定はヘルプページを御覧ください。</a>\n",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "segment_3_tag_id": {
+            "description": "セグメント３ID<br>\n- 取引登録の下書き保存で利用されます。\n- freee会計法人向け エンタープライズプランで利用可能です。\n<br>\n<a href=\"https://support.freee.co.jp/hc/ja/articles/360020679611\" target=\"_blank\">セグメント（分析用タグ）の設定はヘルプページを御覧ください。</a>\n",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "InvoiceResponse_invoice_template": {
+        "description": "帳票テンプレート情報（帳票テンプレート作成の際に設定できる項目です。）",
+        "properties": {
+          "title": {
+            "description": "請求書タイトル",
+            "example": "請求書",
+            "type": "string"
+          },
+          "invoice_registration_number": {
+            "description": "インボイス制度適格請求書発行事業者登録番号\n- 先頭T数字13桁の固定14桁の文字列\n<a target=\"_blank\" href=\"https://www.invoice-kohyo.nta.go.jp/index.html\">国税庁インボイス制度適格請求書発行事業者公表サイト</a>\n",
+            "example": "T1000000000001",
+            "type": "string"
+          },
+          "company_name": {
+            "description": "自社名",
+            "example": "freee株式会社",
+            "type": "string"
+          },
+          "company_description": {
+            "description": "自社情報",
+            "example": "〒141-0032　東京都品川区大崎1-2-2アートヴィレッジ大崎セントラルタワー 21階",
+            "type": "string"
+          },
+          "bank_account_to_transfer": {
+            "description": "振込先",
+            "example": "freee銀行 第一営業支店 1234567",
+            "type": "string"
+          },
+          "message": {
+            "description": "メッセージ",
+            "example": "メッセージ",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "InvoiceResponse_invoice_lines": {
+        "properties": {
+          "id": {
+            "description": "明細行ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "type": {
+            "description": "明細の種類\n- item: 品目行\n- text: テキスト行\n- textの時はsales_date、quantity、unit_price、tax_rate、amount_excluding_tax、account_item_id、tax_code、item_id、section_id、segment_1_tag_id、segment_2_tag_id、segment_3_tag_idはnullになります。\n",
+            "enum": [
+              "item",
+              "text"
+            ],
+            "example": "item",
+            "type": "string"
+          },
+          "description": {
+            "description": "摘要（品名）",
+            "example": "切手代",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "sales_date": {
+            "description": "取引日",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "unit": {
+            "description": "明細の単位名",
+            "example": "個",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "quantity": {
+            "description": "明細の数量 (整数部は8桁まで、小数部は3桁まで)",
+            "example": 1,
+            "maximum": 99999999.999,
+            "minimum": -99999999.999,
+            "nullable": true,
+            "type": "number"
+          },
+          "unit_price": {
+            "description": "明細の単価 (整数部は13桁まで、小数部は3桁まで)",
+            "example": "1234567890123.123",
+            "nullable": true,
+            "type": "string"
+          },
+          "tax_rate": {
+            "description": "税率（%）",
+            "enum": [
+              0,
+              8,
+              10
+            ],
+            "example": 8,
+            "nullable": true,
+            "type": "integer"
+          },
+          "reduced_tax_rate": {
+            "description": "軽減税率対象（true: 対象、 false: 対象外）",
+            "example": true,
+            "type": "boolean"
+          },
+          "withholding": {
+            "description": "源泉徴収対象",
+            "example": true,
+            "type": "boolean"
+          },
+          "amount_excluding_tax": {
+            "description": "税別金額",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "account_item_id": {
+            "description": "勘定科目ID",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "tax_code": {
+            "description": "税区分コード",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "item_id": {
+            "description": "品目ID",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "section_id": {
+            "description": "部門ID",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "tag_ids": {
+            "items": {
+              "description": "メモタグID",
+              "example": 1,
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "segment_1_tag_id": {
+            "description": "セグメント１ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "segment_2_tag_id": {
+            "description": "セグメント２ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "segment_3_tag_id": {
+            "description": "セグメント３ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "type",
+          "withholding"
+        ],
+        "type": "object"
+      },
+      "InvoiceResponse_invoice": {
+        "properties": {
+          "id": {
+            "description": "請求書ID",
+            "example": 101,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "company_id": {
+            "description": "事業所ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "invoice_number": {
+            "description": "請求書番号",
+            "example": "INV-0000000001",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "branch_no": {
+            "description": "枝番",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "subject": {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "template_id": {
+            "description": "帳票テンプレートID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "template_name": {
+            "description": "帳票テンプレート名",
+            "example": "標準の請求書テンプレート",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "billing_date": {
+            "description": "請求日",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "issue_date": {
+            "description": "発生日",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "payment_date": {
+            "description": "期日\n- payment_typeがtransferの場合、入金期日に該当します。\n- payment_typeがdirect_debitの場合、振替日に該当します。\n",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "payment_type": {
+            "description": "入金方法 (振込: transfer, 振替: direct_debit)",
+            "enum": [
+              "transfer",
+              "direct_debit"
+            ],
+            "example": "transfer",
+            "type": "string"
+          },
+          "invoice_note": {
+            "description": "備考",
+            "example": "備考",
+            "maxLength": 4000,
+            "type": "string"
+          },
+          "memo": {
+            "description": "社内メモ",
+            "example": "社内メモ",
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "sending_status": {
+            "description": "送付ステータス（sent: 送付済み、 unsent: 送付待ち）",
+            "enum": [
+              "sent",
+              "unsent"
+            ],
+            "example": "sent",
+            "type": "string"
+          },
+          "payment_status": {
+            "description": "入金ステータス（unsettled: 入金待ち, settled: 入金済み）",
+            "enum": [
+              "settled",
+              "unsettled"
+            ],
+            "example": "settled",
+            "type": "string"
+          },
+          "cancel_status": {
+            "description": "取消済み（canceled: 該当する、 uncanceled: 該当しない）",
+            "enum": [
+              "canceled",
+              "uncanceled"
+            ],
+            "example": "canceled",
+            "type": "string"
+          },
+          "deal_status": {
+            "description": "取引ステータス（registered: 登録済み、 unregistered: 登録待ち）",
+            "enum": [
+              "registered",
+              "unregistered"
+            ],
+            "example": "registered",
+            "type": "string"
+          },
+          "deal_id": {
+            "description": "取引ID （deal_statusがunregisteredの場合、nullになります。）",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "tax_entry_method": {
+            "description": "消費税の内税・外税区分（in: 税込表示（内税）、out: 税別表示（外税））",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "nullable": true,
+            "type": "string"
+          },
+          "tax_fraction": {
+            "description": "消費税端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "omit",
+            "nullable": true,
+            "type": "string"
+          },
+          "line_amount_fraction": {
+            "description": "金額端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "round_up",
+            "nullable": true,
+            "type": "string"
+          },
+          "withholding_tax_entry_method": {
+            "description": "源泉徴収の計算方法（in: 税込み価格で計算、out: 税別価格で計算）",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "nullable": true,
+            "type": "string"
+          },
+          "total_amount": {
+            "description": "合計金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "created_at": {
+            "description": "作成日時",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "type": "string"
+          },
+          "amount_withholding_tax": {
+            "description": "源泉所得税",
+            "example": 1000,
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax": {
+            "description": "税込金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "amount_excluding_tax": {
+            "description": "小計（税別）",
+            "example": 10000,
+            "type": "number"
+          },
+          "amount_tax": {
+            "description": "消費税額",
+            "example": 1000,
+            "type": "number"
+          },
+          "amount_including_tax_10": {
+            "description": "10%対象 税込",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_10": {
+            "description": "10%対象 税抜",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_10": {
+            "description": "10%対象 消費税",
+            "example": 1000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_8": {
+            "description": "8%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_8": {
+            "description": "8%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_8": {
+            "description": "8%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_8_reduced": {
+            "description": "軽減税率8%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_8_reduced": {
+            "description": "軽減税率8%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_8_reduced": {
+            "description": "軽減税率8%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_0": {
+            "description": "0%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_0": {
+            "description": "0%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_0": {
+            "description": "0%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_brought_forward": {
+            "description": "繰越金額",
+            "example": 10000,
+            "format": "double",
+            "maximum": 999999999999,
+            "minimum": -999999999999,
+            "nullable": true,
+            "type": "number"
+          },
+          "partner_id": {
+            "description": "取引先ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "partner_code": {
+            "description": "取引先コード",
+            "example": "code001",
+            "nullable": true,
+            "type": "string"
+          },
+          "partner_name": {
+            "description": "取引先名\n- partner_nameに空文字が戻る場合は、対象レコードをweb画面から更新するか、freee請求書APIから更新すると解消されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_title": {
+            "description": "敬称（御中、様、(空白)の3つから選択）",
+            "enum": [
+              "御中",
+              "様",
+              "(空白)"
+            ],
+            "example": "御中",
+            "type": "string"
+          },
+          "partner_address_zipcode": {
+            "description": "郵便番号",
+            "example": "1410032",
+            "maxLength": 10,
+            "type": "string"
+          },
+          "partner_address_prefecture_code": {
+            "description": "都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄）",
+            "example": 4,
+            "maximum": 46,
+            "minimum": -1,
+            "type": "integer"
+          },
+          "partner_address_street_name1": {
+            "description": "取引先 市区町村・番地",
+            "example": "東京都ＸＸ区ＹＹ１−１−１",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_address_street_name2": {
+            "description": "取引先 建物名・部屋番号など",
+            "example": "ビル 1F",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_department": {
+            "description": "取引先部署",
+            "example": "営業部",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_email_cc": {
+            "description": "取引先担当者メールアドレス（CC）",
+            "example": "tantosha1@example.com,tantosha2@example.com",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_email_to": {
+            "description": "取引先担当者メールアドレス（TO）",
+            "example": "tantosha1@example.com,tantosha2@example.com",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_name": {
+            "description": "取引先担当者名",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_display_name": {
+            "description": "取引先宛名\n- 帳票の宛名に利用されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_bank_account": {
+            "description": "取引先口座\n",
+            "example": "freee銀行 freee支店 普通 1234567 freee",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_sending_method": {
+            "description": "取引先への送付方法",
+            "enum": [
+              "email",
+              "posting",
+              "email_and_posting"
+            ],
+            "example": "email",
+            "nullable": true,
+            "type": "string"
+          },
+          "company_contact_name": {
+            "description": "自社担当者名",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_name": {
+            "description": "自社名",
+            "example": "freee K.K.",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_description": {
+            "description": "自社情報",
+            "example": "〒141-0032　東京都品川区大崎1-2-2アートヴィレッジ大崎セントラルタワー 21階",
+            "type": "string"
+          },
+          "bank_account_to_transfer": {
+            "description": "振込先",
+            "example": "freee銀行 第一営業支店 1234567",
+            "type": "string"
+          },
+          "template": {
+            "$ref": "#/components/schemas/InvoiceResponse_invoice_template"
+          },
+          "lines": {
+            "description": "請求書の明細行",
+            "items": {
+              "$ref": "#/components/schemas/InvoiceResponse_invoice_lines"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "amount_brought_forward",
+          "amount_excluding_tax",
+          "amount_including_tax",
+          "amount_tax",
+          "billing_date",
+          "cancel_status",
+          "company_id",
+          "created_at",
+          "deal_status",
+          "id",
+          "invoice_note",
+          "invoice_number",
+          "lines",
+          "memo",
+          "partner_id",
+          "payment_status",
+          "sending_status",
+          "subject",
+          "total_amount"
+        ],
+        "type": "object"
+      },
+      "InvoiceShowResponse_invoice_lines": {
+        "properties": {
+          "id": {
+            "description": "明細行ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "type": {
+            "description": "明細の種類\n- item: 品目行\n- text: テキスト行\n  - textの時はsales_date、quantity、unit_price、tax_rate、amount_excluding_taxはnullになります。\n",
+            "enum": [
+              "item",
+              "text"
+            ],
+            "example": "item",
+            "type": "string"
+          },
+          "description": {
+            "description": "摘要（品名）",
+            "example": "切手代",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "sales_date": {
+            "description": "取引日",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "unit": {
+            "description": "明細の単位名",
+            "example": "個",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "quantity": {
+            "description": "明細の数量 (整数部は8桁まで、小数部は3桁まで)",
+            "example": 1,
+            "maximum": 99999999.999,
+            "minimum": -99999999.999,
+            "nullable": true,
+            "type": "number"
+          },
+          "unit_price": {
+            "description": "明細の単価 (整数部は13桁まで、小数部は3桁まで)",
+            "example": "1234567890123.123",
+            "nullable": true,
+            "type": "string"
+          },
+          "tax_rate": {
+            "description": "税率（%）",
+            "enum": [
+              0,
+              8,
+              10
+            ],
+            "example": 8,
+            "nullable": true,
+            "type": "integer"
+          },
+          "reduced_tax_rate": {
+            "description": "軽減税率対象（true: 対象、 false: 対象外）",
+            "example": true,
+            "type": "boolean"
+          },
+          "withholding": {
+            "description": "源泉徴収対象",
+            "example": true,
+            "type": "boolean"
+          },
+          "amount_excluding_tax": {
+            "description": "税別金額",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "type",
+          "withholding"
+        ],
+        "type": "object"
+      },
+      "InvoiceShowResponse_invoice": {
+        "properties": {
+          "id": {
+            "description": "請求書ID",
+            "example": 101,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "company_id": {
+            "description": "事業所ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "invoice_number": {
+            "description": "請求書番号",
+            "example": "INV-0000000001",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "branch_no": {
+            "description": "枝番",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "subject": {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "template_id": {
+            "description": "帳票テンプレートID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "template_name": {
+            "description": "帳票テンプレート名",
+            "example": "標準の請求書テンプレート",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "billing_date": {
+            "description": "請求日",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "issue_date": {
+            "description": "発生日",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "payment_date": {
+            "description": "期日\n- payment_typeがtransferの場合、入金期日に該当します。\n- payment_typeがdirect_debitの場合、振替日に該当します。\n",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "payment_type": {
+            "description": "入金方法 (振込: transfer, 振替: direct_debit)",
+            "enum": [
+              "transfer",
+              "direct_debit"
+            ],
+            "example": "transfer",
+            "type": "string"
+          },
+          "invoice_note": {
+            "description": "備考",
+            "example": "備考",
+            "maxLength": 4000,
+            "type": "string"
+          },
+          "memo": {
+            "description": "社内メモ",
+            "example": "社内メモ",
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "sending_status": {
+            "description": "送付ステータス（sent: 送付済み、 unsent: 送付待ち）",
+            "enum": [
+              "sent",
+              "unsent"
+            ],
+            "example": "sent",
+            "type": "string"
+          },
+          "payment_status": {
+            "description": "入金ステータス（unsettled: 入金待ち, settled: 入金済み）",
+            "enum": [
+              "settled",
+              "unsettled"
+            ],
+            "example": "settled",
+            "type": "string"
+          },
+          "cancel_status": {
+            "description": "取消済み（canceled: 該当する、 uncanceled: 該当しない）",
+            "enum": [
+              "canceled",
+              "uncanceled"
+            ],
+            "example": "canceled",
+            "type": "string"
+          },
+          "deal_status": {
+            "description": "取引ステータス（registered: 登録済み、 unregistered: 登録待ち）",
+            "enum": [
+              "registered",
+              "unregistered"
+            ],
+            "example": "registered",
+            "type": "string"
+          },
+          "deal_id": {
+            "description": "取引ID （deal_statusがunregisteredの場合、nullになります。）",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "tax_entry_method": {
+            "description": "消費税の内税・外税区分（in: 税込表示（内税）、out: 税別表示（外税））",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "nullable": true,
+            "type": "string"
+          },
+          "tax_fraction": {
+            "description": "消費税端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "omit",
+            "nullable": true,
+            "type": "string"
+          },
+          "line_amount_fraction": {
+            "description": "金額端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "round_up",
+            "nullable": true,
+            "type": "string"
+          },
+          "withholding_tax_entry_method": {
+            "description": "源泉徴収の計算方法（in: 税込み価格で計算、out: 税別価格で計算）",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "nullable": true,
+            "type": "string"
+          },
+          "total_amount": {
+            "description": "合計金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "created_at": {
+            "description": "作成日時",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "type": "string"
+          },
+          "amount_withholding_tax": {
+            "description": "源泉所得税",
+            "example": 1000,
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax": {
+            "description": "税込金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "amount_excluding_tax": {
+            "description": "小計（税別）",
+            "example": 10000,
+            "type": "number"
+          },
+          "amount_tax": {
+            "description": "消費税額",
+            "example": 1000,
+            "type": "number"
+          },
+          "amount_including_tax_10": {
+            "description": "10%対象 税込",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_10": {
+            "description": "10%対象 税抜",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_10": {
+            "description": "10%対象 消費税",
+            "example": 1000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_8": {
+            "description": "8%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_8": {
+            "description": "8%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_8": {
+            "description": "8%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_8_reduced": {
+            "description": "軽減税率8%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_8_reduced": {
+            "description": "軽減税率8%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_8_reduced": {
+            "description": "軽減税率8%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_0": {
+            "description": "0%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_0": {
+            "description": "0%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_0": {
+            "description": "0%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_brought_forward": {
+            "description": "繰越金額",
+            "example": 10000,
+            "format": "double",
+            "maximum": 999999999999,
+            "minimum": -999999999999,
+            "nullable": true,
+            "type": "number"
+          },
+          "partner_id": {
+            "description": "取引先ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "partner_code": {
+            "description": "取引先コード",
+            "example": "code001",
+            "nullable": true,
+            "type": "string"
+          },
+          "partner_name": {
+            "description": "取引先名\n- partner_nameに空文字が戻る場合は、対象レコードをweb画面から更新するか、freee請求書APIから更新すると解消されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_title": {
+            "description": "敬称（御中、様、(空白)の3つから選択）",
+            "enum": [
+              "御中",
+              "様",
+              "(空白)"
+            ],
+            "example": "御中",
+            "type": "string"
+          },
+          "partner_address_zipcode": {
+            "description": "郵便番号",
+            "example": "1410032",
+            "maxLength": 10,
+            "type": "string"
+          },
+          "partner_address_prefecture_code": {
+            "description": "都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄）",
+            "example": 4,
+            "maximum": 46,
+            "minimum": -1,
+            "type": "integer"
+          },
+          "partner_address_street_name1": {
+            "description": "取引先 市区町村・番地",
+            "example": "東京都ＸＸ区ＹＹ１−１−１",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_address_street_name2": {
+            "description": "取引先 建物名・部屋番号など",
+            "example": "ビル 1F",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_department": {
+            "description": "取引先部署",
+            "example": "営業部",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_name": {
+            "description": "取引先担当者名",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_display_name": {
+            "description": "取引先宛名\n- 帳票の宛名に利用されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_bank_account": {
+            "description": "取引先口座\n",
+            "example": "freee銀行 freee支店 普通 1234567 freee",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_contact_name": {
+            "description": "自社担当者名",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_name": {
+            "description": "自社名 (上書きした場合のみ反映されます、デフォルトがテンプレートの自社名になり。)",
+            "example": "freee K.K.",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_description": {
+            "description": "自社情報 (上書きした場合のみ反映されます、デフォルトがテンプレートの自社情報になり。)",
+            "example": "〒141-0032　東京都品川区大崎1-2-2アートヴィレッジ大崎セントラルタワー 21階",
+            "type": "string"
+          },
+          "bank_account_to_transfer": {
+            "description": "振込先",
+            "example": "freee K.K.銀行 第一営業支店 1234567",
+            "type": "string"
+          },
+          "template": {
+            "$ref": "#/components/schemas/InvoiceResponse_invoice_template"
+          },
+          "lines": {
+            "description": "請求書の明細行",
+            "items": {
+              "$ref": "#/components/schemas/InvoiceShowResponse_invoice_lines"
+            },
+            "type": "array"
+          },
+          "email_url_file_downloaded_at": {
+            "description": "URL共有で送付された送付先のメールのダウンロード時刻",
+            "example": "1994-10-06 12:00:00",
+            "format": "string",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "type": "string"
+          },
+          "email_url_file_downloaded_status": {
+            "description": "URL共有で送付された送付先のメールのダウンロードステータス",
+            "enum": [
+              "downloaded",
+              "undownloaded"
+            ],
+            "example": "downloaded",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount_brought_forward",
+          "amount_excluding_tax",
+          "amount_including_tax",
+          "amount_tax",
+          "billing_date",
+          "cancel_status",
+          "company_id",
+          "created_at",
+          "deal_status",
+          "id",
+          "invoice_note",
+          "invoice_number",
+          "lines",
+          "memo",
+          "partner_id",
+          "payment_status",
+          "sending_status",
+          "subject",
+          "total_amount"
+        ],
+        "type": "object"
+      },
+      "notfoundError_errors": {
+        "properties": {
+          "type": {
+            "example": "not_found",
+            "type": "string"
+          },
+          "messages": {
+            "items": {
+              "example": "存在しないか既に削除されたレコードです。",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "TemplateIndexResponse_templates": {
+        "properties": {
+          "id": {
+            "description": "帳票テンプレートID",
+            "example": 101,
+            "maximum": 2147483647,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "name": {
+            "description": "帳票テンプレート名",
+            "example": "標準の請求書テンプレート",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "QuotationIndexResponse_quotations": {
+        "properties": {
+          "id": {
+            "description": "見積書ID",
+            "example": 101,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "company_id": {
+            "description": "事業所ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "quotation_number": {
+            "description": "見積書番号",
+            "example": "Q-0000000001",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "subject": {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "template_id": {
+            "description": "帳票テンプレートID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "quotation_date": {
+            "description": "見積日",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "expiration_date": {
+            "description": "有効期限",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "memo": {
+            "description": "社内メモ",
+            "example": "社内メモ",
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "sending_status": {
+            "description": "送付ステータス（sent: 送付済み、 unsent: 送付待ち）",
+            "enum": [
+              "sent",
+              "unsent"
+            ],
+            "example": "sent",
+            "type": "string"
+          },
+          "cancel_status": {
+            "description": "取消済み（canceled: 該当する、 uncanceled: 該当しない）",
+            "enum": [
+              "canceled",
+              "uncanceled"
+            ],
+            "example": "canceled",
+            "type": "string"
+          },
+          "total_amount": {
+            "description": "合計金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "amount_withholding_tax": {
+            "description": "源泉所得税",
+            "example": 1000,
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax": {
+            "description": "税込金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "amount_excluding_tax": {
+            "description": "小計（税別）",
+            "example": 10000,
+            "type": "number"
+          },
+          "amount_tax": {
+            "description": "消費税額",
+            "example": 1000,
+            "type": "number"
+          },
+          "partner_id": {
+            "description": "取引先ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "partner_code": {
+            "description": "取引先コード",
+            "example": "code001",
+            "nullable": true,
+            "type": "string"
+          },
+          "partner_name": {
+            "description": "取引先名\n- partner_nameに空文字が戻る場合は、対象レコードをweb画面から更新するか、freee請求書APIから更新すると解消されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_display_name": {
+            "description": "取引先宛名\n- 帳票の宛名に利用されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_contact_name": {
+            "description": "自社担当者 (デフォルト: 表示ユーザー名)\n",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "email_url_file_downloaded_at": {
+            "description": "URL共有で送付された送付先のメールのダウンロード時刻",
+            "example": "1994-10-06 12:00:00",
+            "format": "string",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "type": "string"
+          },
+          "email_url_file_downloaded_status": {
+            "description": "URL共有で送付された送付先のメールのダウンロードステータス",
+            "enum": [
+              "downloaded",
+              "undownloaded"
+            ],
+            "example": "downloaded",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount_excluding_tax",
+          "amount_including_tax",
+          "amount_tax",
+          "cancel_status",
+          "company_id",
+          "id",
+          "memo",
+          "partner_id",
+          "quotation_date",
+          "quotation_number",
+          "sending_status",
+          "subject",
+          "total_amount"
+        ],
+        "type": "object"
+      },
+      "QuotationRequest_lines": {
+        "properties": {
+          "type": {
+            "default": "item",
+            "description": "明細の種類\n- item: 品目行\n  - tax_rate、quantityは必須になります。\n- text: テキスト行\n  - descriptionのみ入力可能です。\n- 入力がない場合、itemが利用されます。\n",
+            "enum": [
+              "item",
+              "text"
+            ],
+            "example": "item",
+            "type": "string"
+          },
+          "description": {
+            "description": "摘要（品名）",
+            "example": "切手代",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "unit": {
+            "description": "明細の単位名",
+            "example": "個",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "quantity": {
+            "description": "明細の数量 (整数部は8桁まで、小数部は3桁まで)",
+            "example": 1,
+            "maximum": 99999999.999,
+            "minimum": -99999999.999,
+            "type": "number"
+          },
+          "unit_price": {
+            "description": "明細の単価 (整数部は13桁まで、小数部は3桁まで)",
+            "example": "1234567890123.123",
+            "pattern": "^\\-?[0-9]{0,13}(\\.[0-9]{1,3})?$",
+            "type": "string"
+          },
+          "tax_rate": {
+            "description": "税率（%）（帳票の税率計算に用います。）",
+            "enum": [
+              0,
+              8,
+              10
+            ],
+            "example": 8,
+            "type": "integer"
+          },
+          "reduced_tax_rate": {
+            "default": false,
+            "description": "軽減税率対象（true: 対象、 false: 対象外）trueはtax_rate:8の時のみ指定可能です。",
+            "example": false,
+            "type": "boolean"
+          },
+          "withholding": {
+            "description": "源泉徴収対象",
+            "example": true,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "QuotationResponse_quotation_template": {
+        "description": "帳票テンプレート情報（帳票テンプレート作成の際に設定できる項目です。）",
+        "properties": {
+          "title": {
+            "description": "見積書タイトル",
+            "example": "見積書",
+            "type": "string"
+          },
+          "company_name": {
+            "description": "自社名",
+            "example": "freee株式会社",
+            "type": "string"
+          },
+          "company_description": {
+            "description": "自社情報",
+            "example": "〒141-0032　東京都品川区大崎1-2-2アートヴィレッジ大崎セントラルタワー 21階",
+            "type": "string"
+          },
+          "message": {
+            "description": "メッセージ",
+            "example": "メッセージ",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "QuotationResponse_quotation_lines": {
+        "properties": {
+          "id": {
+            "description": "明細行ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "type": {
+            "description": "明細の種類\n- item: 品目行\n- text: テキスト行\n",
+            "enum": [
+              "item",
+              "text"
+            ],
+            "example": "item",
+            "type": "string"
+          },
+          "description": {
+            "description": "摘要（品名）",
+            "example": "切手代",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "unit": {
+            "description": "明細の単位名",
+            "example": "個",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "quantity": {
+            "description": "明細の数量 (整数部は8桁まで、小数部は3桁まで)",
+            "example": 1,
+            "maximum": 99999999.999,
+            "minimum": -99999999.999,
+            "nullable": true,
+            "type": "number"
+          },
+          "unit_price": {
+            "description": "明細の単価 (整数部は13桁まで、小数部は3桁まで)",
+            "example": "1234567890123.123",
+            "nullable": true,
+            "type": "string"
+          },
+          "tax_rate": {
+            "description": "税率（%）",
+            "enum": [
+              0,
+              8,
+              10
+            ],
+            "example": 8,
+            "nullable": true,
+            "type": "integer"
+          },
+          "reduced_tax_rate": {
+            "description": "軽減税率対象（true: 対象、 false: 対象外）",
+            "example": true,
+            "type": "boolean"
+          },
+          "withholding": {
+            "description": "源泉徴収対象",
+            "example": true,
+            "type": "boolean"
+          },
+          "amount_excluding_tax": {
+            "description": "税別金額",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "type",
+          "withholding"
+        ],
+        "type": "object"
+      },
+      "QuotationResponse_quotation": {
+        "properties": {
+          "id": {
+            "description": "見積書ID",
+            "example": 101,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "company_id": {
+            "description": "事業所ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "quotation_number": {
+            "description": "見積書番号",
+            "example": "Q-0000000001",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "branch_no": {
+            "description": "枝番",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "subject": {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "template_id": {
+            "description": "帳票テンプレートID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "template_name": {
+            "description": "帳票テンプレート名",
+            "example": "標準の請求書テンプレート",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "quotation_date": {
+            "description": "見積日",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "expiration_date": {
+            "description": "有効期限",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "delivery_deadline": {
+            "description": "納品期限",
+            "example": "2023年12月31日",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "delivery_location": {
+            "description": "納品場所",
+            "example": "納品場所",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "quotation_note": {
+            "description": "備考",
+            "example": "備考",
+            "maxLength": 4000,
+            "type": "string"
+          },
+          "memo": {
+            "description": "社内メモ",
+            "example": "社内メモ",
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "sending_status": {
+            "description": "送付ステータス（sent: 送付済み、 unsent: 送付待ち）",
+            "enum": [
+              "sent",
+              "unsent"
+            ],
+            "example": "sent",
+            "type": "string"
+          },
+          "cancel_status": {
+            "description": "取消済み（canceled: 該当する、 uncanceled: 該当しない）",
+            "enum": [
+              "canceled",
+              "uncanceled"
+            ],
+            "example": "canceled",
+            "type": "string"
+          },
+          "tax_entry_method": {
+            "description": "消費税の内税・外税区分（in: 税込表示（内税）、out: 税別表示（外税））",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "nullable": true,
+            "type": "string"
+          },
+          "tax_fraction": {
+            "description": "消費税端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "omit",
+            "nullable": true,
+            "type": "string"
+          },
+          "line_amount_fraction": {
+            "description": "金額端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "round_up",
+            "nullable": true,
+            "type": "string"
+          },
+          "withholding_tax_entry_method": {
+            "description": "源泉徴収の計算方法（in: 税込み価格で計算、out: 税別価格で計算）",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "nullable": true,
+            "type": "string"
+          },
+          "total_amount": {
+            "description": "合計金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "created_at": {
+            "description": "作成日時",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "type": "string"
+          },
+          "amount_withholding_tax": {
+            "description": "源泉所得税",
+            "example": 1000,
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax": {
+            "description": "税込金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "amount_excluding_tax": {
+            "description": "小計（税別）",
+            "example": 10000,
+            "type": "number"
+          },
+          "amount_tax": {
+            "description": "消費税額",
+            "example": 1000,
+            "type": "number"
+          },
+          "amount_including_tax_10": {
+            "description": "10%対象 税込",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_10": {
+            "description": "10%対象 税抜",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_10": {
+            "description": "10%対象 消費税",
+            "example": 1000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_8": {
+            "description": "8%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_8": {
+            "description": "8%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_8": {
+            "description": "8%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_8_reduced": {
+            "description": "軽減税率8%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_8_reduced": {
+            "description": "軽減税率8%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_8_reduced": {
+            "description": "軽減税率8%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_0": {
+            "description": "0%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_0": {
+            "description": "0%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_0": {
+            "description": "0%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "partner_id": {
+            "description": "取引先ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "partner_code": {
+            "description": "取引先コード",
+            "example": "code001",
+            "nullable": true,
+            "type": "string"
+          },
+          "partner_name": {
+            "description": "取引先名\n- partner_nameに空文字が戻る場合は、対象レコードをweb画面から更新するか、freee請求書APIから更新すると解消されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_title": {
+            "description": "敬称（御中、様、(空白)の3つから選択）",
+            "enum": [
+              "御中",
+              "様",
+              "(空白)"
+            ],
+            "example": "御中",
+            "type": "string"
+          },
+          "partner_address_zipcode": {
+            "description": "郵便番号",
+            "example": "1410032",
+            "maxLength": 10,
+            "type": "string"
+          },
+          "partner_address_prefecture_code": {
+            "description": "都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄）",
+            "example": 4,
+            "maximum": 46,
+            "minimum": -1,
+            "type": "integer"
+          },
+          "partner_address_street_name1": {
+            "description": "取引先 市区町村・番地",
+            "example": "東京都ＸＸ区ＹＹ１−１−１",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_address_street_name2": {
+            "description": "取引先 建物名・部屋番号など",
+            "example": "ビル 1F",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_department": {
+            "description": "取引先部署",
+            "example": "営業部",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_email_cc": {
+            "description": "取引先担当者メールアドレス（CC）",
+            "example": "tantosha1@example.com,tantosha2@example.com",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_email_to": {
+            "description": "取引先担当者メールアドレス（TO）",
+            "example": "tantosha1@example.com,tantosha2@example.com",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_name": {
+            "description": "取引先担当者名",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_display_name": {
+            "description": "取引先宛名\n- 帳票の宛名に利用されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_sending_method": {
+            "description": "取引先への送付方法",
+            "enum": [
+              "email",
+              "posting",
+              "email_and_posting"
+            ],
+            "example": "email",
+            "nullable": true,
+            "type": "string"
+          },
+          "company_contact_name": {
+            "description": "自社担当者名",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_name": {
+            "description": "自社名",
+            "example": "freee K.K.",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_description": {
+            "description": "自社情報",
+            "example": "〒141-0032　東京都品川区大崎1-2-2アートヴィレッジ大崎セントラルタワー 21階",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "template": {
+            "$ref": "#/components/schemas/QuotationResponse_quotation_template"
+          },
+          "lines": {
+            "description": "請求書の明細行",
+            "items": {
+              "$ref": "#/components/schemas/QuotationResponse_quotation_lines"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "amount_excluding_tax",
+          "amount_including_tax",
+          "amount_tax",
+          "cancel_status",
+          "company_id",
+          "created_at",
+          "delivery_deadline",
+          "delivery_location",
+          "id",
+          "lines",
+          "memo",
+          "partner_id",
+          "quotation_date",
+          "quotation_note",
+          "quotation_number",
+          "sending_status",
+          "subject",
+          "total_amount"
+        ],
+        "type": "object"
+      },
+      "QuotationShowResponse_quotation_lines": {
+        "properties": {
+          "id": {
+            "description": "明細行ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "type": {
+            "description": "明細の種類\n- item: 品目行\n- text: テキスト行\n  - textの時はsales_date、quantity、unit_price、tax_rate、amount_excluding_taxはnullになります。\n",
+            "enum": [
+              "item",
+              "text"
+            ],
+            "example": "item",
+            "type": "string"
+          },
+          "description": {
+            "description": "摘要（品名）",
+            "example": "切手代",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "unit": {
+            "description": "明細の単位名",
+            "example": "個",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "quantity": {
+            "description": "明細の数量 (整数部は8桁まで、小数部は3桁まで)",
+            "example": 1,
+            "maximum": 99999999.999,
+            "minimum": -99999999.999,
+            "nullable": true,
+            "type": "number"
+          },
+          "unit_price": {
+            "description": "明細の単価 (整数部は13桁まで、小数部は3桁まで)",
+            "example": "1234567890123.123",
+            "nullable": true,
+            "type": "string"
+          },
+          "tax_rate": {
+            "description": "税率（%）",
+            "enum": [
+              0,
+              8,
+              10
+            ],
+            "example": 8,
+            "nullable": true,
+            "type": "integer"
+          },
+          "reduced_tax_rate": {
+            "description": "軽減税率対象（true: 対象、 false: 対象外）",
+            "example": true,
+            "type": "boolean"
+          },
+          "withholding": {
+            "description": "源泉徴収対象",
+            "example": true,
+            "type": "boolean"
+          },
+          "amount_excluding_tax": {
+            "description": "税別金額",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "type",
+          "withholding"
+        ],
+        "type": "object"
+      },
+      "QuotationShowResponse_quotation": {
+        "properties": {
+          "id": {
+            "description": "見積書ID",
+            "example": 101,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "company_id": {
+            "description": "事業所ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "quotation_number": {
+            "description": "見積書番号",
+            "example": "Q-0000000001",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "branch_no": {
+            "description": "枝番",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "subject": {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "template_id": {
+            "description": "帳票テンプレートID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "template_name": {
+            "description": "帳票テンプレート名",
+            "example": "標準の請求書テンプレート",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "quotation_date": {
+            "description": "見積日",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "expiration_date": {
+            "description": "有効期限",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "delivery_deadline": {
+            "description": "納品期限",
+            "example": "2023年12月31日",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "delivery_location": {
+            "description": "納品場所",
+            "example": "納品場所",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "quotation_note": {
+            "description": "備考",
+            "example": "備考",
+            "maxLength": 4000,
+            "type": "string"
+          },
+          "memo": {
+            "description": "社内メモ",
+            "example": "社内メモ",
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "sending_status": {
+            "description": "送付ステータス（sent: 送付済み、 unsent: 送付待ち）",
+            "enum": [
+              "sent",
+              "unsent"
+            ],
+            "example": "sent",
+            "type": "string"
+          },
+          "cancel_status": {
+            "description": "取消済み（canceled: 該当する、 uncanceled: 該当しない）",
+            "enum": [
+              "canceled",
+              "uncanceled"
+            ],
+            "example": "canceled",
+            "type": "string"
+          },
+          "tax_entry_method": {
+            "description": "消費税の内税・外税区分（in: 税込表示（内税）、out: 税別表示（外税））",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "nullable": true,
+            "type": "string"
+          },
+          "tax_fraction": {
+            "description": "消費税端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "omit",
+            "nullable": true,
+            "type": "string"
+          },
+          "line_amount_fraction": {
+            "description": "金額端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "round_up",
+            "nullable": true,
+            "type": "string"
+          },
+          "withholding_tax_entry_method": {
+            "description": "源泉徴収の計算方法（in: 税込み価格で計算、out: 税別価格で計算）",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "nullable": true,
+            "type": "string"
+          },
+          "total_amount": {
+            "description": "合計金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "created_at": {
+            "description": "作成日時",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "type": "string"
+          },
+          "amount_withholding_tax": {
+            "description": "源泉所得税",
+            "example": 1000,
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax": {
+            "description": "税込金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "amount_excluding_tax": {
+            "description": "小計（税別）",
+            "example": 10000,
+            "type": "number"
+          },
+          "amount_tax": {
+            "description": "消費税額",
+            "example": 1000,
+            "type": "number"
+          },
+          "amount_including_tax_10": {
+            "description": "10%対象 税込",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_10": {
+            "description": "10%対象 税抜",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_10": {
+            "description": "10%対象 消費税",
+            "example": 1000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_8": {
+            "description": "8%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_8": {
+            "description": "8%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_8": {
+            "description": "8%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_8_reduced": {
+            "description": "軽減税率8%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_8_reduced": {
+            "description": "軽減税率8%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_8_reduced": {
+            "description": "軽減税率8%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_0": {
+            "description": "0%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_0": {
+            "description": "0%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_0": {
+            "description": "0%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "partner_id": {
+            "description": "取引先ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "partner_code": {
+            "description": "取引先コード",
+            "example": "code001",
+            "nullable": true,
+            "type": "string"
+          },
+          "partner_name": {
+            "description": "取引先名\n- partner_nameに空文字が戻る場合は、対象レコードをweb画面から更新するか、freee請求書APIから更新すると解消されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_title": {
+            "description": "敬称（御中、様、(空白)の3つから選択）",
+            "enum": [
+              "御中",
+              "様",
+              "(空白)"
+            ],
+            "example": "御中",
+            "type": "string"
+          },
+          "partner_address_zipcode": {
+            "description": "郵便番号",
+            "example": "1410032",
+            "maxLength": 10,
+            "type": "string"
+          },
+          "partner_address_prefecture_code": {
+            "description": "都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄）",
+            "example": 4,
+            "maximum": 46,
+            "minimum": -1,
+            "type": "integer"
+          },
+          "partner_address_street_name1": {
+            "description": "取引先 市区町村・番地",
+            "example": "東京都ＸＸ区ＹＹ１−１−１",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_address_street_name2": {
+            "description": "取引先 建物名・部屋番号など",
+            "example": "ビル 1F",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_department": {
+            "description": "取引先部署",
+            "example": "営業部",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_name": {
+            "description": "取引先担当者名",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_display_name": {
+            "description": "取引先宛名\n- 帳票の宛名に利用されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_contact_name": {
+            "description": "自社担当者名",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_name": {
+            "description": "自社名 (上書きした場合のみ反映されます、デフォルトがテンプレートの自社名になり。)",
+            "example": "freee K.K.",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_description": {
+            "description": "自社情報 (上書きした場合のみ反映されます、デフォルトがテンプレートの自社情報になり。)",
+            "example": "〒141-0032　東京都品川区大崎1-2-2アートヴィレッジ大崎セントラルタワー 21階",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "template": {
+            "$ref": "#/components/schemas/QuotationResponse_quotation_template"
+          },
+          "lines": {
+            "description": "請求書の明細行",
+            "items": {
+              "$ref": "#/components/schemas/QuotationShowResponse_quotation_lines"
+            },
+            "type": "array"
+          },
+          "email_url_file_downloaded_at": {
+            "description": "URL共有で送付された送付先のメールのダウンロード時刻",
+            "example": "1994-10-06 12:00:00",
+            "format": "string",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "type": "string"
+          },
+          "email_url_file_downloaded_status": {
+            "description": "URL共有で送付された送付先のメールのダウンロードステータス",
+            "enum": [
+              "downloaded",
+              "undownloaded"
+            ],
+            "example": "downloaded",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount_excluding_tax",
+          "amount_including_tax",
+          "amount_tax",
+          "cancel_status",
+          "company_id",
+          "created_at",
+          "delivery_deadline",
+          "delivery_location",
+          "id",
+          "lines",
+          "memo",
+          "partner_id",
+          "quotation_date",
+          "quotation_note",
+          "quotation_number",
+          "sending_status",
+          "subject",
+          "total_amount"
+        ],
+        "type": "object"
+      },
+      "DeliverySlipIndexResponse_delivery_slips": {
+        "properties": {
+          "id": {
+            "description": "納品書ID",
+            "example": 101,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "company_id": {
+            "description": "事業所ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "delivery_slip_number": {
+            "description": "納品書番号",
+            "example": "DEL-0000000001",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "subject": {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "template_id": {
+            "description": "帳票テンプレートID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "delivery_slip_date": {
+            "description": "納品日",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "issue_date": {
+            "description": "発生日",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "memo": {
+            "description": "社内メモ",
+            "example": "社内メモ",
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "sending_status": {
+            "description": "送付ステータス（sent: 送付済み、 unsent: 送付待ち）",
+            "enum": [
+              "sent",
+              "unsent"
+            ],
+            "example": "sent",
+            "type": "string"
+          },
+          "payment_status": {
+            "description": "入金ステータス（unsettled: 入金待ち, settled: 入金済み）",
+            "enum": [
+              "settled",
+              "unsettled"
+            ],
+            "example": "settled",
+            "type": "string"
+          },
+          "cancel_status": {
+            "description": "取消済み（canceled: 該当する、 uncanceled: 該当しない）",
+            "enum": [
+              "canceled",
+              "uncanceled"
+            ],
+            "example": "canceled",
+            "type": "string"
+          },
+          "deal_status": {
+            "description": "取引ステータス（registered: 登録済み、 unregistered: 登録待ち）",
+            "enum": [
+              "registered",
+              "unregistered"
+            ],
+            "example": "registered",
+            "type": "string"
+          },
+          "deal_id": {
+            "description": "取引ID （deal_statusがunregisteredの場合、nullになります。）",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "total_amount": {
+            "description": "合計金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "amount_withholding_tax": {
+            "description": "源泉所得税",
+            "example": 1000,
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax": {
+            "description": "税込金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "amount_excluding_tax": {
+            "description": "小計（税別）",
+            "example": 10000,
+            "type": "number"
+          },
+          "amount_tax": {
+            "description": "消費税額",
+            "example": 1000,
+            "type": "number"
+          },
+          "partner_id": {
+            "description": "取引先ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "partner_code": {
+            "description": "取引先コード",
+            "example": "code001",
+            "nullable": true,
+            "type": "string"
+          },
+          "partner_name": {
+            "description": "取引先名\n- partner_nameに空文字が戻る場合は、対象レコードをweb画面から更新するか、freee請求書APIから更新すると解消されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_display_name": {
+            "description": "取引先宛名\n- 帳票の宛名に利用されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_contact_name": {
+            "description": "自社担当者 (デフォルト: 表示ユーザー名)\n",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "email_url_file_downloaded_at": {
+            "description": "URL共有で送付された送付先のメールのダウンロード時刻",
+            "example": "1994-10-06 12:00:00",
+            "format": "string",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "type": "string"
+          },
+          "email_url_file_downloaded_status": {
+            "description": "URL共有で送付された送付先のメールのダウンロードステータス",
+            "enum": [
+              "downloaded",
+              "undownloaded"
+            ],
+            "example": "downloaded",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount_excluding_tax",
+          "amount_including_tax",
+          "amount_tax",
+          "cancel_status",
+          "company_id",
+          "deal_status",
+          "delivery_slip_date",
+          "delivery_slip_number",
+          "id",
+          "memo",
+          "partner_id",
+          "payment_status",
+          "sending_status",
+          "subject",
+          "total_amount"
+        ],
+        "type": "object"
+      },
+      "DeliverySlipRequest_lines": {
+        "properties": {
+          "type": {
+            "default": "item",
+            "description": "明細の種類\n- item: 品目行\n  - tax_rate、quantityは必須になります。\n- text: テキスト行\n  - descriptionのみ入力可能です。\n- 入力がない場合、itemが利用されます。\n",
+            "enum": [
+              "item",
+              "text"
+            ],
+            "example": "item",
+            "type": "string"
+          },
+          "description": {
+            "description": "摘要（品名）",
+            "example": "切手代",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "unit": {
+            "description": "明細の単位名",
+            "example": "個",
+            "maxLength": 255,
+            "minLength": 1,
+            "type": "string"
+          },
+          "quantity": {
+            "description": "明細の数量 (整数部は8桁まで、小数部は3桁まで)",
+            "example": 1,
+            "maximum": 99999999.999,
+            "minimum": -99999999.999,
+            "type": "number"
+          },
+          "unit_price": {
+            "description": "明細の単価 (整数部は13桁まで、小数部は3桁まで)",
+            "example": "1234567890123.123",
+            "pattern": "^\\-?[0-9]{0,13}(\\.[0-9]{1,3})?$",
+            "type": "string"
+          },
+          "tax_rate": {
+            "description": "税率（%）（帳票の税額計算に用います。）",
+            "enum": [
+              0,
+              8,
+              10
+            ],
+            "example": 8,
+            "type": "integer"
+          },
+          "reduced_tax_rate": {
+            "default": false,
+            "description": "軽減税率対象（true: 対象、 false: 対象外）trueはtax_rate:8の時のみ指定可能です。",
+            "example": false,
+            "type": "boolean"
+          },
+          "withholding": {
+            "description": "源泉徴収対象",
+            "example": true,
+            "type": "boolean"
+          },
+          "account_item_id": {
+            "description": "勘定科目ID（取引登録の下書き保存で利用されます。）",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "tax_code": {
+            "description": "税区分コード（取引登録の下書き保存で利用されます。）",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "item_id": {
+            "description": "品目ID（取引登録の下書き保存で利用されます。）",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "section_id": {
+            "description": "部門ID<br>\n- 取引登録の下書き保存で利用されます。\n- 親部門は利用できません。\n- グループ管理で制限された部門は利用できません。\n<br>\n<a href=\"https://support.freee.co.jp/hc/ja/articles/215225263\" target=\"_blank\">グループ管理の設定はヘルプページを御覧ください。</a>\n",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "tag_ids": {
+            "items": {
+              "description": "メモタグID（10個まで設定可能です。）（取引登録の下書き保存で利用されます。）",
+              "example": 1,
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "segment_1_tag_id": {
+            "description": "セグメント１ID<br>\n- 取引登録の下書き保存で利用されます。\n- freee会計法人向け プロフェッショナルプラン以上で利用可能です。\n<br>\n<a href=\"https://support.freee.co.jp/hc/ja/articles/360020679611\" target=\"_blank\">セグメント（分析用タグ）の設定はヘルプページを御覧ください。</a>\n",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "segment_2_tag_id": {
+            "description": "セグメント２ID<br>\n- 取引登録の下書き保存で利用されます。\n- freee会計法人向け エンタープライズプランで利用可能です。\n<br>\n<a href=\"https://support.freee.co.jp/hc/ja/articles/360020679611\" target=\"_blank\">セグメント（分析用タグ）の設定はヘルプページを御覧ください。</a>\n",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "segment_3_tag_id": {
+            "description": "セグメント３ID<br>\n- 取引登録の下書き保存で利用されます。\n- freee会計法人向け エンタープライズプランで利用可能です。\n<br>\n<a href=\"https://support.freee.co.jp/hc/ja/articles/360020679611\" target=\"_blank\">セグメント（分析用タグ）の設定はヘルプページを御覧ください。</a>\n",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "DeliverySlipResponse_delivery_slip_template": {
+        "description": "帳票テンプレート情報（帳票テンプレート作成の際に設定できる項目です。）",
+        "properties": {
+          "title": {
+            "description": "納品書タイトル",
+            "example": "納品書",
+            "type": "string"
+          },
+          "invoice_registration_number": {
+            "description": "インボイス制度適格請求書発行事業者登録番号\n- 先頭T数字13桁の固定14桁の文字列\n<a target=\"_blank\" href=\"https://www.invoice-kohyo.nta.go.jp/index.html\">国税庁インボイス制度適格請求書発行事業者公表サイト</a>\n",
+            "example": "T1000000000001",
+            "type": "string"
+          },
+          "company_name": {
+            "description": "自社名",
+            "example": "freee株式会社",
+            "type": "string"
+          },
+          "company_description": {
+            "description": "自社情報",
+            "example": "〒141-0032　東京都品川区大崎1-2-2アートヴィレッジ大崎セントラルタワー 21階",
+            "type": "string"
+          },
+          "message": {
+            "description": "メッセージ",
+            "example": "メッセージ",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DeliverySlipResponse_delivery_slip_lines": {
+        "properties": {
+          "id": {
+            "description": "明細行ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "type": {
+            "description": "明細の種類\n- item: 品目行\n- text: テキスト行\n- textの時はquantity、unit_price、tax_rate、amount_excluding_tax、account_item_id、tax_code、item_id、section_id、segment_1_tag_id、segment_2_tag_id、segment_3_tag_idはnullになります。\n",
+            "enum": [
+              "item",
+              "text"
+            ],
+            "example": "item",
+            "type": "string"
+          },
+          "description": {
+            "description": "摘要（品名）",
+            "example": "切手代",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "unit": {
+            "description": "明細の単位名",
+            "example": "個",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "quantity": {
+            "description": "明細の数量 (整数部は8桁まで、小数部は3桁まで)",
+            "example": 1,
+            "maximum": 99999999.999,
+            "minimum": -99999999.999,
+            "nullable": true,
+            "type": "number"
+          },
+          "unit_price": {
+            "description": "明細の単価 (整数部は13桁まで、小数部は3桁まで)",
+            "example": "1234567890123.123",
+            "nullable": true,
+            "type": "string"
+          },
+          "tax_rate": {
+            "description": "税率（%）",
+            "enum": [
+              0,
+              8,
+              10
+            ],
+            "example": 8,
+            "nullable": true,
+            "type": "integer"
+          },
+          "reduced_tax_rate": {
+            "description": "軽減税率対象（true: 対象、 false: 対象外）",
+            "example": true,
+            "type": "boolean"
+          },
+          "withholding": {
+            "description": "源泉徴収対象",
+            "example": true,
+            "type": "boolean"
+          },
+          "amount_excluding_tax": {
+            "description": "税別金額",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "account_item_id": {
+            "description": "勘定科目ID",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "tax_code": {
+            "description": "税区分コード",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "item_id": {
+            "description": "品目ID",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "section_id": {
+            "description": "部門ID",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "tag_ids": {
+            "items": {
+              "description": "メモタグID",
+              "example": 1,
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "segment_1_tag_id": {
+            "description": "セグメント１ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "segment_2_tag_id": {
+            "description": "セグメント２ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "segment_3_tag_id": {
+            "description": "セグメント３ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "type",
+          "withholding"
+        ],
+        "type": "object"
+      },
+      "DeliverySlipResponse_delivery_slip": {
+        "properties": {
+          "id": {
+            "description": "納品書ID",
+            "example": 101,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "company_id": {
+            "description": "事業所ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "delivery_slip_number": {
+            "description": "納品書番号",
+            "example": "DEL-0000000001",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "branch_no": {
+            "description": "枝番",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "subject": {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "template_id": {
+            "description": "帳票テンプレートID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "template_name": {
+            "description": "帳票テンプレート名",
+            "example": "標準の納品書テンプレート",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "delivery_slip_date": {
+            "description": "納品日",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "issue_date": {
+            "description": "発生日",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "payment_date": {
+            "description": "期日\n- payment_typeがtransferの場合、入金期日に該当します。\n- payment_typeがdirect_debitの場合、振替日に該当します。\n",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "payment_type": {
+            "description": "入金方法 (振込: transfer, 振替: direct_debit)",
+            "enum": [
+              "transfer",
+              "direct_debit"
+            ],
+            "example": "transfer",
+            "type": "string"
+          },
+          "delivery_slip_note": {
+            "description": "備考",
+            "example": "備考",
+            "maxLength": 4000,
+            "type": "string"
+          },
+          "memo": {
+            "description": "社内メモ",
+            "example": "社内メモ",
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "sending_status": {
+            "description": "送付ステータス（sent: 送付済み、 unsent: 送付待ち）",
+            "enum": [
+              "sent",
+              "unsent"
+            ],
+            "example": "sent",
+            "type": "string"
+          },
+          "payment_status": {
+            "description": "入金ステータス（unsettled: 入金待ち, settled: 入金済み）",
+            "enum": [
+              "settled",
+              "unsettled"
+            ],
+            "example": "settled",
+            "type": "string"
+          },
+          "cancel_status": {
+            "description": "取消済み（canceled: 該当する、 uncanceled: 該当しない）",
+            "enum": [
+              "canceled",
+              "uncanceled"
+            ],
+            "example": "canceled",
+            "type": "string"
+          },
+          "deal_status": {
+            "description": "取引ステータス（registered: 登録済み、 unregistered: 登録待ち）",
+            "enum": [
+              "registered",
+              "unregistered"
+            ],
+            "example": "registered",
+            "type": "string"
+          },
+          "deal_id": {
+            "description": "取引ID （deal_statusがunregisteredの場合、nullになります。）",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "tax_entry_method": {
+            "description": "消費税の内税・外税区分（in: 税込表示（内税）、out: 税別表示（外税））",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "nullable": true,
+            "type": "string"
+          },
+          "tax_fraction": {
+            "description": "消費税端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "omit",
+            "nullable": true,
+            "type": "string"
+          },
+          "line_amount_fraction": {
+            "description": "金額端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "round_up",
+            "nullable": true,
+            "type": "string"
+          },
+          "withholding_tax_entry_method": {
+            "description": "源泉徴収の計算方法（in: 税込み価格で計算、out: 税別価格で計算）",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "nullable": true,
+            "type": "string"
+          },
+          "total_amount": {
+            "description": "合計金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "created_at": {
+            "description": "作成日時",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "type": "string"
+          },
+          "amount_withholding_tax": {
+            "description": "源泉所得税",
+            "example": 1000,
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax": {
+            "description": "税込金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "amount_excluding_tax": {
+            "description": "小計（税別）",
+            "example": 10000,
+            "type": "number"
+          },
+          "amount_tax": {
+            "description": "消費税額",
+            "example": 1000,
+            "type": "number"
+          },
+          "amount_including_tax_10": {
+            "description": "10%対象 税込",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_10": {
+            "description": "10%対象 税抜",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_10": {
+            "description": "10%対象 消費税",
+            "example": 1000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_8": {
+            "description": "8%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_8": {
+            "description": "8%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_8": {
+            "description": "8%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_8_reduced": {
+            "description": "軽減税率8%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_8_reduced": {
+            "description": "軽減税率8%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_8_reduced": {
+            "description": "軽減税率8%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_0": {
+            "description": "0%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_0": {
+            "description": "0%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_0": {
+            "description": "0%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "partner_id": {
+            "description": "取引先ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "partner_code": {
+            "description": "取引先コード",
+            "example": "code001",
+            "nullable": true,
+            "type": "string"
+          },
+          "partner_name": {
+            "description": "取引先名\n- partner_nameに空文字が戻る場合は、対象レコードをweb画面から更新するか、freee請求書APIから更新すると解消されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_title": {
+            "description": "敬称（御中、様、(空白)の3つから選択）",
+            "enum": [
+              "御中",
+              "様",
+              "(空白)"
+            ],
+            "example": "御中",
+            "type": "string"
+          },
+          "partner_address_zipcode": {
+            "description": "郵便番号",
+            "example": "1410032",
+            "maxLength": 10,
+            "type": "string"
+          },
+          "partner_address_prefecture_code": {
+            "description": "都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄）",
+            "example": 4,
+            "maximum": 46,
+            "minimum": -1,
+            "type": "integer"
+          },
+          "partner_address_street_name1": {
+            "description": "取引先 市区町村・番地",
+            "example": "東京都ＸＸ区ＹＹ１−１−１",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_address_street_name2": {
+            "description": "取引先 建物名・部屋番号など",
+            "example": "ビル 1F",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_department": {
+            "description": "取引先部署",
+            "example": "営業部",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_email_cc": {
+            "description": "取引先担当者メールアドレス（CC）",
+            "example": "tantosha1@example.com,tantosha2@example.com",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_email_to": {
+            "description": "取引先担当者メールアドレス（TO）",
+            "example": "tantosha1@example.com,tantosha2@example.com",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_name": {
+            "description": "取引先担当者名",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_display_name": {
+            "description": "取引先宛名\n- 帳票の宛名に利用されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_bank_account": {
+            "description": "取引先口座\n",
+            "example": "freee銀行 freee支店 普通 1234567 freee",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_sending_method": {
+            "description": "取引先への送付方法",
+            "enum": [
+              "email",
+              "posting",
+              "email_and_posting"
+            ],
+            "example": "email",
+            "nullable": true,
+            "type": "string"
+          },
+          "company_contact_name": {
+            "description": "自社担当者名",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_name": {
+            "description": "自社名",
+            "example": "freee K.K.",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_description": {
+            "description": "自社情報",
+            "example": "〒141-0032　東京都品川区大崎1-2-2アートヴィレッジ大崎セントラルタワー 21階",
+            "type": "string"
+          },
+          "template": {
+            "$ref": "#/components/schemas/DeliverySlipResponse_delivery_slip_template"
+          },
+          "lines": {
+            "description": "納品書の明細行",
+            "items": {
+              "$ref": "#/components/schemas/DeliverySlipResponse_delivery_slip_lines"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "amount_excluding_tax",
+          "amount_including_tax",
+          "amount_tax",
+          "cancel_status",
+          "company_id",
+          "created_at",
+          "deal_status",
+          "delivery_slip_date",
+          "delivery_slip_note",
+          "delivery_slip_number",
+          "id",
+          "lines",
+          "memo",
+          "partner_id",
+          "payment_status",
+          "sending_status",
+          "subject",
+          "total_amount"
+        ],
+        "type": "object"
+      },
+      "DeliverySlipShowResponse_delivery_slip_lines": {
+        "properties": {
+          "id": {
+            "description": "明細行ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "type": {
+            "description": "明細の種類\n- item: 品目行\n- text: テキスト行\n  - textの時はquantity、unit_price、tax_rate、amount_excluding_taxはnullになります。\n",
+            "enum": [
+              "item",
+              "text"
+            ],
+            "example": "item",
+            "type": "string"
+          },
+          "description": {
+            "description": "摘要（品名）",
+            "example": "切手代",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "unit": {
+            "description": "明細の単位名",
+            "example": "個",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "quantity": {
+            "description": "明細の数量 (整数部は8桁まで、小数部は3桁まで)",
+            "example": 1,
+            "maximum": 99999999.999,
+            "minimum": -99999999.999,
+            "nullable": true,
+            "type": "number"
+          },
+          "unit_price": {
+            "description": "明細の単価 (整数部は13桁まで、小数部は3桁まで)",
+            "example": "1234567890123.123",
+            "nullable": true,
+            "type": "string"
+          },
+          "tax_rate": {
+            "description": "税率（%）",
+            "enum": [
+              0,
+              8,
+              10
+            ],
+            "example": 8,
+            "nullable": true,
+            "type": "integer"
+          },
+          "reduced_tax_rate": {
+            "description": "軽減税率対象（true: 対象、 false: 対象外）",
+            "example": true,
+            "type": "boolean"
+          },
+          "withholding": {
+            "description": "源泉徴収対象",
+            "example": true,
+            "type": "boolean"
+          },
+          "amount_excluding_tax": {
+            "description": "税別金額",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "required": [
+          "description",
+          "id",
+          "type",
+          "withholding"
+        ],
+        "type": "object"
+      },
+      "DeliverySlipShowResponse_delivery_slip": {
+        "properties": {
+          "id": {
+            "description": "納品書ID",
+            "example": 101,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "company_id": {
+            "description": "事業所ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "delivery_slip_number": {
+            "description": "納品書番号",
+            "example": "DEL-0000000001",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "branch_no": {
+            "description": "枝番",
+            "example": 1,
+            "maximum": 2147483647,
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "subject": {
+            "description": "件名",
+            "example": "Webサイト製作費",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "template_id": {
+            "description": "帳票テンプレートID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "template_name": {
+            "description": "帳票テンプレート名",
+            "example": "標準の納品書テンプレート",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "delivery_slip_date": {
+            "description": "請求日",
+            "example": "2023-04-01",
+            "format": "date",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "issue_date": {
+            "description": "発生日",
+            "example": "2023-04-01",
+            "format": "date",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "type": "string"
+          },
+          "delivery_slip_note": {
+            "description": "備考",
+            "example": "備考",
+            "maxLength": 4000,
+            "type": "string"
+          },
+          "memo": {
+            "description": "社内メモ",
+            "example": "社内メモ",
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "sending_status": {
+            "description": "送付ステータス（sent: 送付済み、 unsent: 送付待ち）",
+            "enum": [
+              "sent",
+              "unsent"
+            ],
+            "example": "sent",
+            "type": "string"
+          },
+          "payment_status": {
+            "description": "入金ステータス（unsettled: 入金待ち, settled: 入金済み）",
+            "enum": [
+              "settled",
+              "unsettled"
+            ],
+            "example": "settled",
+            "type": "string"
+          },
+          "cancel_status": {
+            "description": "取消済み（canceled: 該当する、 uncanceled: 該当しない）",
+            "enum": [
+              "canceled",
+              "uncanceled"
+            ],
+            "example": "canceled",
+            "type": "string"
+          },
+          "deal_status": {
+            "description": "取引ステータス（registered: 登録済み、 unregistered: 登録待ち）",
+            "enum": [
+              "registered",
+              "unregistered"
+            ],
+            "example": "registered",
+            "type": "string"
+          },
+          "deal_id": {
+            "description": "取引ID （deal_statusがunregisteredの場合、nullになります。）",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "nullable": true,
+            "type": "integer"
+          },
+          "tax_entry_method": {
+            "description": "消費税の内税・外税区分（in: 税込表示（内税）、out: 税別表示（外税））",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "nullable": true,
+            "type": "string"
+          },
+          "tax_fraction": {
+            "description": "消費税端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "omit",
+            "nullable": true,
+            "type": "string"
+          },
+          "line_amount_fraction": {
+            "description": "金額端数の計算方法（omit: 切り捨て、round_up: 切り上げ、round: 四捨五入）",
+            "enum": [
+              "omit",
+              "round_up",
+              "round"
+            ],
+            "example": "round_up",
+            "nullable": true,
+            "type": "string"
+          },
+          "withholding_tax_entry_method": {
+            "description": "源泉徴収の計算方法（in: 税込み価格で計算、out: 税別価格で計算）",
+            "enum": [
+              "in",
+              "out"
+            ],
+            "example": "out",
+            "nullable": true,
+            "type": "string"
+          },
+          "total_amount": {
+            "description": "合計金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "created_at": {
+            "description": "作成日時",
+            "format": "date-time",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "type": "string"
+          },
+          "amount_withholding_tax": {
+            "description": "源泉所得税",
+            "example": 1000,
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax": {
+            "description": "税込金額",
+            "example": 11000,
+            "format": "double",
+            "type": "number"
+          },
+          "amount_excluding_tax": {
+            "description": "小計（税別）",
+            "example": 10000,
+            "type": "number"
+          },
+          "amount_tax": {
+            "description": "消費税額",
+            "example": 1000,
+            "type": "number"
+          },
+          "amount_including_tax_10": {
+            "description": "10%対象 税込",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_10": {
+            "description": "10%対象 税抜",
+            "example": 10000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_10": {
+            "description": "10%対象 消費税",
+            "example": 1000,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_8": {
+            "description": "8%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_8": {
+            "description": "8%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_8": {
+            "description": "8%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_8_reduced": {
+            "description": "軽減税率8%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_8_reduced": {
+            "description": "軽減税率8%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_8_reduced": {
+            "description": "軽減税率8%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_including_tax_0": {
+            "description": "0%対象 税込",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_excluding_tax_0": {
+            "description": "0%対象 税抜",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "amount_tax_0": {
+            "description": "0%対象 消費税",
+            "example": 0,
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "partner_id": {
+            "description": "取引先ID",
+            "example": 1,
+            "format": "int64",
+            "maximum": 9223372036854775807,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "partner_code": {
+            "description": "取引先コード",
+            "example": "code001",
+            "nullable": true,
+            "type": "string"
+          },
+          "partner_name": {
+            "description": "取引先名\n- partner_nameに空文字が戻る場合は、対象レコードをweb画面から更新するか、freee請求書APIから更新すると解消されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_title": {
+            "description": "敬称（御中、様、(空白)の3つから選択）",
+            "enum": [
+              "御中",
+              "様",
+              "(空白)"
+            ],
+            "example": "御中",
+            "type": "string"
+          },
+          "partner_address_zipcode": {
+            "description": "郵便番号",
+            "example": "1410032",
+            "maxLength": 10,
+            "type": "string"
+          },
+          "partner_address_prefecture_code": {
+            "description": "都道府県コード（-1: 設定しない、0: 北海道、1:青森、2:岩手、3:宮城、4:秋田、5:山形、6:福島、7:茨城、8:栃木、9:群馬、10:埼玉、11:千葉、12:東京、13:神奈川、14:新潟、15:富山、16:石川、17:福井、18:山梨、19:長野、20:岐阜、21:静岡、22:愛知、23:三重、24:滋賀、25:京都、26:大阪、27:兵庫、28:奈良、29:和歌山、30:鳥取、31:島根、32:岡山、33:広島、34:山口、35:徳島、36:香川、37:愛媛、38:高知、39:福岡、40:佐賀、41:長崎、42:熊本、43:大分、44:宮崎、45:鹿児島、46:沖縄）",
+            "example": 4,
+            "maximum": 46,
+            "minimum": -1,
+            "type": "integer"
+          },
+          "partner_address_street_name1": {
+            "description": "取引先 市区町村・番地",
+            "example": "東京都ＸＸ区ＹＹ１−１−１",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_address_street_name2": {
+            "description": "取引先 建物名・部屋番号など",
+            "example": "ビル 1F",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_department": {
+            "description": "取引先部署",
+            "example": "営業部",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_contact_name": {
+            "description": "取引先担当者名",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "partner_display_name": {
+            "description": "取引先宛名\n- 帳票の宛名に利用されます。\n",
+            "example": "freeeパートナー",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_contact_name": {
+            "description": "自社担当者名",
+            "example": "法人営業担当",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_name": {
+            "description": "自社名 (上書きした場合のみ反映されます、デフォルトがテンプレートの自社名になり。)",
+            "example": "freee K.K.",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "company_description": {
+            "description": "自社情報 (上書きした場合のみ反映されます、デフォルトがテンプレートの自社情報になり。)",
+            "example": "〒141-0032　東京都品川区大崎1-2-2アートヴィレッジ大崎セントラルタワー 21階",
+            "maxLength": 255,
+            "type": "string"
+          },
+          "template": {
+            "$ref": "#/components/schemas/DeliverySlipResponse_delivery_slip_template"
+          },
+          "lines": {
+            "description": "納品書の明細行",
+            "items": {
+              "$ref": "#/components/schemas/DeliverySlipShowResponse_delivery_slip_lines"
+            },
+            "type": "array"
+          },
+          "email_url_file_downloaded_at": {
+            "description": "URL共有で送付された送付先のメールのダウンロード時刻",
+            "example": "1994-10-06 12:00:00",
+            "format": "string",
+            "nullable": true,
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}(:[0-9]{2})?$",
+            "type": "string"
+          },
+          "email_url_file_downloaded_status": {
+            "description": "URL共有で送付された送付先のメールのダウンロードステータス",
+            "enum": [
+              "downloaded",
+              "undownloaded"
+            ],
+            "example": "downloaded",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount_excluding_tax",
+          "amount_including_tax",
+          "amount_tax",
+          "cancel_status",
+          "company_id",
+          "created_at",
+          "deal_status",
+          "delivery_slip_date",
+          "delivery_slip_note",
+          "delivery_slip_number",
+          "id",
+          "lines",
+          "memo",
+          "partner_id",
+          "payment_status",
+          "sending_status",
+          "subject",
+          "total_amount"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "oauth2": {
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://accounts.secure.freee.co.jp/public_api/authorize",
+            "scopes": {
+              "write": "データの書き込み",
+              "read": "データの読み取り"
+            },
+            "tokenUrl": "https://accounts.secure.freee.co.jp/public_api/token"
+          }
+        },
+        "type": "oauth2"
+      }
+    }
+  }
+}

--- a/openapi/pm-api-schema.json
+++ b/openapi/pm-api-schema.json
@@ -1,0 +1,2527 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "freee工数管理",
+    "version": "v1.1.0",
+    "x-copyright": "&copy; Since 2013 freee K.K.",
+    "description": "<h1 id=\"freee_api\">freee工数管理</h1> <hr />\n<h2 id=\"start_guide\">スタートガイド</h2> <p>freee API開発がはじめての方は<a href=\"https://developer.freee.co.jp/getting-started\">freee APIスタートガイド</a>を参照してください。</p>\n<hr />\n<h2 id=\"specification\">仕様</h2>\n<h3 id=\"api_endpoint\">APIエンドポイント</h3> <p>https://api.freee.co.jp/pm (httpsのみ)</p>\n<h3 id=\"about_authorize\">認証について</h3> <p>OAuth2.0を利用します。<a href=\"https://developer.freee.co.jp/reference/#%e8%aa%8d%e8%a8%bc\" target=\"_blank\">詳細はリファレンスの認証に関する記載を参照してください。</a></p>\n<h3 id=\"data_format\">データフォーマット</h3> <p>リクエスト、レスポンスともにJSON形式をサポートしていますが、詳細は、API毎の説明欄（application/jsonなど）を確認してください。</p>\n<h3 id=\"compatibility\">後方互換性ありの変更</h3> <p>freeeでは、APIを改善していくために以下のような変更は後方互換性ありとして通知なく変更を入れることがあります。アプリケーション実装者は以下を踏まえて開発を行ってください。</p> <ul>\n  <li>新しいAPIリソース・エンドポイントの追加</li>\n  <li>既存のAPIに対して必須ではない新しいリクエストパラメータの追加</li>\n  <li>既存のAPIレスポンスに対する新しいプロパティの追加</li>\n  <li>既存のAPIレスポンスに対するプロパティの順番の入れ変え</li>\n  <li>keyとなっているidやcodeの長さの変更（長くする）</li>\n  <li>エラーメッセージの変更</li>\n</ul>\n<h3 id=\"common_response_header\">共通レスポンスヘッダー</h3> <p>すべてのAPIのレスポンスには以下のHTTPヘッダーが含まれます。</p> <ul>\n  <li>\n    <p>X-Freee-Request-ID</p>\n    <ul>\n      <li>各リクエスト毎に発行されるID</li>\n    </ul>\n  </li>\n</ul>\n<h3 id=\"common_error_response\">共通エラーレスポンス</h3> <ul>\n  <li>\n    <p>ステータスコードはレスポンス内のJSONに含まれる他、HTTPヘッダにも含まれます</p>\n  </li>\n  <li>\n    <p>\n      一部のエラーレスポンスにはエラーコードが含まれます。<br>\n      詳細は、<a href=\"https://developer.freee.co.jp/tips/faq/40x-checkpoint\">HTTPステータスコード400台エラー時のチェックポイント</a>を参照してください\n    </p>\n  </li>\n  <p>type</p>\n  <ul>\n    <li>status : HTTPステータスコードの説明</li>\n    <li>validation : エラーの詳細の説明（開発者向け）</li>\n  </ul>\n</ul>\n<p>レスポンスの例</p> <pre><code>  {\n    &quot;status_code&quot; : 400,\n    &quot;errors&quot; : [\n      {\n        &quot;type&quot; : &quot;status&quot;,\n        &quot;messages&quot; : [&quot;不正なリクエストです。&quot;]\n      },\n      {\n        &quot;type&quot; : &quot;validation&quot;,\n        &quot;messages&quot; : [&quot;Date は不正な日付フォーマットです。入力例：'2013-01-01'&quot;]\n      }\n    ]\n  }</code></pre>\n\n<h3 id=\"api_rate_limit\">API使用制限</h3> <p>APIリクエストは1時間で5000回を上限としています。API使用ステータスはレスポンスヘッダに付与されます。<br> 各ヘッダの意味は次のとおりです。</p> <table>\n  <thead>\n    <tr><th>ヘッダ名</th><th>説明</th></tr>\n  </thead>\n  <tbody>\n    <tr><td>X-RateLimit-Limit</td><td>使用回数の上限</td></tr>\n    <tr><td>X-RateLimit-Remaining</td><td>残り使用回数</td></tr>\n    <tr><td>X-RateLimit-Reset</td><td>使用回数がリセットされる時刻</td></tr>\n  </tbody>\n</table>\n<p>上記に加え、freeeは一定期間に過度のアクセスを検知した場合、APIアクセスをコントロールする場合があります。<br> その際のhttp status codeは403となります。制限がかかってから10分程度が過ぎると再度使用することができるようになります。</p>\n<h3 id=\"demo_company\">開発用テスト環境</h3> <p>\n  会計・人事労務のAPIはアプリストアから開発用テスト環境を作成することができますが、freee工数管理の環境には対応しておりません。<br>\n  freee工数管理のお試しをご自身で行っていただいくと、テストに使用できる環境としてお使いいただけます。<br>\n  <br>\n  freee工数管理のお試しは以下の手順で行うことができます。<br>\n  <ol>\n    <li>アプリストアから開発用テスト事業所を作成してください。</li>\n    <li>作成した事業所にログインして、freee工数管理にアクセスしてください。</li>\n    <li>『プランを選択する』をクリックして、必要事項を入力してください。</li>\n    <li>プラン選択画面にてお試しプランを選択してください。</li>\n    <li>freee工数管理がテストに使用できる状態になりました。</li>\n  </ol>\n</p>"
+  },
+  "tags": [
+    {
+      "name": "Users",
+      "description": "ログインユーザー"
+    }
+  ],
+  "servers": [
+    {
+      "url": "https://api.freee.co.jp/pm"
+    }
+  ],
+  "security": [
+    {
+      "oauth2": [
+        "write",
+        "read"
+      ]
+    }
+  ],
+  "paths": {
+    "/users/me": {
+      "get": {
+        "operationId": "/users/me/index",
+        "summary": "ログインユーザー情報の取得",
+        "description": "このリクエストの認可セッションにおけるログインユーザーの情報を返します。 freee工数管理では一人のログインユーザーを複数の事業所に関連付けられるため、このユーザーと関連のあるすべての事業所の情報をリストで返します。 他のAPIのパラメータとして company_id が求められる場合は、このAPIで取得した company_id を使用します。",
+        "tags": [
+          "Users"
+        ],
+        "responses": {
+          "200": {
+            "description": "成功時",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1users~1me/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1users~1me/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects": {
+      "post": {
+        "operationId": "/projects/create",
+        "summary": "プロジェクトの登録",
+        "description": "プロジェクトを登録することができます。",
+        "tags": [
+          "Projects"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/create_project_param"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功時",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "project": {
+                      "$ref": "#/components/schemas/project_detail"
+                    }
+                  },
+                  "required": [
+                    "project"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1users~1me/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1projects/post/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1projects/post/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1projects/post/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1projects/post/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "プロジェクト一覧の取得",
+        "description": "この事業所のプロジェクトの一覧情報を返します。 運用ステータス、マネージャー、発注先、発注元で絞り込みできます。",
+        "tags": [
+          "Projects"
+        ],
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "運用ステータス",
+            "in": "query",
+            "name": "operational_status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "planning",
+                "awaiting_approval",
+                "in_progress",
+                "rejected",
+                "done"
+              ]
+            }
+          },
+          {
+            "description": "マネージャのユーザID",
+            "explode": true,
+            "in": "query",
+            "name": "manager_ids[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "発注元の取引先ID",
+            "explode": true,
+            "in": "query",
+            "name": "orderer_ids[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "発注先の取引先ID",
+            "explode": true,
+            "in": "query",
+            "name": "contractor_ids[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "取得レコードの件数（デフォルト：50, 最小：1, 最大100）",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "description": "取得レコードのオフセット（デフォルト：0）",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9223372036854776000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功時",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/meta"
+                    },
+                    "projects_counts": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "integer",
+                          "description": "取得件数合計",
+                          "example": 10
+                        },
+                        "by_status": {
+                          "type": "object",
+                          "properties": {
+                            "planning": {
+                              "type": "integer",
+                              "description": "計画中件数",
+                              "example": 10
+                            },
+                            "awaiting_approval": {
+                              "type": "integer",
+                              "description": "承認待ち件数",
+                              "example": 10
+                            },
+                            "in_progress": {
+                              "type": "integer",
+                              "description": "運用中件数",
+                              "example": 10
+                            },
+                            "rejected": {
+                              "type": "integer",
+                              "description": "差し戻し件数",
+                              "example": 10
+                            },
+                            "done": {
+                              "type": "integer",
+                              "description": "終了件数",
+                              "example": 10
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "projects": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/project"
+                      }
+                    }
+                  },
+                  "required": [
+                    "projects",
+                    "projects_counts",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1users~1me/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1projects/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1projects/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/projects/{id}": {
+      "get": {
+        "summary": "プロジェクト詳細の取得",
+        "description": "IDに該当するプロジェクトの詳細情報を返します。",
+        "tags": [
+          "Projects"
+        ],
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "プロジェクトID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功時",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "project": {
+                      "$ref": "#/paths/~1projects/post/responses/200/content/application~1json/schema/properties/project"
+                    }
+                  },
+                  "required": [
+                    "project"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1users~1me/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1projects~1%7Bid%7D/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1projects~1%7Bid%7D/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/unit_costs": {
+      "get": {
+        "operationId": "/unit_costs/index",
+        "summary": "単価マスタの取得",
+        "description": "従業員の単価マスタを返します。",
+        "tags": [
+          "UnitCosts"
+        ],
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "取得レコードの件数（デフォルト：50, 最小：1, 最大100）",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "description": "取得レコードのオフセット（デフォルト：0）",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9223372036854776000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功時",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "unit_costs": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/unit_cost"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/paths/~1projects/get/responses/200/content/application~1json/schema/properties/meta"
+                    }
+                  },
+                  "required": [
+                    "unit_costs",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1users~1me/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1unit_costs/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1unit_costs/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/people": {
+      "get": {
+        "summary": "従業員一覧の取得",
+        "description": "このリクエストで指定したIDの事業所の従業員一覧を返します。 権限・ステータス・従業員IDで取得する情報を絞り込むことができます。",
+        "tags": [
+          "People"
+        ],
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "役割",
+            "in": "query",
+            "name": "role",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ステータス（招待中・利用中・無効）",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "sent",
+                "accepted",
+                "inactive"
+              ]
+            }
+          },
+          {
+            "description": "従業員ID",
+            "explode": true,
+            "in": "query",
+            "name": "person_ids[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "取得レコードの件数（デフォルト：50, 最小：1, 最大100）",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "description": "取得レコードのオフセット（デフォルト：0）",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9223372036854776000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功時",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/paths/~1projects/get/responses/200/content/application~1json/schema/properties/meta"
+                    },
+                    "people_counts": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "integer",
+                          "description": "取得件数合計",
+                          "example": 10
+                        },
+                        "by_status": {
+                          "type": "object",
+                          "properties": {
+                            "sent": {
+                              "type": "integer",
+                              "description": "招待済み従業員件数",
+                              "example": 10
+                            },
+                            "accepted": {
+                              "type": "integer",
+                              "description": "利用中従業員件数",
+                              "example": 10
+                            },
+                            "inactive": {
+                              "type": "integer",
+                              "description": "無効従業員件数",
+                              "example": 10
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "people": {
+                      "items": {
+                        "$ref": "#/components/schemas/person"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "people",
+                    "people_counts",
+                    "meta"
+                  ],
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1users~1me/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1people/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1people/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/partners": {
+      "get": {
+        "operationId": "/partners/index",
+        "summary": "取引先の一覧取得",
+        "description": "登録されている取引先の一覧を返します。",
+        "tags": [
+          "Partners"
+        ],
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "取得レコードの件数（デフォルト：50, 最小：1, 最大100）",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "description": "取得レコードのオフセット（デフォルト：0）",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9223372036854776000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功時",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "partners": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/partner"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/paths/~1projects/get/responses/200/content/application~1json/schema/properties/meta"
+                    }
+                  },
+                  "required": [
+                    "partners",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1users~1me/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1partners/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1partners/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workloads": {
+      "post": {
+        "operationId": "/workloads/create",
+        "summary": "工数登録",
+        "description": "工数を登録することが出来ます。",
+        "tags": [
+          "Workloads"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/create_workload_param"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功時",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "workload": {
+                      "$ref": "#/components/schemas/workload"
+                    }
+                  },
+                  "required": [
+                    "workload"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1users~1me/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1workloads/post/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1workloads/post/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1workloads/post/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1workloads/post/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "工数詳細の取得",
+        "description": "取得対象の従業員の工数実績の詳細を返します。 取得対象従業員と年月の取得範囲で絞り込みできます。",
+        "tags": [
+          "Workloads"
+        ],
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "取得対象従業員の検索スコープです。 <ul> <li> allを指定した場合は全従業員が対象です。 絞り込みを行わない場合にご使用ください。 person_ids, team_idsでの絞り込みはできません。 </li> <li> teamを指定した場合はチーム単位で絞り込みが可能です。 team_idsでの絞り込みができます。 person_idsでの絞り込みはできません。 </li> <li> employeeを指定した場合はperson_idsによる絞り込みができます。 team_idsでの絞り込みは行なえません。 </li> <li> scopeを指定しない場合はログインユーザの情報のみの取得です。 </li> </ul>",
+            "in": "query",
+            "name": "employees_scope",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "all",
+                "team",
+                "employee"
+              ]
+            }
+          },
+          {
+            "description": "取得対象従業員のユーザID",
+            "explode": true,
+            "in": "query",
+            "name": "person_ids[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "取得対象のチームID",
+            "explode": true,
+            "in": "query",
+            "name": "team_ids[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "取得対象範囲（YYYY-MM）",
+            "in": "query",
+            "name": "year_month",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "取得レコードの件数（デフォルト：50, 最小：1, 最大100）",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "description": "取得レコードのオフセット（デフォルト：0）",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9223372036854776000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功時",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "workloads": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/paths/~1workloads/post/responses/200/content/application~1json/schema/properties/workload"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/paths/~1projects/get/responses/200/content/application~1json/schema/properties/meta"
+                    }
+                  },
+                  "required": [
+                    "workloads",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1users~1me/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1workloads/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1workloads/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workload_summaries": {
+      "get": {
+        "summary": "工数実績の取得",
+        "description": "取得対象の従業員の工数実績のサマリを返します。 取得対象従業員と年月の取得範囲で絞り込みできます。",
+        "tags": [
+          "Workloads"
+        ],
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "取得対象従業員の検索スコープです。 <ul> <li> allを指定した場合は全従業員が対象です。 絞り込みを行わない場合にご使用ください。 person_ids, team_idsでの絞り込みはできません。 </li> <li> teamを指定した場合はチーム単位で絞り込みが可能です。 team_idsでの絞り込みができます。 person_idsでの絞り込みはできません。 </li> <li> employeeを指定した場合はperson_idsによる絞り込みができます。 team_idsでの絞り込みは行なえません。 </li> <li> scopeを指定しない場合はログインユーザの情報のみの取得です。 </li> </ul>",
+            "in": "query",
+            "name": "employees_scope",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "all",
+                "team",
+                "employee"
+              ]
+            }
+          },
+          {
+            "description": "取得対象従業員のユーザID",
+            "explode": true,
+            "in": "query",
+            "name": "person_ids[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "取得対象のチームID",
+            "explode": true,
+            "in": "query",
+            "name": "team_ids[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "取得対象範囲（YYYY-MM）",
+            "in": "query",
+            "name": "year_month",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "取得レコードの件数（デフォルト：50, 最小：1, 最大100）",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "description": "取得レコードのオフセット（デフォルト：0）",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9223372036854776000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功時",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "workload_summaries": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/workload_summary"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/paths/~1projects/get/responses/200/content/application~1json/schema/properties/meta"
+                    }
+                  },
+                  "required": [
+                    "workload_summaries",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1users~1me/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1workload_summaries/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1workload_summaries/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teams": {
+      "get": {
+        "operationId": "/teams/index",
+        "summary": "チームの一覧取得",
+        "description": "登録されているチームの一覧を返します。",
+        "tags": [
+          "Teams"
+        ],
+        "parameters": [
+          {
+            "description": "事業所ID",
+            "in": "query",
+            "name": "company_id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "取得レコードの件数（デフォルト：50, 最小：1, 最大100）",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "description": "取得レコードのオフセット（デフォルト：0）",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9223372036854776000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功時",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "teams": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/team"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/paths/~1projects/get/responses/200/content/application~1json/schema/properties/meta"
+                    }
+                  },
+                  "required": [
+                    "teams",
+                    "meta"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1users~1me/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1teams/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/paths/~1teams/get/responses/400/content/application~1json/schema"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://accounts.secure.freee.co.jp/public_api/authorize",
+            "tokenUrl": "https://accounts.secure.freee.co.jp/public_api/token",
+            "scopes": {
+              "write": "データの書き込み",
+              "read": "データの読み取り"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "user": {
+        "type": "object",
+        "description": "ログインユーザー情報",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "ユーザーID",
+            "example": 1
+          },
+          "companies": {
+            "type": "array",
+            "description": "ユーザーが属する事業所の一覧",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "description": "事業所ID",
+                  "example": 1
+                },
+                "name": {
+                  "type": "string",
+                  "description": "事業所名",
+                  "example": "フリー株式会社"
+                },
+                "display_name": {
+                  "type": "string",
+                  "description": "事業所に所属する従業員の表示名",
+                  "example": "フリー株式会社"
+                },
+                "role": {
+                  "type": "string",
+                  "description": "事業所におけるロール",
+                  "example": "company_admin"
+                },
+                "external_cid": {
+                  "type": "string",
+                  "description": "事業所番号(半角英数字10桁)",
+                  "example": "1234567890"
+                },
+                "person_me": {
+                  "type": "object",
+                  "description": "ログインユーザー情報",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "従業員ID",
+                      "example": 1
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "氏名",
+                      "example": "“田中太郎”"
+                    },
+                    "email": {
+                      "type": "string",
+                      "description": "メールアドレス",
+                      "example": "test@example.com"
+                    },
+                    "role": {
+                      "type": "string",
+                      "description": "事業所におけるロール",
+                      "example": "company_admin"
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "ステータス",
+                      "example": "accepted"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "project": {
+        "type": "object",
+        "description": "プロジェクト",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "プロジェクトID",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "プロジェクト名",
+            "example": "PJ-AAA"
+          },
+          "code": {
+            "type": "string",
+            "description": "プロジェクトコード",
+            "example": "PJ-AAA"
+          },
+          "description": {
+            "type": "string",
+            "description": "プロジェクト概要",
+            "example": "プロジェクトの概要",
+            "nullable": true
+          },
+          "manager": {
+            "type": "object",
+            "description": "プロジェクトマネージャー",
+            "properties": {
+              "person_id": {
+                "type": "integer",
+                "description": "ユーザID",
+                "example": 1
+              },
+              "person_name": {
+                "type": "string",
+                "description": "氏名",
+                "example": "テスト太郎"
+              }
+            }
+          },
+          "color": {
+            "type": "string",
+            "description": "カラー",
+            "example": "#c8790f"
+          },
+          "from_date": {
+            "type": "string",
+            "description": "期間from",
+            "example": "2021-01-01"
+          },
+          "thru_date": {
+            "type": "string",
+            "description": "期間to",
+            "example": "2021-12-31"
+          },
+          "publish_to_employee": {
+            "type": "boolean",
+            "description": "従業員への公開設定",
+            "example": true
+          },
+          "assignment_url_enabled": {
+            "type": "boolean",
+            "description": "招待リンク",
+            "example": false
+          },
+          "operational_status": {
+            "type": "string",
+            "description": "運用ステータス",
+            "example": "in_progress"
+          },
+          "sales_order_status": {
+            "type": "string",
+            "description": "受注ステータス",
+            "example": "受注済み"
+          },
+          "members": {
+            "type": "array",
+            "description": "プロジェクトメンバー",
+            "items": {
+              "type": "object",
+              "properties": {
+                "person_id": {
+                  "type": "integer",
+                  "description": "ユーザID",
+                  "example": 1
+                },
+                "person_name": {
+                  "type": "string",
+                  "description": "氏名",
+                  "example": "田中太郎"
+                }
+              }
+            }
+          },
+          "orderers": {
+            "type": "array",
+            "description": "発注元",
+            "items": {
+              "type": "object",
+              "properties": {
+                "partner_id": {
+                  "type": "integer",
+                  "description": "取引先ID",
+                  "example": 1
+                },
+                "partner_name": {
+                  "type": "string",
+                  "description": "取引先名",
+                  "example": "XX株式会社"
+                },
+                "partner_code": {
+                  "type": "string",
+                  "description": "取引先コード",
+                  "example": "CORP-XX",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "contractors": {
+            "type": "array",
+            "description": "発注先",
+            "items": {
+              "type": "object",
+              "properties": {
+                "partner_id": {
+                  "type": "integer",
+                  "description": "取引先ID",
+                  "example": 2
+                },
+                "partner_name": {
+                  "type": "string",
+                  "description": "取引先名",
+                  "example": "CORP-YY"
+                },
+                "partner_code": {
+                  "type": "string",
+                  "description": "取引先コード",
+                  "example": "YY株式会社",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "project_tags": {
+            "type": "array",
+            "description": "プロジェクトタグ",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tag_group_name": {
+                  "type": "string",
+                  "description": "タググループ名",
+                  "example": "タググループA"
+                },
+                "tag_name": {
+                  "type": "string",
+                  "description": "タグ名",
+                  "example": "タグA",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "workload_tag_groups": {
+            "type": "array",
+            "description": "プロジェクトで使える工数タグのグループ",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tag_group_id": {
+                  "type": "integer",
+                  "description": "タググループID",
+                  "example": 1
+                },
+                "tag_group_name": {
+                  "type": "string",
+                  "description": "タググループ名",
+                  "example": "タググループA"
+                },
+                "required": {
+                  "type": "boolean",
+                  "description": "工数登録時に必須かどうかのフラグ",
+                  "example": true
+                },
+                "tags": {
+                  "type": "array",
+                  "description": "タグ",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "description": "タグID",
+                        "example": 1
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "タグ名",
+                        "example": "タグA"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "create_project_param": {
+        "type": "object",
+        "description": "プロジェクト情報",
+        "properties": {
+          "company_id": {
+            "description": "事業所ID",
+            "format": "int32",
+            "type": "integer",
+            "example": 1
+          },
+          "name": {
+            "description": "プロジェクト名",
+            "type": "string"
+          },
+          "code": {
+            "description": "プロジェクトコード",
+            "type": "string"
+          },
+          "description": {
+            "description": "プロジェクト概要",
+            "type": "string"
+          },
+          "from_date": {
+            "description": "プロジェクト開始日",
+            "type": "string"
+          },
+          "thru_date": {
+            "description": "プロジェクト終了日",
+            "type": "string"
+          },
+          "publish_to_employee": {
+            "description": "従業員への公開設定\n公開するとプロジェクト一覧に表示され、従業員がアサインリクエストを送れるようになります。（詳細画面は閲覧不可）",
+            "type": "boolean"
+          },
+          "assignment_url_enabled": {
+            "description": "プロジェクトの招待リンク機能設定\nプロジェクトの招待リンクを発行できるようにするかどうかを設定します。",
+            "type": "boolean"
+          },
+          "sales_order_status_id": {
+            "description": "受注ステータスID",
+            "format": "int32",
+            "type": "integer",
+            "example": 2
+          },
+          "manager_person_id": {
+            "description": "プロジェクトマネージャーの従業員ID\nこのパラメータはシステム管理者かプロジェクトマネージャーでログインしているときのみ指定可能。\n（デフォルト：指定しない場合はログインユーザ）",
+            "format": "int32",
+            "type": "integer",
+            "example": 10,
+            "nullable": true
+          },
+          "pm_budgets_cost": {
+            "description": "プロジェクトマネージャーのコスト(円)",
+            "format": "int32",
+            "type": "integer",
+            "example": 4000
+          },
+          "color_id": {
+            "description": "プロジェクトの色を指定可能（デフォルト：orange）\n{ orange: 1, blue_green: 2, green: 3, blue: 4, purple: 5, red: 6, yellow: 7 }",
+            "format": "int32",
+            "type": "integer",
+            "example": 3
+          },
+          "members": {
+            "description": "アサインするユーザの配列",
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "person_id": {
+                  "description": "従業員ID",
+                  "format": "int32",
+                  "type": "integer",
+                  "example": 11
+                },
+                "unit_cost_id": {
+                  "description": "このプロジェクトでの実績単価ID",
+                  "format": "int32",
+                  "type": "integer",
+                  "example": 3
+                },
+                "budgets_cost": {
+                  "description": "予算計算用の単価(円)",
+                  "format": "int32",
+                  "type": "integer",
+                  "example": 2000
+                },
+                "use_standard_unit_cost": {
+                  "description": "標準従業員単価の利用（デフォルト：false）",
+                  "type": "boolean",
+                  "example": true
+                }
+              },
+              "required": [
+                "person_id",
+                "unit_cost_id",
+                "budgets_cost"
+              ]
+            }
+          },
+          "orderer_ids": {
+            "description": "発注元として指定する取引先IDの配列",
+            "items": {
+              "type": "integer",
+              "example": 20
+            },
+            "type": "array"
+          },
+          "contractor_ids": {
+            "description": "発注先として指定する取引先IDの配列",
+            "items": {
+              "type": "integer",
+              "example": 10
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "company_id",
+          "name",
+          "code",
+          "from_date",
+          "thru_date",
+          "pm_budgets_cost"
+        ]
+      },
+      "project_detail": {
+        "type": "object",
+        "description": "プロジェクト",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "プロジェクトID",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "プロジェクト名",
+            "example": "PJ-AAA"
+          },
+          "code": {
+            "type": "string",
+            "description": "プロジェクトコード",
+            "example": "PJ-AAA"
+          },
+          "description": {
+            "type": "string",
+            "description": "プロジェクト概要",
+            "example": "プロジェクトの概要",
+            "nullable": true
+          },
+          "manager": {
+            "type": "object",
+            "description": "プロジェクトマネージャー",
+            "properties": {
+              "person_id": {
+                "type": "integer",
+                "description": "ユーザID",
+                "example": 1
+              },
+              "person_name": {
+                "type": "string",
+                "description": "氏名",
+                "example": "テスト太郎"
+              }
+            }
+          },
+          "color": {
+            "type": "string",
+            "description": "カラー",
+            "example": "#c8790f"
+          },
+          "from_date": {
+            "type": "string",
+            "description": "期間from",
+            "example": "2021-01-01"
+          },
+          "thru_date": {
+            "type": "string",
+            "description": "期間to",
+            "example": "2021-12-31"
+          },
+          "publish_to_employee": {
+            "type": "boolean",
+            "description": "従業員への公開設定",
+            "example": true
+          },
+          "assignment_url_enabled": {
+            "type": "boolean",
+            "description": "招待リンク",
+            "example": false
+          },
+          "operational_status": {
+            "type": "string",
+            "description": "運用ステータス",
+            "example": "in_progress"
+          },
+          "sales_order_status": {
+            "type": "string",
+            "description": "受注ステータス",
+            "example": "受注済み"
+          },
+          "members": {
+            "type": "array",
+            "description": "プロジェクトメンバー",
+            "items": {
+              "type": "object",
+              "properties": {
+                "person_id": {
+                  "type": "integer",
+                  "description": "ユーザID",
+                  "example": 1
+                },
+                "person_name": {
+                  "type": "string",
+                  "description": "氏名",
+                  "example": "田中太郎"
+                }
+              }
+            }
+          },
+          "orderers": {
+            "type": "array",
+            "description": "発注元",
+            "items": {
+              "type": "object",
+              "properties": {
+                "partner_id": {
+                  "type": "integer",
+                  "description": "取引先ID",
+                  "example": 1
+                },
+                "partner_name": {
+                  "type": "string",
+                  "description": "取引先名",
+                  "example": "XX株式会社"
+                },
+                "code": {
+                  "type": "string",
+                  "description": "取引先コード",
+                  "example": "CORP-XX",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "contractors": {
+            "type": "array",
+            "description": "発注先",
+            "items": {
+              "type": "object",
+              "properties": {
+                "partner_id": {
+                  "type": "integer",
+                  "description": "取引先ID",
+                  "example": 2
+                },
+                "partner_name": {
+                  "type": "string",
+                  "description": "取引先名",
+                  "example": "CORP-YY"
+                },
+                "code": {
+                  "type": "string",
+                  "description": "取引先コード",
+                  "example": "YY株式会社",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "balance": {
+            "type": "object",
+            "description": "収支管理詳細",
+            "properties": {
+              "labor_costs": {
+                "type": "object",
+                "description": "人件費",
+                "properties": {
+                  "total": {
+                    "type": "object",
+                    "description": "全体",
+                    "properties": {
+                      "budget": {
+                        "type": "integer",
+                        "description": "予算",
+                        "example": 100000
+                      },
+                      "actual_result": {
+                        "type": "integer",
+                        "description": "実績",
+                        "example": 100000
+                      }
+                    }
+                  },
+                  "monthly": {
+                    "type": "array",
+                    "description": "各月",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "year_month": {
+                          "type": "string",
+                          "description": "年月（YYYY-MM）",
+                          "example": "2021-01"
+                        },
+                        "budget": {
+                          "type": "integer",
+                          "description": "予算",
+                          "example": 100000
+                        },
+                        "actual_result": {
+                          "type": "integer",
+                          "description": "実績",
+                          "example": 100000
+                        }
+                      }
+                    }
+                  },
+                  "details": {
+                    "type": "array",
+                    "description": "各メンバーの内訳",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "person_id": {
+                          "type": "integer",
+                          "description": "ユーザーID",
+                          "example": 1
+                        },
+                        "person_name": {
+                          "type": "string",
+                          "description": "ユーザー名",
+                          "example": "テスト太郎"
+                        },
+                        "total": {
+                          "type": "object",
+                          "properties": {
+                            "budget": {
+                              "type": "object",
+                              "description": "予算",
+                              "properties": {
+                                "cost": {
+                                  "type": "integer",
+                                  "description": "金額",
+                                  "example": 100000
+                                },
+                                "minutes": {
+                                  "type": "integer",
+                                  "description": "時間",
+                                  "example": 9600
+                                }
+                              }
+                            },
+                            "actual_result": {
+                              "type": "object",
+                              "description": "実績",
+                              "properties": {
+                                "cost": {
+                                  "type": "integer",
+                                  "description": "金額",
+                                  "example": 100000
+                                },
+                                "minutes": {
+                                  "type": "integer",
+                                  "description": "時間",
+                                  "example": 9600
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "monthly": {
+                          "type": "array",
+                          "description": "各月",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "year_month": {
+                                "type": "string",
+                                "description": "年月（YYYY-MM）",
+                                "example": "2021-01"
+                              },
+                              "budget": {
+                                "type": "object",
+                                "description": "予算",
+                                "properties": {
+                                  "cost": {
+                                    "type": "integer",
+                                    "description": "金額",
+                                    "example": 100000
+                                  },
+                                  "minutes": {
+                                    "type": "integer",
+                                    "description": "時間",
+                                    "example": 9600
+                                  }
+                                }
+                              },
+                              "actual_result": {
+                                "type": "object",
+                                "description": "実績",
+                                "properties": {
+                                  "cost": {
+                                    "type": "integer",
+                                    "description": "金額",
+                                    "example": 100000
+                                  },
+                                  "minutes": {
+                                    "type": "integer",
+                                    "description": "時間",
+                                    "example": 9600
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "unit_cost": {
+        "type": "object",
+        "description": "従業員単価マスタ",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "単価マスタID",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "単価マスタ名",
+            "example": "サンプル単価"
+          },
+          "current_cost": {
+            "type": "integer",
+            "description": "取得時点での適用金額",
+            "example": 2000
+          },
+          "rules": {
+            "type": "array",
+            "description": "期間ごとの適用金額の配列",
+            "items": {
+              "type": "object",
+              "properties": {
+                "from_date": {
+                  "description": "適用開始日",
+                  "type": "string",
+                  "format": "date",
+                  "example": "2020-01-01"
+                },
+                "thru_date": {
+                  "description": "適用日終了日",
+                  "type": "string",
+                  "format": "date",
+                  "example": "2020-12-31"
+                },
+                "cost": {
+                  "type": "integer",
+                  "description": "適用期間の金額",
+                  "example": 3000
+                }
+              }
+            }
+          }
+        }
+      },
+      "person": {
+        "type": "object",
+        "description": "従業員情報",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "従業員ID",
+            "example": 1
+          },
+          "status": {
+            "type": "string",
+            "description": "ステータス",
+            "example": "accepted"
+          },
+          "name": {
+            "type": "string",
+            "description": "氏名",
+            "example": "田中太郎"
+          },
+          "role": {
+            "type": "string",
+            "description": "事業所におけるロール",
+            "example": "company_admin"
+          },
+          "role_display_name": {
+            "type": "string",
+            "description": "事業所におけるロールの表示名",
+            "example": "システム管理者"
+          },
+          "unit_cost": {
+            "type": "object",
+            "description": "標準単価",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "標準単価ID",
+                "example": 1
+              },
+              "name": {
+                "type": "string",
+                "description": "名前",
+                "example": "サンプル単価"
+              }
+            }
+          },
+          "email": {
+            "type": "string",
+            "description": "メールアドレス",
+            "example": "test@example.com"
+          },
+          "payroll_employee_id": {
+            "type": "integer",
+            "description": "人事労務側従業員ID",
+            "example": 1
+          }
+        }
+      },
+      "partner": {
+        "type": "object",
+        "description": "取引先情報",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "取引先ID",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "取引先名前",
+            "example": "〇〇株式会社"
+          },
+          "code": {
+            "type": "string",
+            "description": "取引先code",
+            "example": "001-〇〇株式会社-B",
+            "nullable": true
+          },
+          "projects_as_orderer": {
+            "type": "array",
+            "description": "発注元として登録されているプロジェクト一覧",
+            "items": {
+              "type": "object",
+              "properties": {
+                "project_id": {
+                  "type": "integer",
+                  "description": "プロジェクトID",
+                  "example": 1
+                },
+                "project_name": {
+                  "type": "string",
+                  "description": "プロジェクト名",
+                  "example": "プロジェクトX"
+                }
+              }
+            }
+          },
+          "projects_as_contractor": {
+            "type": "array",
+            "description": "発注先として登録されているプロジェクト一覧",
+            "items": {
+              "type": "object",
+              "properties": {
+                "project_id": {
+                  "type": "integer",
+                  "description": "プロジェクトID",
+                  "example": 1
+                },
+                "project_name": {
+                  "type": "string",
+                  "description": "プロジェクト名",
+                  "example": "プロジェクトX"
+                }
+              }
+            }
+          }
+        }
+      },
+      "workload": {
+        "type": "object",
+        "description": "工数実績詳細",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "工数実績ID",
+            "example": 1
+          },
+          "person_id": {
+            "type": "integer",
+            "description": "対象従業員のユーザーID",
+            "example": 1
+          },
+          "person_name": {
+            "type": "string",
+            "description": "対象従業員氏名",
+            "example": "テスト太郎"
+          },
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "工数登録日",
+            "example": "2021-01-01"
+          },
+          "project_id": {
+            "description": "対象プロジェクトID",
+            "format": "int32",
+            "type": "integer",
+            "example": 100
+          },
+          "project_name": {
+            "type": "string",
+            "description": "プロジェクト名",
+            "example": "プロジェクトA"
+          },
+          "project_code": {
+            "type": "string",
+            "description": "プロジェクトコード",
+            "example": "PRJ-A"
+          },
+          "memo": {
+            "type": "string",
+            "description": "業務内容",
+            "example": "会議"
+          },
+          "minutes": {
+            "type": "integer",
+            "description": "工数実績（分）",
+            "example": 9600
+          },
+          "workload_tags": {
+            "type": "array",
+            "description": "工数タグ",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tag_group_id": {
+                  "type": "integer",
+                  "description": "タググループのID",
+                  "example": 11
+                },
+                "tag_group_name": {
+                  "type": "string",
+                  "description": "タググループ名",
+                  "example": "タググループA"
+                },
+                "tag_id": {
+                  "type": "integer",
+                  "description": "タグのID",
+                  "example": 12,
+                  "nullable": true
+                },
+                "tag_name": {
+                  "type": "string",
+                  "description": "タグ名",
+                  "example": "タグA",
+                  "nullable": true
+                }
+              },
+              "required": [
+                "tag_group_id",
+                "tag_group_name"
+              ]
+            }
+          }
+        },
+        "required": [
+          "person_id",
+          "person_name",
+          "project_id",
+          "project_name",
+          "project_code",
+          "date",
+          "minutes"
+        ]
+      },
+      "create_workload_param": {
+        "type": "object",
+        "description": "工数情報",
+        "properties": {
+          "company_id": {
+            "description": "事業所ID",
+            "format": "int32",
+            "type": "integer",
+            "example": 1
+          },
+          "person_id": {
+            "description": "\n対象従業員ID\nこのパラメータは管理者かチームリーダーでログインしているときのみ指定可能。\n指定しない場合はログインユーザに登録",
+            "format": "int32",
+            "type": "integer",
+            "example": 10
+          },
+          "project_id": {
+            "description": "対象プロジェクトID",
+            "format": "int32",
+            "type": "integer",
+            "example": 100
+          },
+          "date": {
+            "description": "対象日",
+            "type": "string",
+            "format": "date",
+            "example": "2020-12-15"
+          },
+          "minutes": {
+            "description": "記録時間（分）",
+            "format": "int32",
+            "type": "integer",
+            "minimum": 1,
+            "example": 120
+          },
+          "memo": {
+            "description": "業務内容",
+            "type": "string",
+            "maxLength": 255,
+            "example": "コーディング"
+          },
+          "workload_tags": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tag_group_id": {
+                  "description": "工数タググループID",
+                  "format": "int32",
+                  "type": "integer",
+                  "example": 11
+                },
+                "tag_id": {
+                  "description": "工数タグID",
+                  "format": "int32",
+                  "type": "integer",
+                  "example": 12
+                }
+              },
+              "required": [
+                "tag_group_id",
+                "tag_id"
+              ]
+            }
+          }
+        },
+        "required": [
+          "company_id",
+          "project_id",
+          "date",
+          "minutes"
+        ]
+      },
+      "workload_summary": {
+        "type": "object",
+        "description": "工数実績サマリ",
+        "properties": {
+          "person_id": {
+            "type": "integer",
+            "description": "対象従業員のユーザーid",
+            "example": 1
+          },
+          "person_name": {
+            "type": "string",
+            "description": "対象従業員氏名",
+            "example": "テスト太郎"
+          },
+          "from_date": {
+            "type": "string",
+            "description": "工数登録期間from",
+            "example": "2021-01-01"
+          },
+          "thru_date": {
+            "type": "string",
+            "description": "工数登録期間to",
+            "example": "2021-12-31"
+          },
+          "minutes": {
+            "type": "integer",
+            "description": "工数実績（分）",
+            "example": 9600
+          },
+          "productive_minutes": {
+            "type": "integer",
+            "description": "生産時間実績（分）",
+            "example": 6000
+          }
+        }
+      },
+      "team": {
+        "type": "object",
+        "description": "チーム情報",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "チームID",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "チーム名",
+            "example": "プロジェクトX開発チーム"
+          },
+          "memo": {
+            "type": "string",
+            "description": "memo",
+            "example": "社長室直轄",
+            "nullable": true
+          },
+          "member_count": {
+            "type": "integer",
+            "description": "メンバー数",
+            "example": 10
+          },
+          "members": {
+            "type": "array",
+            "description": "チームに登録されているメンバーの配列",
+            "items": {
+              "type": "object",
+              "properties": {
+                "person_id": {
+                  "type": "integer",
+                  "description": "チームに所属している従業員ID",
+                  "example": 1
+                },
+                "person_name": {
+                  "type": "string",
+                  "description": "チームに所属している従業員名",
+                  "example": "田中太郎"
+                },
+                "is_leader": {
+                  "type": "boolean",
+                  "description": "リーダフラグ、リーダならばtrue",
+                  "example": true
+                }
+              },
+              "required": [
+                "person_id",
+                "person_name",
+                "is_leader"
+              ]
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "member_count"
+        ]
+      },
+      "error": {
+        "type": "object",
+        "properties": {
+          "status_code": {
+            "type": "integer",
+            "example": 400
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "messages": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "example": "リクエストの形式が不正です。"
+                  }
+                },
+                "type": {
+                  "type": "string",
+                  "example": "validate",
+                  "enum": [
+                    "status",
+                    "validate",
+                    "error",
+                    "unauthorized",
+                    "record_not_found",
+                    "payment_required"
+                  ]
+                },
+                "codes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "example": "company_not_found"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "meta": {
+        "type": "object",
+        "description": "ページネーションのメタ情報",
+        "properties": {
+          "current_offset": {
+            "type": "integer",
+            "description": "リクエストのオフセット件数",
+            "example": 50
+          },
+          "next_offset": {
+            "type": "integer",
+            "description": "次ページのオフセット件数",
+            "example": 100,
+            "nullable": true
+          },
+          "prev_offset": {
+            "type": "integer",
+            "description": "前ページのオフセット件数",
+            "example": 0,
+            "nullable": true
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "全レコード件数",
+            "example": 200
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -7,8 +7,9 @@ export async function makeApiRequest(
   path: string,
   params?: Record<string, unknown>,
   body?: Record<string, unknown>,
+  baseUrl?: string,
 ): Promise<unknown> {
-  const baseUrl = config.freee.apiUrl;
+  const apiUrl = baseUrl || config.freee.apiUrl;
   const companyId = await getCurrentCompanyId();
 
   const accessToken = await getValidAccessToken();
@@ -21,7 +22,7 @@ export async function makeApiRequest(
     );
   }
 
-  const url = new URL(path, baseUrl);
+  const url = new URL(path, apiUrl);
   if (params) {
     Object.entries(params).forEach(([key, value]) => {
       if (value !== undefined) {

--- a/src/openapi/client-mode.ts
+++ b/src/openapi/client-mode.ts
@@ -1,104 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import freeeApiSchema from '../data/freee-api-schema.json';
-import { OpenAPIOperation, OpenAPIPathItem } from '../api/types.js';
 import { makeApiRequest } from '../api/client.js';
-
-interface PathValidationResult {
-  isValid: boolean;
-  message: string;
-  operation?: OpenAPIOperation;
-  actualPath?: string;
-}
-
-/**
- * Validates if a given path and method exist in the OpenAPI schema
- * Supports path parameters like /api/1/deals/{id}
- */
-export function validatePath(method: string, path: string): PathValidationResult {
-  const paths = freeeApiSchema.paths;
-  const normalizedMethod = method.toLowerCase();
-
-  // Try exact match first
-  if (path in paths) {
-    const pathItem = paths[path as keyof typeof paths] as OpenAPIPathItem;
-    if (normalizedMethod in pathItem) {
-      return {
-        isValid: true,
-        message: 'Valid path and method',
-        operation: pathItem[normalizedMethod as keyof OpenAPIPathItem] as OpenAPIOperation,
-        actualPath: path,
-      };
-    }
-  }
-
-  // Try pattern matching for paths with parameters
-  const pathKeys = Object.keys(paths);
-  for (const schemaPath of pathKeys) {
-    // Convert OpenAPI path pattern to regex
-    // /api/1/deals/{id} -> /api/1/deals/[^/]+
-    const pattern = schemaPath.replace(/\{[^}]+\}/g, '[^/]+');
-    const regex = new RegExp(`^${pattern}$`);
-
-    if (regex.test(path)) {
-      const pathItem = paths[schemaPath as keyof typeof paths] as OpenAPIPathItem;
-      if (normalizedMethod in pathItem) {
-        return {
-          isValid: true,
-          message: 'Valid path and method',
-          operation: pathItem[normalizedMethod as keyof OpenAPIPathItem] as OpenAPIOperation,
-          actualPath: path,
-        };
-      }
-    }
-  }
-
-  // Path not found, provide helpful error
-  const availableMethods = Object.keys(paths)
-    .filter((p) => {
-      const pattern = p.replace(/\{[^}]+\}/g, '[^/]+');
-      const regex = new RegExp(`^${pattern}$`);
-      return regex.test(path);
-    })
-    .flatMap((p) => {
-      const pathItem = paths[p as keyof typeof paths] as OpenAPIPathItem;
-      return Object.keys(pathItem).filter((m) =>
-        ['get', 'post', 'put', 'delete', 'patch'].includes(m)
-      );
-    });
-
-  if (availableMethods.length > 0) {
-    return {
-      isValid: false,
-      message: `Method '${method}' not found for path '${path}'. Available methods: ${availableMethods.join(', ')}`,
-    };
-  }
-
-  return {
-    isValid: false,
-    message: `Path '${path}' not found in OpenAPI schema. Please check the path format.`,
-  };
-}
-
-/**
- * Lists all available paths in the OpenAPI schema
- */
-export function listAvailablePaths(): string {
-  const paths = freeeApiSchema.paths;
-  const pathList: string[] = [];
-
-  Object.entries(paths).forEach(([path, pathItem]) => {
-    const methods = Object.keys(pathItem as OpenAPIPathItem)
-      .filter((m) => ['get', 'post', 'put', 'delete', 'patch'].includes(m))
-      .map((m) => m.toUpperCase());
-
-    if (methods.length > 0) {
-      pathList.push(`${methods.join('|')} ${path}`);
-    }
-  });
-
-  return pathList.sort().join('\n');
-}
+import { validatePathAcrossApis, listAllAvailablePaths } from './schema-loader.js';
 
 /**
  * Creates a tool handler for a specific HTTP method
@@ -113,8 +16,8 @@ function createMethodTool(method: string): (args: { path: string; query?: Record
     try {
       const { path, query, body } = args;
 
-      // Validate path against OpenAPI schema
-      const validation = validatePath(method, path);
+      // Validate path against all OpenAPI schemas
+      const validation = validatePathAcrossApis(method, path);
       if (!validation.isValid) {
         return {
           content: [
@@ -127,12 +30,13 @@ function createMethodTool(method: string): (args: { path: string; query?: Record
         };
       }
 
-      // Make API request
+      // Make API request with the correct base URL
       const result = await makeApiRequest(
         method,
         validation.actualPath!,
         query,
         body,
+        validation.baseUrl,
       );
 
       return {
@@ -221,15 +125,15 @@ export function generateClientModeTool(server: McpServer): void {
   // Add helper tool to list available paths
   server.tool(
     'freee_api_list_paths',
-    'freee APIで利用可能なすべてのエンドポイントパスとHTTPメソッドの一覧を表示します。',
+    'freee APIで利用可能なすべてのエンドポイントパスとHTTPメソッドの一覧を表示します。会計、人事労務、請求書、工数管理の全APIに対応しています。',
     {},
     async () => {
-      const pathsList = listAvailablePaths();
+      const pathsList = listAllAvailablePaths();
       return {
         content: [
           {
             type: 'text' as const,
-            text: `# freee API 利用可能なエンドポイント一覧\n\n${pathsList}\n\n` +
+            text: `# freee API 利用可能なエンドポイント一覧${pathsList}\n\n` +
                   `💡 使用例:\n` +
                   `freee_api_get { "path": "/api/1/deals", "query": { "limit": 10 } }\n` +
                   `freee_api_post { "path": "/api/1/deals", "body": { "issue_date": "2024-01-01", ... } }`,

--- a/src/openapi/converter.ts
+++ b/src/openapi/converter.ts
@@ -1,88 +1,97 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import freeeApiSchema from '../data/freee-api-schema.json';
 import { OpenAPIOperation, OpenAPIPathItem, OpenAPIParameter } from '../api/types.js';
 import { convertParameterToZodSchema, convertPathToToolName, sanitizePropertyName } from './schema.js';
 import { makeApiRequest } from '../api/client.js';
+import { getAllSchemas } from './schema-loader.js';
 
 export function generateToolsFromOpenApi(server: McpServer): void {
-  const paths = freeeApiSchema.paths;
+  // Generate tools from all API schemas
+  const allSchemas = getAllSchemas();
 
-  const orderedPathKeys = Object.keys(paths).sort() as (keyof typeof paths)[];
+  allSchemas.forEach(({ apiType, config }) => {
+    const paths = config.schema.paths;
+    const prefix = config.prefix;
+    const baseUrl = config.baseUrl;
 
-  orderedPathKeys.forEach((pathKey) => {
-    const pathItem: OpenAPIPathItem = paths[pathKey];
-    Object.entries(pathItem).forEach(([method, operation]: [string, OpenAPIOperation]) => {
-      const toolName = `${method}_${convertPathToToolName(pathKey)}`;
-      const description = operation.summary || operation.description || '';
+    const orderedPathKeys = Object.keys(paths).sort();
 
-      const parameterSchema: Record<string, z.ZodType> = {};
+    orderedPathKeys.forEach((pathKey) => {
+      const pathItem: OpenAPIPathItem = paths[pathKey];
+      Object.entries(pathItem).forEach(([method, operation]: [string, OpenAPIOperation]) => {
+        // Add API prefix to tool name
+        const toolName = `${prefix}_${method}_${convertPathToToolName(pathKey)}`;
+        const description = `[${config.name}] ${operation.summary || operation.description || ''}`;
 
-      const pathParams = operation.parameters?.filter((p) => p.in === 'path') || [];
-      pathParams.forEach((param) => {
-        parameterSchema[sanitizePropertyName(param.name)] = convertParameterToZodSchema(param);
-      });
+        const parameterSchema: Record<string, z.ZodType> = {};
 
-      const queryParams = operation.parameters?.filter((p) => p.in === 'query') || [];
-      queryParams.forEach((param) => {
-        let schema = convertParameterToZodSchema(param);
-        if (param.name === 'company_id') {
-          schema = schema.optional();
+        const pathParams = operation.parameters?.filter((p) => p.in === 'path') || [];
+        pathParams.forEach((param) => {
+          parameterSchema[sanitizePropertyName(param.name)] = convertParameterToZodSchema(param);
+        });
+
+        const queryParams = operation.parameters?.filter((p) => p.in === 'query') || [];
+        queryParams.forEach((param) => {
+          let schema = convertParameterToZodSchema(param);
+          if (param.name === 'company_id') {
+            schema = schema.optional();
+          }
+          parameterSchema[sanitizePropertyName(param.name)] = schema;
+        });
+
+        let bodySchema = z.any();
+        if (method === 'post' || method === 'put') {
+          const requestBody = operation.requestBody?.content?.['application/json']?.schema;
+          if (requestBody) {
+            parameterSchema['body'] = bodySchema.describe('Request body');
+          }
         }
-        parameterSchema[sanitizePropertyName(param.name)] = schema;
-      });
 
-      let bodySchema = z.any();
-      if (method === 'post' || method === 'put') {
-        const requestBody = operation.requestBody?.content?.['application/json']?.schema;
-        if (requestBody) {
-          parameterSchema['body'] = bodySchema.describe('Request body');
-        }
-      }
+        server.tool(toolName, description, parameterSchema, async (params) => {
+          try {
+            let actualPath = pathKey as string;
+            pathParams.forEach((param: OpenAPIParameter) => {
+              const sanitizedName = sanitizePropertyName(param.name);
+              actualPath = actualPath.replace(`{${param.name}}`, String(params[sanitizedName]));
+            });
 
-      server.tool(toolName, description, parameterSchema, async (params) => {
-        try {
-          let actualPath = pathKey as string;
-          pathParams.forEach((param: OpenAPIParameter) => {
-            const sanitizedName = sanitizePropertyName(param.name);
-            actualPath = actualPath.replace(`{${param.name}}`, String(params[sanitizedName]));
-          });
+            const queryParameters: Record<string, unknown> = {};
+            queryParams.forEach((param: OpenAPIParameter) => {
+              const sanitizedName = sanitizePropertyName(param.name);
+              if (params[sanitizedName] !== undefined) {
+                queryParameters[param.name] = params[sanitizedName];
+              }
+            });
 
-          const queryParameters: Record<string, unknown> = {};
-          queryParams.forEach((param: OpenAPIParameter) => {
-            const sanitizedName = sanitizePropertyName(param.name);
-            if (params[sanitizedName] !== undefined) {
-              queryParameters[param.name] = params[sanitizedName];
-            }
-          });
+            const bodyParameters =
+              method === 'post' || method === 'put' ? params.body : undefined;
+            const result = await makeApiRequest(
+              method.toUpperCase(),
+              actualPath,
+              queryParameters,
+              bodyParameters,
+              baseUrl, // Use the API-specific base URL
+            );
 
-          const bodyParameters =
-            method === 'post' || method === 'put' ? params.body : undefined;
-          const result = await makeApiRequest(
-            method.toUpperCase(),
-            actualPath,
-            queryParameters,
-            bodyParameters,
-          );
-
-          return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify(result, null, 2),
-              },
-            ],
-          };
-        } catch (error) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Error: ${error instanceof Error ? error.message : String(error)}`,
-              },
-            ],
-          };
-        }
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(result, null, 2),
+                },
+              ],
+            };
+          } catch (error) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+                },
+              ],
+            };
+          }
+        });
       });
     });
   });

--- a/src/openapi/schema-loader.ts
+++ b/src/openapi/schema-loader.ts
@@ -1,0 +1,146 @@
+import accountingSchema from '../../openapi/accounting-api-schema.json';
+import hrSchema from '../../openapi/hr-api-schema.json';
+import invoiceSchema from '../../openapi/invoice-api-schema.json';
+import pmSchema from '../../openapi/pm-api-schema.json';
+import { OpenAPIOperation, OpenAPIPathItem } from '../api/types.js';
+
+export type ApiType = 'accounting' | 'hr' | 'invoice' | 'pm';
+
+export interface ApiConfig {
+  schema: {
+    paths: Record<string, OpenAPIPathItem>;
+  };
+  baseUrl: string;
+  prefix: string;
+  name: string;
+}
+
+export const API_CONFIGS: Record<ApiType, ApiConfig> = {
+  accounting: {
+    schema: accountingSchema as unknown as { paths: Record<string, OpenAPIPathItem> },
+    baseUrl: 'https://api.freee.co.jp',
+    prefix: 'accounting',
+    name: 'freee会計 API',
+  },
+  hr: {
+    schema: hrSchema as unknown as { paths: Record<string, OpenAPIPathItem> },
+    baseUrl: 'https://api.freee.co.jp/hr',
+    prefix: 'hr',
+    name: 'freee人事労務 API',
+  },
+  invoice: {
+    schema: invoiceSchema as unknown as { paths: Record<string, OpenAPIPathItem> },
+    baseUrl: 'https://api.freee.co.jp/iv',
+    prefix: 'invoice',
+    name: 'freee請求書 API',
+  },
+  pm: {
+    schema: pmSchema as unknown as { paths: Record<string, OpenAPIPathItem> },
+    baseUrl: 'https://api.freee.co.jp/pm',
+    prefix: 'pm',
+    name: 'freee工数管理 API',
+  },
+};
+
+export interface PathValidationResult {
+  isValid: boolean;
+  message: string;
+  operation?: OpenAPIOperation;
+  actualPath?: string;
+  apiType?: ApiType;
+  baseUrl?: string;
+}
+
+/**
+ * Validates if a given path and method exist across all API schemas
+ * Returns the matching API type and base URL
+ */
+export function validatePathAcrossApis(method: string, path: string): PathValidationResult {
+  const normalizedMethod = method.toLowerCase();
+
+  // Search across all API schemas
+  for (const [apiType, config] of Object.entries(API_CONFIGS) as [ApiType, ApiConfig][]) {
+    const paths = config.schema.paths;
+
+    // Try exact match first
+    if (path in paths) {
+      const pathItem = paths[path];
+      if (normalizedMethod in pathItem) {
+        return {
+          isValid: true,
+          message: 'Valid path and method',
+          operation: pathItem[normalizedMethod as keyof OpenAPIPathItem] as OpenAPIOperation,
+          actualPath: path,
+          apiType,
+          baseUrl: config.baseUrl,
+        };
+      }
+    }
+
+    // Try pattern matching for paths with parameters
+    const pathKeys = Object.keys(paths);
+    for (const schemaPath of pathKeys) {
+      // Convert OpenAPI path pattern to regex
+      const pattern = schemaPath.replace(/\{[^}]+\}/g, '[^/]+');
+      const regex = new RegExp(`^${pattern}$`);
+
+      if (regex.test(path)) {
+        const pathItem = paths[schemaPath];
+        if (normalizedMethod in pathItem) {
+          return {
+            isValid: true,
+            message: 'Valid path and method',
+            operation: pathItem[normalizedMethod as keyof OpenAPIPathItem] as OpenAPIOperation,
+            actualPath: path,
+            apiType,
+            baseUrl: config.baseUrl,
+          };
+        }
+      }
+    }
+  }
+
+  // Path not found in any API
+  return {
+    isValid: false,
+    message: `Path '${path}' not found in any freee API schema. Please check the path format or use freee_api_list_paths to see available endpoints.`,
+  };
+}
+
+/**
+ * Lists all available paths across all API schemas, grouped by API type
+ */
+export function listAllAvailablePaths(): string {
+  const sections: string[] = [];
+
+  for (const [apiType, config] of Object.entries(API_CONFIGS) as [ApiType, ApiConfig][]) {
+    const paths = config.schema.paths;
+    const pathList: string[] = [];
+
+    Object.entries(paths).forEach(([path, pathItem]) => {
+      const methods = Object.keys(pathItem as OpenAPIPathItem)
+        .filter((m) => ['get', 'post', 'put', 'delete', 'patch'].includes(m))
+        .map((m) => m.toUpperCase());
+
+      if (methods.length > 0) {
+        pathList.push(`  ${methods.join('|')} ${path}`);
+      }
+    });
+
+    if (pathList.length > 0) {
+      sections.push(`\n## ${config.name} (${config.baseUrl})\n${pathList.sort().join('\n')}`);
+    }
+  }
+
+  return sections.join('\n');
+}
+
+/**
+ * Get all schemas for API mode tool generation
+ */
+export function getAllSchemas(): Array<{ apiType: ApiType; config: ApiConfig }> {
+  return Object.entries(API_CONFIGS).map(([apiType, config]) => ({
+    apiType: apiType as ApiType,
+    config,
+  }));
+}


### PR DESCRIPTION
## 概要

複数のfreee APIに対応しました。これにより、会計APIだけでなく、人事労務・請求書・工数管理APIも使用できるようになります。

## 対応API

| API | ベースURL | スキーマファイル |
|-----|----------|----------------|
| 会計API | `https://api.freee.co.jp` | `openapi/accounting-api-schema.json` |
| 人事労務API | `https://api.freee.co.jp/hr` | `openapi/hr-api-schema.json` |
| 請求書API | `https://api.freee.co.jp/iv` | `openapi/invoice-api-schema.json` |
| 工数管理API | `https://api.freee.co.jp/pm` | `openapi/pm-api-schema.json` |

## 主な変更

### 1. スキーマの統合管理 (`src/openapi/schema-loader.ts`)
- 4つのAPIスキーマを読み込み・管理
- パス検証時に全APIを横断検索
- 各APIのベースURLとプレフィックスを定義

### 2. Client Mode対応 ⭐推奨
- `freee_api_get`, `freee_api_post`などのツールで全API対応
- パスから自動的にAPIタイプとベースURLを判定
- 利用方法は変わらず、パスを指定するだけ
- `freee_api_list_paths`で全APIの一覧を表示（API別にグループ化）

### 3. API Mode対応
- 各APIのツールにプレフィックスを付与
  - 例: `accounting_get_deals`, `hr_get_employees`, `invoice_get_delivery_slips`, `pm_get_projects`
- 各ツールが自動的に正しいベースURLを使用

### 4. makeApiRequest更新
- オプショナルな`baseUrl`パラメータを追加
- 各APIの異なるベースURLに対応

## 使用例

### Client Mode（推奨）
```bash
freee-mcp client
```

```typescript
// 会計API
freee_api_get({ path: "/api/1/deals", query: { limit: 10 } })

// 人事労務API
freee_api_get({ path: "/api/v1/employees", query: { limit: 10 } })

// 請求書API
freee_api_get({ path: "/delivery_slips", query: { limit: 10 } })

// 工数管理API
freee_api_get({ path: "/projects" })
```

### API Mode
```bash
freee-mcp api
```

ツール名でAPIを区別：
- `accounting_get_deals`
- `hr_get_employees`
- `invoice_get_delivery_slips`
- `pm_get_projects`

## テスト結果

- ✅ Type check: パス
- ✅ Build: 成功
- ✅ Tests: 78 tests passed

## 後方互換性

- Client modeは既存の使い方と完全に互換性あり
- API modeはツール名が変更（プレフィックス追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple Freee APIs (Accounting, HR, Invoice, and Time Tracking).
  * Introduced Client Mode with automatic API base URL detection based on path validation.
  * API-specific tool naming for clearer identification (e.g., accounting_get_deals, hr_get_employees).

* **Improvements**
  * Enhanced path validation across all supported APIs.
  * Reduced context window usage with streamlined 6-tool client mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->