### PR TITLE
fix: configureコマンドが即時終了する問題を修正

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -30,7 +30,7 @@ await build({
 const binFile = './bin/cli.js';
 await build({
   bundle: true,
-  entryPoints: ['src/cli.ts'],
+  entryPoints: ['src/index.ts'],
   external: Object.keys(dependencies),
   logLevel: 'info' as 'info',
   minify: true,


### PR DESCRIPTION
## Summary
- `npx @him0/freee-mcp configure` が即時終了する問題を修正
- `bin/cli.js` のビルドエントリポイントを `src/cli.ts` から `src/index.ts` に変更

## 原因
`build.ts` で `bin/cli.js` のエントリポイントとして `src/cli.ts` を使用していましたが、このファイルは `configure` 関数をエクスポートするだけで、メインの実行コード（コマンドライン引数の処理や `configure()` の呼び出し）が含まれていませんでした。

## Test plan
- [x] `pnpm build` が成功することを確認
- [x] `./bin/cli.js configure` でセットアップウィザードが起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI build entry point configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->