### PR TITLE
chore: add NODE_OPTIONS for type-check and build steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # - name: Run type check
-      #   run: pnpm type-check
+      - name: Run type check
+        run: pnpm type-check
+        env:
+          NODE_OPTIONS: "--max-old-space-size=6144"
 
       - name: Run linter
         run: pnpm lint
@@ -55,6 +57,8 @@ jobs:
 
       - name: Build project
         run: pnpm build
+        env:
+          NODE_OPTIONS: "--max-old-space-size=6144"
 
       - name: Check build artifacts
         run: |


### PR DESCRIPTION
## Summary
- Re-enable type-check step in release workflow
- Add `NODE_OPTIONS="--max-old-space-size=6144"` to type-check and build steps to prevent out-of-memory errors during CI

## Test plan
- [ ] Verify release workflow runs successfully with increased memory limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)