### PR TITLE
ci: use Node.js 24 only in CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: [24]
 
     steps:
     - name: Checkout code
@@ -43,7 +43,7 @@ jobs:
       run: pnpm test:coverage
 
     - name: Upload coverage reports
-      if: matrix.node-version == 22
+      if: matrix.node-version == 24
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage/lcov.info


### PR DESCRIPTION
## Summary
- CIのテストmatrixからNode.js 22を削除し、Node.js 24のみでテストを実行するように変更
- Codecovのカバレッジアップロード条件をNode.js 24に更新

## Changes
- `.github/workflows/test.yml`: Node.js matrixを `[22, 24]` から `[24]` に変更
- Codecovアップロード条件を `matrix.node-version == 22` から `matrix.node-version == 24` に変更

## Test plan
- [ ] CI workflowが正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)