### PR TITLE
Address GitHub issue 67

### DIFF
--- a/src/auth/tokens.test.ts
+++ b/src/auth/tokens.test.ts
@@ -2,16 +2,17 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
-import { 
-  TokenData, 
-  saveTokens, 
-  loadTokens, 
-  isTokenValid, 
-  refreshAccessToken, 
-  clearTokens, 
-  getValidAccessToken 
+import {
+  TokenData,
+  saveTokens,
+  loadTokens,
+  isTokenValid,
+  refreshAccessToken,
+  clearTokens,
+  getValidAccessToken
 } from './tokens.js';
 import { setupTestTempDir } from '../test-utils/temp-dir.js';
+import { CONFIG_FILE_PERMISSION } from '../constants.js';
 
 // テスト用一時ディレクトリの設定
 const { tempDir, setup: setupTempDir, cleanup: cleanupTempDir } = setupTestTempDir('tokens-test-');
@@ -85,7 +86,7 @@ describe('tokens', () => {
       expect(mockFs.writeFile).toHaveBeenCalledWith(
         expectedTokenPath,
         JSON.stringify(mockTokenData, null, 2),
-        { mode: 0o600 }
+        { mode: CONFIG_FILE_PERMISSION }
       );
     });
 

--- a/src/auth/tokens.ts
+++ b/src/auth/tokens.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import { config } from '../config.js';
+import { CONFIG_FILE_PERMISSION } from '../constants.js';
 
 export interface TokenData {
   access_token: string;
@@ -29,7 +30,7 @@ export async function saveTokens(tokens: TokenData): Promise<void> {
     console.error(`📁 Creating directory: ${configDir}`);
     await fs.mkdir(configDir, { recursive: true });
     console.error(`💾 Writing tokens to: ${tokenPath}`);
-    await fs.writeFile(tokenPath, JSON.stringify(tokens, null, 2), { mode: 0o600 });
+    await fs.writeFile(tokenPath, JSON.stringify(tokens, null, 2), { mode: CONFIG_FILE_PERMISSION });
     console.error('✅ Tokens saved successfully');
   } catch (error) {
     console.error('❌ Failed to save tokens:', error);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import {
 import { buildAuthUrl, exchangeCodeForTokens } from './auth/oauth.js';
 import { config as defaultConfig } from './config.js';
 import { setCurrentCompany, saveFullConfig, type FullConfig } from './config/companies.js';
+import { DEFAULT_CALLBACK_PORT, AUTH_TIMEOUT_MS } from './constants.js';
 
 interface ConfigValues {
   clientId: string;
@@ -102,7 +103,7 @@ export async function configure(): Promise<void> {
         type: 'text',
         name: 'callbackPort',
         message: 'FREEE_CALLBACK_PORT:',
-        initial: String(existingConfig.callbackPort || 54321),
+        initial: String(existingConfig.callbackPort || DEFAULT_CALLBACK_PORT),
       },
     ]);
 
@@ -164,7 +165,7 @@ export async function configure(): Promise<void> {
         () => {
           reject(new Error('認証がタイムアウトしました（5分）'));
         },
-        5 * 60 * 1000,
+        AUTH_TIMEOUT_MS,
       );
 
       // Store callback handlers globally so server.ts can access them

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { loadConfig } from './config.js';
+import { AUTH_TIMEOUT_MS } from './constants.js';
 
 describe('config', () => {
   it('should have correct OAuth configuration', async () => {
@@ -18,7 +19,7 @@ describe('config', () => {
 
   it('should have correct auth timeout', async () => {
     const config = await loadConfig();
-    expect(config.auth.timeoutMs).toBe(5 * 60 * 1000);
+    expect(config.auth.timeoutMs).toBe(AUTH_TIMEOUT_MS);
   });
 
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { loadFullConfig } from './config/companies.js';
+import { DEFAULT_CALLBACK_PORT, AUTH_TIMEOUT_MS } from './constants.js';
 
 // Mode can be set programmatically via setMode()
 let clientMode = false;
@@ -62,7 +63,7 @@ export async function loadConfig(): Promise<Config> {
     clientSecret = process.env.FREEE_CLIENT_SECRET || '';
     callbackPort = process.env.FREEE_CALLBACK_PORT
       ? parseInt(process.env.FREEE_CALLBACK_PORT, 10)
-      : 54321;
+      : DEFAULT_CALLBACK_PORT;
   } else {
     // Load from config file
     if (!fullConfig.clientId || !fullConfig.clientSecret) {
@@ -74,7 +75,7 @@ export async function loadConfig(): Promise<Config> {
 
     clientId = fullConfig.clientId;
     clientSecret = fullConfig.clientSecret;
-    callbackPort = fullConfig.callbackPort || 54321;
+    callbackPort = fullConfig.callbackPort || DEFAULT_CALLBACK_PORT;
   }
 
   // Load default company ID from env (deprecated)
@@ -103,7 +104,7 @@ export async function loadConfig(): Promise<Config> {
       version: '1.0.0',
     },
     auth: {
-      timeoutMs: 5 * 60 * 1000, // 5分
+      timeoutMs: AUTH_TIMEOUT_MS,
     },
   };
 

--- a/src/config/companies.ts
+++ b/src/config/companies.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
+import { CONFIG_FILE_PERMISSION } from '../constants.js';
 
 export interface CompanyConfig {
   id: string;
@@ -122,7 +123,7 @@ export async function loadFullConfig(): Promise<FullConfig> {
 export async function saveFullConfig(config: FullConfig): Promise<void> {
   await ensureConfigDir();
   const configPath = getConfigFilePath();
-  await fs.writeFile(configPath, JSON.stringify(config, null, 2), { mode: 0o600 });
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), { mode: CONFIG_FILE_PERMISSION });
 }
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,21 @@
+/**
+ * Centralized constants for freee-mcp
+ *
+ * This file consolidates magic numbers and hardcoded values that are used
+ * across multiple files in the codebase.
+ */
+
+/**
+ * Default port for OAuth callback server
+ */
+export const DEFAULT_CALLBACK_PORT = 54321;
+
+/**
+ * Authentication timeout in milliseconds (5 minutes)
+ */
+export const AUTH_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * File permission for sensitive configuration files (owner read/write only)
+ */
+export const CONFIG_FILE_PERMISSION = 0o600;


### PR DESCRIPTION
- Create src/constants.ts with centralized constants:
  - DEFAULT_CALLBACK_PORT (54321)
  - AUTH_TIMEOUT_MS (5 * 60 * 1000)
  - CONFIG_FILE_PERMISSION (0o600)
- Update src/config.ts to use DEFAULT_CALLBACK_PORT and AUTH_TIMEOUT_MS
- Update src/cli.ts to use DEFAULT_CALLBACK_PORT and AUTH_TIMEOUT_MS
- Update src/auth/tokens.ts to use CONFIG_FILE_PERMISSION
- Update src/config/companies.ts to use CONFIG_FILE_PERMISSION
- Update test files to use constants instead of magic numbers

Fixes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized configuration constants for authentication timeout, callback port, and file permissions, improving maintainability across the codebase.
  * Updated test assertions to use standardized configuration constants instead of hard-coded values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->