### PR TITLE
fix: resolve TypeScript OOM during type checking

### DIFF
--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -192,7 +192,6 @@ export function addAuthenticationTools(server: McpServer): void {
   );
 
   // Company management tools
-  // @ts-expect-error - Zod 3.25+ type inference issue with MCP SDK
   server.tool(
     'freee_set_company',
     '事業所を設定・切り替え。',
@@ -201,7 +200,7 @@ export function addAuthenticationTools(server: McpServer): void {
       name: z.string().optional().describe('事業所名'),
       description: z.string().optional().describe('説明'),
     },
-    async (args) => {
+    async (args: { company_id: string; name?: string; description?: string }) => {
       try {
         const { company_id, name, description } = args;
 

--- a/src/openapi/client-mode.ts
+++ b/src/openapi/client-mode.ts
@@ -75,7 +75,6 @@ function createMethodTool(method: string): (args: {
  */
 export function generateClientModeTool(server: McpServer): void {
   // GET tool
-  // @ts-expect-error - Zod 3.25+ type inference issue with MCP SDK
   server.tool(
     'freee_api_get',
     `freee API GET。${SERVICE_HINT}`,
@@ -88,7 +87,6 @@ export function generateClientModeTool(server: McpServer): void {
   );
 
   // POST tool
-  // @ts-expect-error - Zod 3.25+ type inference issue with MCP SDK
   server.tool(
     'freee_api_post',
     `freee API POST。${SERVICE_HINT}`,

--- a/src/openapi/converter.ts
+++ b/src/openapi/converter.ts
@@ -48,7 +48,7 @@ export function generateToolsFromOpenApi(server: McpServer): void {
           }
         }
 
-        server.tool(toolName, description, parameterSchema, async (params) => {
+        server.tool(toolName, description, parameterSchema, async (params: Record<string, unknown>) => {
           try {
             let actualPath = pathKey as string;
             pathParams.forEach((param: MinimalParameter) => {
@@ -65,7 +65,7 @@ export function generateToolsFromOpenApi(server: McpServer): void {
             });
 
             const bodyParameters =
-              method === 'post' || method === 'put' ? params.body : undefined;
+              method === 'post' || method === 'put' ? (params.body as Record<string, unknown> | undefined) : undefined;
             const result = await makeApiRequest(
               method.toUpperCase(),
               actualPath,

--- a/src/types/mcp-overrides.d.ts
+++ b/src/types/mcp-overrides.d.ts
@@ -1,0 +1,13 @@
+// Type overrides to prevent OOM during type checking
+// The complex type inference between Zod 3.25+ and MCP SDK causes excessive memory usage
+// This file simplifies the McpServer.tool method signature to avoid deep type inference
+
+import '@modelcontextprotocol/sdk/server/mcp.js';
+
+declare module '@modelcontextprotocol/sdk/server/mcp.js' {
+  interface McpServer {
+    // Override tool method with simplified signature to avoid OOM
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tool(name: string, description: string, schema: any, handler: any): void;
+  }
+}


### PR DESCRIPTION
## Summary

- TypeScript の型チェック時に OOM (Out of Memory) が発生する問題を修正
- Zod 3.25+ と MCP SDK の `McpServer.tool()` メソッドの型推論が組み合わさることで、4GB+ のメモリを消費していた

## Changes

- `src/types/mcp-overrides.d.ts`: `McpServer.tool` の型を簡素化して型推論を回避
- `src/openapi/schema-loader.ts`: JSON インポートを `fs.readFileSync` によるランタイム読み込みに変更
- `src/mcp/tools.ts`, `src/openapi/client-mode.ts`: 不要な `@ts-expect-error` を削除
- `src/openapi/converter.ts`: コールバックパラメータに明示的な型注釈を追加

## Test plan

- [ ] `pnpm typecheck` がメモリ増加なしで成功することを確認
- [ ] `pnpm lint` が成功することを確認
- [ ] `pnpm build` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety with explicit type annotations in tool handlers and API integrations, enabling compile-time error detection
  * Implemented lazy-loading for API schemas to optimize initialization and improve startup performance
  * Refined TypeScript type system declarations to streamline type inference and provide a better development experience

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->