### PR TITLE
Address GitHub issue 71

### DIFF
--- a/.changeset/replace-zod-any-with-concrete-schema.md
+++ b/.changeset/replace-zod-any-with-concrete-schema.md
@@ -1,0 +1,9 @@
+---
+"@him0/freee-mcp": patch
+---
+
+z.any() を具体的なスキーマに置き換え
+
+- `converter.ts` の body スキーマを `z.record(z.string(), z.unknown())` に変更
+- `client-mode.ts` の body/query スキーマを `z.record(z.string(), z.unknown())` に変更
+- 型安全性の向上とランタイムエラーリスクの低減

--- a/src/openapi/client-mode.ts
+++ b/src/openapi/client-mode.ts
@@ -81,7 +81,7 @@ export function generateClientModeTool(server: McpServer): void {
     {
       service: serviceSchema,
       path: z.string().describe('APIパス (例: /api/1/deals, /invoices)'),
-      query: z.record(z.string(), z.any()).optional().describe('クエリパラメータ (オプション)'),
+      query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ (オプション)'),
     },
     createMethodTool('GET')
   );
@@ -93,8 +93,8 @@ export function generateClientModeTool(server: McpServer): void {
     {
       service: serviceSchema,
       path: z.string().describe('APIパス (例: /api/1/deals, /invoices)'),
-      body: z.record(z.string(), z.any()).describe('リクエストボディ'),
-      query: z.record(z.string(), z.any()).optional().describe('クエリパラメータ (オプション)'),
+      body: z.record(z.string(), z.unknown()).describe('リクエストボディ'),
+      query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ (オプション)'),
     },
     createMethodTool('POST')
   );
@@ -106,8 +106,8 @@ export function generateClientModeTool(server: McpServer): void {
     {
       service: serviceSchema,
       path: z.string().describe('APIパス (例: /api/1/deals/123, /invoices/123)'),
-      body: z.record(z.string(), z.any()).describe('リクエストボディ'),
-      query: z.record(z.string(), z.any()).optional().describe('クエリパラメータ (オプション)'),
+      body: z.record(z.string(), z.unknown()).describe('リクエストボディ'),
+      query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ (オプション)'),
     },
     createMethodTool('PUT')
   );
@@ -119,7 +119,7 @@ export function generateClientModeTool(server: McpServer): void {
     {
       service: serviceSchema,
       path: z.string().describe('APIパス (例: /api/1/deals/123)'),
-      query: z.record(z.string(), z.any()).optional().describe('クエリパラメータ (オプション)'),
+      query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ (オプション)'),
     },
     createMethodTool('DELETE')
   );
@@ -131,8 +131,8 @@ export function generateClientModeTool(server: McpServer): void {
     {
       service: serviceSchema,
       path: z.string().describe('APIパス (例: /api/1/deals/123)'),
-      body: z.record(z.string(), z.any()).describe('リクエストボディ'),
-      query: z.record(z.string(), z.any()).optional().describe('クエリパラメータ (オプション)'),
+      body: z.record(z.string(), z.unknown()).describe('リクエストボディ'),
+      query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ (オプション)'),
     },
     createMethodTool('PATCH')
   );

--- a/src/openapi/converter.ts
+++ b/src/openapi/converter.ts
@@ -41,7 +41,7 @@ export function generateToolsFromOpenApi(server: McpServer): void {
           parameterSchema[sanitizePropertyName(param.name)] = schema;
         });
 
-        const bodySchema = z.any();
+        const bodySchema = z.record(z.string(), z.unknown());
         if (method === 'post' || method === 'put') {
           if (operation.hasJsonBody) {
             parameterSchema['body'] = bodySchema.describe('Request body');


### PR DESCRIPTION
- converter.ts の body スキーマを z.record(z.string(), z.unknown()) に変更
- client-mode.ts の body/query スキーマを z.record(z.string(), z.unknown()) に変更
- 型安全性の向上とランタイムエラーリスクの低減

Fixes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened validation of API request bodies and query parameters with more precise and explicit type checking
  * Applied enhanced validation across all HTTP methods (GET, POST, PUT, DELETE, PATCH)
  * Improved detection of invalid request formats to reduce runtime errors and enhance API reliability

* **Chores**
  * Updated internal validation schemas for improved type safety and code maintainability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->