### PR TITLE
Address GitHub issue 74

### DIFF
--- a/.changeset/consolidate-error-handling.md
+++ b/.changeset/consolidate-error-handling.md
@@ -1,0 +1,5 @@
+---
+"@him0/freee-mcp": patch
+---
+
+Consolidate duplicate error handling patterns into a shared safeParseJson utility function

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,7 @@
 import { config } from '../config.js';
 import { getValidAccessToken } from '../auth/tokens.js';
 import { getCurrentCompanyId } from '../config/companies.js';
+import { safeParseJson } from '../utils/error.js';
 
 export async function makeApiRequest(
   method: string,
@@ -46,7 +47,7 @@ export async function makeApiRequest(
   });
 
   if (response.status === 401 || response.status === 403) {
-    const errorData = await response.json().catch(() => ({}));
+    const errorData = await safeParseJson(response);
     throw new Error(
       `認証エラーが発生しました。freee_authenticate ツールを使用して再認証を行ってください。\n` +
       `現在の事業所ID: ${companyId}\n` +
@@ -60,8 +61,8 @@ export async function makeApiRequest(
   }
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    
+    const errorData = await safeParseJson(response);
+
     // Extract detailed error messages from freee API response
     let errorMessage = `API request failed: ${response.status}`;
     

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import { config } from '../config.js';
 import { TokenData, saveTokens } from './tokens.js';
+import { safeParseJson } from '../utils/error.js';
 
 export function generatePKCE(): { codeVerifier: string; codeChallenge: string } {
   const codeVerifier = crypto.randomBytes(32).toString('base64url');
@@ -39,7 +40,7 @@ export async function exchangeCodeForTokens(code: string, codeVerifier: string, 
   });
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
+    const errorData = await safeParseJson(response);
     throw new Error(`Token exchange failed: ${response.status} ${JSON.stringify(errorData)}`);
   }
 

--- a/src/auth/tokens.ts
+++ b/src/auth/tokens.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import os from 'os';
 import { config } from '../config.js';
 import { CONFIG_FILE_PERMISSION } from '../constants.js';
+import { safeParseJson } from '../utils/error.js';
 
 export interface TokenData {
   access_token: string;
@@ -113,7 +114,7 @@ export async function refreshAccessToken(refreshToken: string): Promise<TokenDat
   });
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
+    const errorData = await safeParseJson(response);
     throw new Error(`Token refresh failed: ${response.status} ${JSON.stringify(errorData)}`);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { buildAuthUrl, exchangeCodeForTokens } from './auth/oauth.js';
 import { config as defaultConfig } from './config.js';
 import { saveFullConfig, type FullConfig } from './config/companies.js';
 import { DEFAULT_CALLBACK_PORT, AUTH_TIMEOUT_MS } from './constants.js';
+import { safeParseJson } from './utils/error.js';
 
 type Credentials = {
   clientId: string;
@@ -47,7 +48,7 @@ async function fetchCompanies(accessToken: string): Promise<Company[]> {
   });
 
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
+    const errorData = await safeParseJson(response);
     throw new Error(
       `事業所一覧の取得に失敗しました: ${response.status} ${JSON.stringify(errorData)}`,
     );

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,10 @@
+/**
+ * Safely parses JSON from a Response object.
+ * Returns an empty object if parsing fails.
+ *
+ * @param response - The fetch Response object to parse
+ * @returns Parsed JSON data or empty object on failure
+ */
+export async function safeParseJson(response: Response): Promise<Record<string, unknown>> {
+  return response.json().catch(() => ({}));
+}


### PR DESCRIPTION
Create shared safeParseJson utility function in src/utils/error.ts and replace duplicate error handling patterns across:
- src/api/client.ts (2 occurrences)
- src/cli.ts
- src/auth/oauth.ts
- src/auth/tokens.ts

Closes #74