### PR TITLE
refactor: MCPツールとログから絵文字を削除

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -80,7 +80,7 @@ export async function makeApiRequest(
         
         // Add helpful guidance for bad request errors
         if (response.status === 400) {
-          errorMessage += `\n\n💡 ヒント: 不正なリクエストエラーが発生しました。`;
+          errorMessage += `\n\nヒント: 不正なリクエストエラーが発生しました。`;
           errorMessage += `\n既存のデータを取得して正しい構造を確認することをお勧めします。`;
           errorMessage += `\n例: get_items, get_partners, get_account_items などで既存データの構造を確認してください。`;
         }

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -27,26 +27,26 @@ export class AuthenticationManager {
   private cliAuthHandlers = new Map<string, CliAuthHandler>();
 
   registerAuthentication(state: string, codeVerifier: string): void {
-    console.error(`🔐 Registering authentication request with state: ${state.substring(0, 10)}...`);
-    console.error(`🔐 Code verifier: ${codeVerifier.substring(0, 10)}...`);
+    console.error(`Registering authentication request with state: ${state.substring(0, 10)}...`);
+    console.error(`Code verifier: ${codeVerifier.substring(0, 10)}...`);
 
     const timeout = setTimeout(() => {
       this.pendingAuthentications.delete(state);
-      console.error(`⏰ Authentication timeout for state: ${state.substring(0, 10)}...`);
+      console.error(`Authentication timeout for state: ${state.substring(0, 10)}...`);
     }, config.auth.timeoutMs);
 
     this.pendingAuthentications.set(state, {
       codeVerifier,
       resolve: (tokens: TokenData) => {
-        console.error('🎉 Authentication completed successfully!');
+        console.error('Authentication completed successfully!');
       },
       reject: (error: Error) => {
-        console.error('❌ Authentication failed:', error);
+        console.error('Authentication failed:', error);
       },
       timeout
     });
 
-    console.error(`📝 Registration complete. Total pending: ${this.pendingAuthentications.size}`);
+    console.error(`Registration complete. Total pending: ${this.pendingAuthentications.size}`);
   }
 
   getPendingAuthentication(state: string): PendingAuthentication | undefined {
@@ -125,12 +125,12 @@ export class CallbackServer {
     this.port = port;
 
     if (port !== preferredPort) {
-      console.error(`⚠️ Port ${preferredPort} is in use. Using fallback port ${port} for OAuth callback server.`);
+      console.error(`Warning: Port ${preferredPort} is in use. Using fallback port ${port} for OAuth callback server.`);
     }
 
     return new Promise((resolve, reject) => {
       this.server = http.createServer((req, res) => {
-        console.error(`📥 Callback request: ${req.method} ${req.url}`);
+        console.error(`Callback request: ${req.method} ${req.url}`);
         const url = new URL(req.url!, `http://127.0.0.1:${port}`);
 
         if (url.pathname === '/callback') {
@@ -150,7 +150,7 @@ export class CallbackServer {
       });
 
       this.server.listen(port, '127.0.0.1', () => {
-        console.error(`🔗 OAuth callback server listening on http://127.0.0.1:${port}`);
+        console.error(`OAuth callback server listening on http://127.0.0.1:${port}`);
         resolve();
       });
     });
@@ -161,7 +161,7 @@ export class CallbackServer {
       this.authManager.clearAllPending();
 
       this.server.close(() => {
-        console.error('🔴 OAuth callback server stopped');
+        console.error('OAuth callback server stopped');
       });
       this.server = null;
       this.port = null;
@@ -199,20 +199,20 @@ export class CallbackServer {
     const error = url.searchParams.get('error');
     const errorDescription = url.searchParams.get('error_description');
 
-    console.error(`🔍 Callback received - URL: ${url.toString()}`);
-    console.error(`🔍 Callback parameters:`, {
+    console.error(`Callback received - URL: ${url.toString()}`);
+    console.error(`Callback parameters:`, {
       code: code ? `${code.substring(0, 10)}...` : null,
       state: state ? `${state.substring(0, 10)}...` : null,
       error,
       errorDescription
     });
-    console.error(`🔍 Pending authentications count: ${this.authManager.pendingCount}`);
+    console.error(`Pending authentications count: ${this.authManager.pendingCount}`);
 
     const cliHandler = state ? this.authManager.getCliAuthHandler(state) : undefined;
 
     if (error) {
       const errorMsg = errorDescription || error;
-      console.error(`❌ OAuth error: ${error} - ${errorDescription}`);
+      console.error(`OAuth error: ${error} - ${errorDescription}`);
       res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end(`<h1>認証エラー</h1><p>認証に失敗しました: ${errorMsg}</p>`);
 
@@ -230,7 +230,7 @@ export class CallbackServer {
     }
 
     if (!code || !state) {
-      console.error(`❌ Missing code or state`);
+      console.error(`Missing code or state`);
       res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end('<h1>認証エラー</h1><p>認証コードまたは状態パラメータが不足しています。</p>');
       return;
@@ -238,7 +238,7 @@ export class CallbackServer {
 
     // Handle CLI authentication
     if (cliHandler) {
-      console.error(`✅ Valid CLI callback received`);
+      console.error(`Valid CLI callback received`);
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end('<h1>認証完了</h1><p>認証が完了しました。このページを閉じてターミナルに戻ってください。</p>');
 
@@ -248,13 +248,13 @@ export class CallbackServer {
 
     const pendingAuth = this.authManager.getPendingAuthentication(state);
     if (!pendingAuth) {
-      console.error(`❌ Unknown state: ${state}`);
+      console.error(`Unknown state: ${state}`);
       res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
       res.end('<h1>認証エラー</h1><p>不明な認証状態です。認証を再開してください。</p>');
       return;
     }
 
-    console.error(`✅ Valid callback received, exchanging code for tokens...`);
+    console.error(`Valid callback received, exchanging code for tokens...`);
     res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
     res.end('<h1>認証完了</h1><p>認証が完了しました。このページを閉じてください。</p>');
 
@@ -262,11 +262,11 @@ export class CallbackServer {
 
     exchangeCodeForTokens(code, pendingAuth.codeVerifier, this.getRedirectUri())
       .then((tokens) => {
-        console.error(`🎉 Token exchange successful!`);
+        console.error(`Token exchange successful!`);
         pendingAuth.resolve(tokens);
       })
       .catch((exchangeError) => {
-        console.error(`❌ Token exchange failed:`, exchangeError);
+        console.error(`Token exchange failed:`, exchangeError);
         pendingAuth.reject(exchangeError);
       });
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,7 +63,7 @@ async function collectCredentials(): Promise<Credentials> {
   const hasExistingCredentials = !!(existingConfig.clientId && existingConfig.clientSecret);
 
   if (hasExistingCredentials) {
-    console.log('✓ 既存の設定が見つかりました。');
+    console.log('既存の設定が見つかりました。');
     console.log('  変更しない項目はそのまま Enter を押してください。\n');
   }
 
@@ -115,7 +115,7 @@ async function collectCredentials(): Promise<Credentials> {
   process.env.FREEE_CLIENT_SECRET = clientSecret;
   process.env.FREEE_CALLBACK_PORT = String(callbackPort);
 
-  console.log('\n✓ 認証情報を受け取りました。\n');
+  console.log('\n認証情報を受け取りました。\n');
 
   return { clientId, clientSecret, callbackPort };
 }
@@ -165,11 +165,11 @@ async function performOAuth(): Promise<OAuthResult> {
 
   try {
     const authCode = await callbackPromise;
-    console.log('✓ 認証コードを受け取りました。');
+    console.log('認証コードを受け取りました。');
 
     console.log('トークンを取得中...');
     const tokens = await exchangeCodeForTokens(authCode, codeVerifier, getActualRedirectUri());
-    console.log('✓ トークンを取得しました。\n');
+    console.log('トークンを取得しました。\n');
 
     return {
       accessToken: tokens.access_token,
@@ -210,7 +210,7 @@ async function selectCompany(accessToken: string): Promise<{ selected: SelectedC
     throw new Error(`選択した事業所が見つかりません: ID ${companySelection.companyId}`);
   }
 
-  console.log(`\n✓ ${selectedCompany.display_name || selectedCompany.name} を選択しました。\n`);
+  console.log(`\n${selectedCompany.display_name || selectedCompany.name} を選択しました。\n`);
 
   return {
     selected: {
@@ -248,7 +248,7 @@ async function saveConfig(
   });
 
   await saveFullConfig(fullConfig);
-  console.log('✓ 設定情報を保存しました。\n');
+  console.log('設定情報を保存しました。\n');
 
   console.log('=== MCP設定 ===\n');
   console.log('以下の設定をClaude desktopの設定ファイルに追加してください:\n');
@@ -275,7 +275,7 @@ async function saveConfig(
   };
 
   console.log(JSON.stringify(mcpConfig, null, 2));
-  console.log('\n✓ セットアップ完了！\n');
+  console.log('\nセットアップ完了!\n');
   console.log('認証情報は ~/.config/freee-mcp/config.json に保存されました。');
   console.log('トークンは ~/.config/freee-mcp/tokens.json に保存されました。');
   console.log('Claude desktopを再起動すると、freee-mcpが利用可能になります。\n');
@@ -293,7 +293,7 @@ export async function configure(): Promise<void> {
     await saveConfig(credentials, selectedCompany, allCompanies);
   } catch (error) {
     if (error instanceof Error) {
-      console.error(`\n❌ ${error.message}`);
+      console.error(`\nError: ${error.message}`);
     } else {
       console.error('\n設定中にエラーが発生しました:', error);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,9 +55,9 @@ export async function loadConfig(): Promise<Config> {
 
   if (hasEnvCredentials()) {
     // Environment variables take priority (with deprecation warning)
-    console.error('⚠️  警告: 環境変数での認証情報設定は非推奨です。');
-    console.error('    `freee-mcp configure` を実行して設定ファイルに移行してください。');
-    console.error('    環境変数設定は将来のバージョンで削除される予定です。\n');
+    console.error('Warning: 環境変数での認証情報設定は非推奨です。');
+    console.error('  `freee-mcp configure` を実行して設定ファイルに移行してください。');
+    console.error('  環境変数設定は将来のバージョンで削除される予定です。\n');
 
     clientId = process.env.FREEE_CLIENT_ID || '';
     clientSecret = process.env.FREEE_CLIENT_SECRET || '';
@@ -81,8 +81,8 @@ export async function loadConfig(): Promise<Config> {
   // Load default company ID from env (deprecated)
   let companyId = process.env.FREEE_DEFAULT_COMPANY_ID || '0';
   if (process.env.FREEE_DEFAULT_COMPANY_ID) {
-    console.error('⚠️  警告: FREEE_DEFAULT_COMPANY_ID 環境変数は非推奨です。');
-    console.error('    事業所IDは `freee_set_company` ツールで動的に変更できます。\n');
+    console.error('Warning: FREEE_DEFAULT_COMPANY_ID 環境変数は非推奨です。');
+    console.error('  事業所IDは `freee_set_company` ツールで動的に変更できます。\n');
   }
 
   cachedConfig = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,10 @@ const main = async (): Promise<void> => {
   // Set mode based on subcommand
   if (subcommand === 'client') {
     setMode(true);
-    console.error('🚀 Starting freee MCP server in client mode (HTTP method sub-commands)');
+    console.error('Starting freee MCP server in client mode (HTTP method sub-commands)');
   } else if (subcommand === 'api' || !subcommand) {
     setMode(false);
-    console.error('🚀 Starting freee MCP server in API mode (individual tools per endpoint)');
+    console.error('Starting freee MCP server in API mode (individual tools per endpoint)');
   } else {
     console.error(`Unknown subcommand: ${subcommand}`);
     console.error('Usage: freee-mcp [configure|client|api]');

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -19,18 +19,18 @@ export async function createAndStartServer(): Promise<void> {
 
   // Use client mode or generate individual tools based on mode
   if (getMode()) {
-    console.error('🔧 Using API client mode (single generic tool)');
+    console.error('Using API client mode (single generic tool)');
     generateClientModeTool(server);
   } else {
-    console.error('🔧 Using individual tool mode (one tool per endpoint)');
+    console.error('Using individual tool mode (one tool per endpoint)');
     generateToolsFromOpenApi(server);
   }
 
   try {
     await startCallbackServer();
-    console.error(`✅ OAuth callback server started on http://127.0.0.1:${config.oauth.callbackPort}`);
+    console.error(`OAuth callback server started on http://127.0.0.1:${config.oauth.callbackPort}`);
   } catch (error) {
-    console.error('⚠️ Failed to start callback server:', error);
+    console.error('Failed to start callback server:', error);
     console.error('OAuth authentication will fall back to manual mode');
   }
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -97,7 +97,7 @@ export function addAuthenticationTools(server: McpServer): void {
 
         registerAuthenticationRequest(state, codeVerifier);
 
-        console.error(`🌐 Authentication URL: ${authUrl}`);
+        console.error(`Authentication URL: ${authUrl}`);
 
         return {
           content: [

--- a/src/openapi/client-mode.ts
+++ b/src/openapi/client-mode.ts
@@ -39,8 +39,8 @@ function createMethodTool(method: string): (args: {
             {
               type: 'text' as const,
               text:
-                `❌ パス検証エラー: ${validation.message}\n\n` +
-                `💡 利用可能なパスを確認するには freee_api_list_paths ツールを使用してください。`,
+                `パス検証エラー: ${validation.message}\n\n` +
+                `利用可能なパスを確認するには freee_api_list_paths ツールを使用してください。`,
             },
           ],
         };
@@ -62,7 +62,7 @@ function createMethodTool(method: string): (args: {
         content: [
           {
             type: 'text' as const,
-            text: `❌ APIリクエストエラー: ${error instanceof Error ? error.message : String(error)}`,
+            text: `APIリクエストエラー: ${error instanceof Error ? error.message : String(error)}`,
           },
         ],
       };
@@ -150,7 +150,7 @@ export function generateClientModeTool(server: McpServer): void {
             type: 'text' as const,
             text:
               `# freee API 利用可能なエンドポイント一覧${pathsList}\n\n` +
-              `💡 使用例:\n` +
+              `使用例:\n` +
               `freee_api_get { "service": "accounting", "path": "/api/1/deals", "query": { "limit": 10 } }\n` +
               `freee_api_get { "service": "invoice", "path": "/invoices" }\n` +
               `freee_api_post { "service": "accounting", "path": "/api/1/deals", "body": { "issue_date": "2024-01-01", ... } }`,


### PR DESCRIPTION
コンソール出力やMCPツールのメッセージから全ての絵文字を削除し、
プレーンテキストに置き換えました。

変更ファイル:
- src/auth/server.ts: 認証関連のログメッセージ
- src/cli.ts: CLIセットアップメッセージ
- src/config.ts: 非推奨警告メッセージ
- src/index.ts: サーバー起動メッセージ
- src/mcp/handlers.ts: ハンドラーログメッセージ
- src/mcp/tools.ts: 認証URLログ
- src/api/client.ts: APIエラーメッセージ
- src/openapi/client-mode.ts: パス検証エラーとヒント