### PR TITLE
fix: enable changeset commits in config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
   "changelog": "@changesets/cli/changelog",
-  "commit": false,
+  "commit": true,
   "fixed": [],
   "linked": [],
   "access": "public",


### PR DESCRIPTION
## 問題

GitHub Actions の release ワークフローが以下のエラーで失敗していました:

```
Validation Failed: {"resource":"PullRequest","code":"custom","message":"No commits between main and changeset-release/main"}
```

**失敗したワークフロー実行:** https://github.com/him0/freee-mcp/actions/runs/20624375320

## 根本原因

`.changeset/config.json` と `.github/workflows/release.yml` の設定に不整合がありました:

- **ワークフロー設定**: `changesets/action@v1` が `commit: "chore: release packages"` を指定し、コミット作成を期待
- **Changeset 設定**: `.changeset/config.json` が `"commit": false` でコミット作成を無効化
- **結果**: `pnpm version` がファイルを更新してもコミットを作成せず、PR に変更が含まれない

## 解決方法

`.changeset/config.json` の `commit` フィールドを `true` に変更しました。

これにより、`changeset version` コマンドがバージョンバンプを自動的にコミットし、ワークフローが正常に release PR を作成できるようになります。

## 動作確認

この修正により、次回の release ワークフロー実行時に:
1. `pnpm version` が実行される
2. package.json と CHANGELOG.md が更新される
3. 変更が自動的にコミットされる
4. `changeset-release/main` ブランチにプッシュされる
5. PR が正常に作成される

## 変更内容

- `.changeset/config.json`: `"commit": false` → `"commit": true`