### PR TITLE
fix: use 'pnpm run' for version and release scripts in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,13 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm version
-          publish: pnpm release
+          version: pnpm run version
+          publish: pnpm run release
           title: "chore: release packages"
           commit: "chore: release packages"
+          setupGitUser: true
+          createGithubReleases: true
+          commitMode: git-cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 問題

PR #98 をマージした後も、release ワークフローが同じエラーで失敗し続けています:

```
Validation Failed: {"resource":"PullRequest","code":"custom","message":"No commits between main and changeset-release/main"}
```

**失敗したワークフロー実行:**
- https://github.com/him0/freee-mcp/actions/runs/20624375320 (PR #98 前)
- https://github.com/him0/freee-mcp/actions/runs/20624928231 (PR #98 後)

## 根本原因

`.github/workflows/release.yml` の以下の設定が間違っていました:

```yaml
version: pnpm version    # ❌ バージョン情報を表示するだけ
publish: pnpm release    # ❌ 無効なコマンド
```

### 何が起きていたか

ワークフローログ（run 20624928231）を見ると:

```
[command]/home/runner/setup-pnpm/node_modules/.bin/pnpm version
{
  '@him0/freee-mcp': '0.3.3',   # ← バージョン情報を表示しているだけ
  npm: '11.6.2',
  node: '24.12.0',
  ...
}
[command]/usr/bin/git status --porcelain
                                # ← 出力なし = 変更なし
```

`pnpm version` は package.json の `version` スクリプトを実行せず、単にバージョン情報を表示します。

## 解決方法

`pnpm run` プレフィックスを追加:

```diff
- version: pnpm version
+ version: pnpm run version
- publish: pnpm release
+ version: pnpm run release
```

### なぜこれで動作するか

1. `pnpm run version` が package.json の `version` スクリプトを実行
2. `version` スクリプトが `changeset version` を実行
3. package.json、CHANGELOG.md が更新され、changeset ファイルが消費される
4. PR #98 で有効化した `commit: true` により、変更が自動コミットされる
5. コミットが `changeset-release/main` にプッシュされる
6. バージョンバンプ PR が正常に作成される

## PR #98 との関係

- **PR #98**: `.changeset/config.json` で `commit: true` を有効化 → ✅ 必要だが不十分
- **この PR**: ワークフローで正しいコマンドを使用 → ✅ これで完全に動作

両方の修正が揃って初めて、release ワークフローが正常に機能します。

## テスト計画

この PR をマージ後:
1. release ワークフローを手動実行
2. changeset が正しく処理されることを確認
3. バージョンバンプ PR が作成されることを確認