### PR TITLE
docs: add PR workflow instructions

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,3 @@
+# Pull Request Workflow
+
+Before creating a PR, please commit your changesets


### PR DESCRIPTION
## Summary

- Add `.github/CLAUDE.md` with PR workflow documentation
- Remind contributors to commit changesets before creating a PR

## Changes

This PR adds a new documentation file in `.github/CLAUDE.md` that provides guidance for the PR creation workflow. The file serves as a reminder for contributors to commit their changesets before creating a pull request.

## Test plan

- [x] Verified file content is correct
- [x] Confirmed file is placed in the correct location

🤖 Generated with [Claude Code](https://claude.com/claude-code)