### PR TITLE
fix: include minimal schema files in npm package

### DIFF
--- a/.changeset/fix-minimal-schema-in-npm.md
+++ b/.changeset/fix-minimal-schema-in-npm.md
@@ -1,0 +1,10 @@
+---
+"@him0/freee-mcp": patch
+---
+
+Fix: npm パッケージに minimal スキーマファイルが含まれない問題を修正
+
+npx で実行時に `ENOENT: no such file or directory, open '.../node_modules/@him0/openapi/minimal/accounting.json'` エラーが発生する問題を解決しました。
+
+- ビルド時に `openapi/minimal/*.json` を `dist/openapi/minimal/` にコピーするように修正
+- ランタイムでのパス解決を動的に行い、開発・テスト・本番環境すべてで動作するように改善

--- a/build.ts
+++ b/build.ts
@@ -1,6 +1,7 @@
 import { build } from 'esbuild';
 import { dependencies } from './package.json';
-import { chmod } from 'fs/promises';
+import { chmod, mkdir, copyFile, readdir } from 'fs/promises';
+import { join } from 'path';
 
 const entryFile = 'src/index.ts';
 const shared = {
@@ -44,3 +45,17 @@ await build({
   },
 });
 await chmod(binFile, 0o755);
+
+// Copy minimal schema files to dist for npm package
+const minimalSrcDir = './openapi/minimal';
+const minimalDestDir = './dist/openapi/minimal';
+await mkdir(minimalDestDir, { recursive: true });
+
+const minimalFiles = await readdir(minimalSrcDir);
+for (const file of minimalFiles) {
+  if (file.endsWith('.json')) {
+    await copyFile(join(minimalSrcDir, file), join(minimalDestDir, file));
+  }
+}
+console.log(`Copied ${minimalFiles.filter(f => f.endsWith('.json')).length} minimal schema files to dist/`);
+

--- a/src/openapi/schema-loader.ts
+++ b/src/openapi/schema-loader.ts
@@ -8,7 +8,21 @@ import {
 } from './minimal-types.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const schemasDir = path.resolve(__dirname, '../../openapi/minimal');
+
+// Resolve schemas directory based on runtime context:
+// - In built dist: dist/openapi/schema-loader.js -> ../openapi/minimal -> dist/openapi/minimal
+// - In development/test (tsx): src/openapi/schema-loader.ts -> ../../openapi/minimal -> openapi/minimal
+function getSchemasDir(): string {
+  // Try built location first (dist/openapi/minimal)
+  const distPath = path.resolve(__dirname, '../openapi/minimal');
+  if (fs.existsSync(distPath)) {
+    return distPath;
+  }
+  // Fall back to source tree location (openapi/minimal)
+  return path.resolve(__dirname, '../../openapi/minimal');
+}
+
+const schemasDir = getSchemasDir();
 
 function loadSchema(filename: string): MinimalSchema {
   const filePath = path.join(schemasDir, filename);


### PR DESCRIPTION
## Summary

- npx で freee-mcp を実行した際に `ENOENT: no such file or directory` エラーが発生する問題を修正
- ビルド時に `openapi/minimal/*.json` を `dist/openapi/minimal/` にコピーするように変更
- ランタイムでのパス解決を動的に行い、開発・テスト・本番環境すべてで動作するよう改善

## Test plan

- [x] `pnpm typecheck` - パス
- [x] `pnpm lint` - パス
- [x] `pnpm test:run` - 107 テストすべてパス
- [x] `pnpm build` - `dist/openapi/minimal/` に5つのJSONファイルがコピーされることを確認
- [ ] `npm pack` 後の動作確認（npm パッケージにminimalディレクトリが含まれていることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)