### PR TITLE
chore: add changeset for schema-loader path resolution fix

### DIFF
--- a/.changeset/fix-schema-loader-path.md
+++ b/.changeset/fix-schema-loader-path.md
@@ -1,0 +1,5 @@
+---
+"@him0/freee-mcp": patch
+---
+
+Fix bin/cli.js path resolution for minimal schemas when running via npx


### PR DESCRIPTION
## Summary

- Add missing changeset for PR #108 (`fix: support bin/cli.js path resolution for minimal schemas`)

## Background

PR #108 was merged without a changeset. This PR adds the changeset to enable the next release.

## Changes

- Added `.changeset/fix-schema-loader-path.md` with `patch` bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)