### PR TITLE
refactor: replace company_id auto-injection with validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ HTTPメソッドごとのシンプルなツール構成:
 
 パスは OpenAPI スキーマに対して自動検証されます。
 
+### company_id の取り扱い
+
+リクエスト（パラメータまたはボディ）に `company_id` を含める場合、現在の事業所と一致している必要があります。不一致の場合はエラーになります。
+
+- 事業所の確認: `freee_get_current_company`
+- 事業所の切り替え: `freee_set_company`
+- company_id を含まない API（例: `/api/1/companies`）はそのまま実行可能
+
 ## 開発者向け
 
 ```bash

--- a/skills/freee-api-skill/SKILL.md
+++ b/skills/freee-api-skill/SKILL.md
@@ -82,6 +82,13 @@ serviceパラメータ (必須):
 | `invoice` | freee請求書 (請求書、見積書、納品書) | `/invoices` |
 | `pm` | freee工数管理 (プロジェクト、工数など) | `/api/1/projects` |
 
+### company_id について
+
+リクエストに `company_id` を含める場合、現在設定されている事業所（`freee_get_current_company` で確認可能）と一致している必要があります。不一致の場合はエラーになります。
+
+- 事業所を変更する場合: 先に `freee_set_company` で切り替えてからリクエストを実行
+- company_id を含まない API（例: `/api/1/companies`）: そのまま実行可能
+
 ### 基本ワークフロー
 
 1. リファレンスを検索: Grep で `skills/freee-api-skill/references` を検索

--- a/skills/freee-api-skill/docs/troubleshooting.md
+++ b/skills/freee-api-skill/docs/troubleshooting.md
@@ -75,6 +75,24 @@ freee_current_user  # 切り替わったことを確認
 - 不明な場合は経理部門に確認
 - `freee_list_companies`で事業所の説明を確認
 
+### 問題: "company_id の不整合"
+
+原因: リクエストに含まれる `company_id` と、現在設定されている事業所が異なる
+
+解決方法:
+
+```
+# 現在の事業所を確認
+freee_get_current_company
+
+# 方法1: 事業所を切り替える
+freee_set_company [リクエストで使用したい事業所ID]
+
+# 方法2: リクエストの company_id を現在の事業所に合わせる
+```
+
+注意: company_id を含むリクエストは、必ず現在の事業所と一致している必要があります。
+
 ## 経費申請作成時のエラー
 
 ### 問題: "expense_application_line_template_id が無効"

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -124,7 +124,7 @@ describe('client', () => {
       const result = await makeApiRequest('GET', '/api/1/users/me');
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${TEST_API_URL}/api/1/users/me?company_id=${TEST_COMPANY_ID}`,
+        `${TEST_API_URL}/api/1/users/me`,
         {
           method: 'GET',
           headers: {
@@ -145,7 +145,7 @@ describe('client', () => {
       await makeApiRequest('GET', '/api/1/deals', queryParams);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${TEST_API_URL}/api/1/deals?limit=10&offset=0&company_id=${TEST_COMPANY_ID}`,
+        `${TEST_API_URL}/api/1/deals?limit=10&offset=0`,
         expect.any(Object)
       );
     });
@@ -157,7 +157,7 @@ describe('client', () => {
       await makeApiRequest('GET', '/api/1/deals', { limit: 10, offset: undefined });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${TEST_API_URL}/api/1/deals?limit=10&company_id=${TEST_COMPANY_ID}`,
+        `${TEST_API_URL}/api/1/deals?limit=10`,
         expect.any(Object)
       );
     });
@@ -170,7 +170,7 @@ describe('client', () => {
       await makeApiRequest('POST', '/api/1/deals', undefined, requestBody);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${TEST_API_URL}/api/1/deals?company_id=${TEST_COMPANY_ID}`,
+        `${TEST_API_URL}/api/1/deals`,
         {
           method: 'POST',
           headers: {
@@ -180,6 +180,49 @@ describe('client', () => {
           body: JSON.stringify(requestBody),
         }
       );
+    });
+
+    it('should pass through matching company_id in params', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+      mockFetch.mockResolvedValue(createJsonResponse({}));
+
+      await makeApiRequest('GET', '/api/1/deals', { company_id: TEST_COMPANY_ID });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${TEST_API_URL}/api/1/deals?company_id=${TEST_COMPANY_ID}`,
+        expect.any(Object)
+      );
+    });
+
+    it('should throw error for mismatched company_id in params', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+
+      await expect(
+        makeApiRequest('GET', '/api/1/deals', { company_id: '99999' })
+      ).rejects.toThrow('company_id の不整合');
+    });
+
+    it('should pass through matching company_id in body', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+      mockFetch.mockResolvedValue(createJsonResponse({}));
+
+      const requestBody = { company_id: TEST_COMPANY_ID, name: 'Test' };
+      await makeApiRequest('POST', '/api/1/deals', undefined, requestBody);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${TEST_API_URL}/api/1/deals`,
+        expect.objectContaining({
+          body: JSON.stringify(requestBody),
+        })
+      );
+    });
+
+    it('should throw error for mismatched company_id in body', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+
+      await expect(
+        makeApiRequest('POST', '/api/1/deals', undefined, { company_id: '99999' })
+      ).rejects.toThrow('company_id の不整合');
     });
 
     it('should throw error when no access token available', async () => {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -85,7 +85,23 @@ export async function makeApiRequest(
     });
   }
 
-  url.searchParams.append('company_id', String(companyId));
+  // Validate company_id consistency if present in params
+  const paramsCompanyId = params?.company_id;
+  if (paramsCompanyId !== undefined && String(paramsCompanyId) !== String(companyId)) {
+    throw new Error(
+      `company_id の不整合: リクエストの company_id (${paramsCompanyId}) と現在の事業所 (${companyId}) が異なります。\n` +
+      `freee_set_company で事業所を切り替えるか、リクエストの company_id を修正してください。`
+    );
+  }
+
+  // Validate company_id consistency if present in body
+  const bodyCompanyId = body?.company_id;
+  if (bodyCompanyId !== undefined && String(bodyCompanyId) !== String(companyId)) {
+    throw new Error(
+      `company_id の不整合: リクエストボディの company_id (${bodyCompanyId}) と現在の事業所 (${companyId}) が異なります。\n` +
+      `freee_set_company で事業所を切り替えるか、リクエストの company_id を修正してください。`
+    );
+  }
 
   const response = await fetch(url.toString(), {
     method,


### PR DESCRIPTION
Instead of automatically appending company_id to all requests,
now validate that any company_id in params or body matches the
current company. This provides explicit error when mismatched
rather than silently overriding user intent.

- Remove automatic company_id query parameter injection
- Add validation for company_id in both params and body
- Update tests to reflect new behavior
- Update README, SKILL.md, and troubleshooting docs