### PR TITLE
feat: add e2e tests for built dist files

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -4,9 +4,10 @@ import { chmod, mkdir, copyFile, readdir } from 'fs/promises';
 import { join } from 'path';
 
 const entryFile = 'src/index.ts';
+const libFile = 'src/lib.ts';
+
 const shared = {
   bundle: true,
-  entryPoints: [entryFile],
   external: Object.keys(dependencies),
   logLevel: 'info' as 'info',
   minify: true,
@@ -16,6 +17,7 @@ const shared = {
 
 await build({
   ...shared,
+  entryPoints: [entryFile],
   format: 'esm',
   outfile: './dist/index.esm.js',
   target: ['ES2022'],
@@ -23,8 +25,18 @@ await build({
 
 await build({
   ...shared,
+  entryPoints: [entryFile],
   format: 'cjs',
   outfile: './dist/index.cjs',
+  target: ['ES2022'],
+});
+
+// Build library exports (for testing and programmatic use)
+await build({
+  ...shared,
+  entryPoints: [libFile],
+  format: 'esm',
+  outfile: './dist/lib.esm.js',
   target: ['ES2022'],
 });
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "inspector": "mcp-inspector pnpm run start",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:e2e-dist": "vitest run --config vitest.config.e2e-dist.ts",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
     "generate:references": "tsx scripts/generate-references.ts",

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,15 @@
+/**
+ * Library exports for testing and programmatic use
+ * This file exports internal functions without starting the MCP server
+ */
+
+export {
+  API_CONFIGS,
+  validatePathForService,
+  listAllAvailablePaths,
+  type ApiType,
+  type ApiConfig,
+  type PathValidationResult,
+} from './openapi/schema-loader.js';
+
+export { generateClientModeTool } from './openapi/client-mode.js';

--- a/test/e2e-dist/schema-loading.test.ts
+++ b/test/e2e-dist/schema-loading.test.ts
@@ -1,0 +1,94 @@
+/**
+ * E2E tests for built dist files
+ * Validates that dynamic file loading works correctly with dist-only files
+ */
+
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// Use lib.esm.js which exports internal functions without starting the server
+const distPath = path.resolve(__dirname, '../../dist/lib.esm.js');
+
+describe('E2E: Dist Schema Loading', () => {
+  it('should dynamically import dist/lib.esm.js', async () => {
+    const module = await import(distPath);
+    expect(module).toBeDefined();
+  });
+
+  it('should export expected functions from lib', async () => {
+    const module = await import(distPath);
+
+    expect(module.API_CONFIGS).toBeDefined();
+    expect(module.validatePathForService).toBeDefined();
+    expect(module.listAllAvailablePaths).toBeDefined();
+    expect(module.generateClientModeTool).toBeDefined();
+  });
+
+  it('should successfully validate paths using dist bundle', async () => {
+    const { validatePathForService, API_CONFIGS } = await import(distPath);
+
+    // Test that API_CONFIGS is accessible (lazy loaded)
+    expect(API_CONFIGS).toBeDefined();
+
+    // Access accounting API config - this triggers schema loading
+    const accountingConfig = API_CONFIGS['accounting'];
+    expect(accountingConfig).toBeDefined();
+    expect(accountingConfig.baseUrl).toBe('https://api.freee.co.jp');
+    expect(accountingConfig.name).toBe('freee会計 API');
+
+    // The schema should be loaded
+    expect(accountingConfig.schema).toBeDefined();
+    expect(accountingConfig.schema.paths).toBeDefined();
+  });
+
+  it('should load all 5 API schemas from dist', async () => {
+    const { API_CONFIGS } = await import(distPath);
+
+    const apiTypes = ['accounting', 'hr', 'invoice', 'pm', 'sm'] as const;
+
+    for (const apiType of apiTypes) {
+      const config = API_CONFIGS[apiType];
+      expect(config, `${apiType} config should exist`).toBeDefined();
+      expect(config.schema, `${apiType} schema should be loaded`).toBeDefined();
+      expect(config.schema.paths, `${apiType} paths should exist`).toBeDefined();
+      expect(Object.keys(config.schema.paths).length, `${apiType} should have paths`).toBeGreaterThan(0);
+    }
+  });
+
+  it('should validate accounting API paths correctly', async () => {
+    const { validatePathForService } = await import(distPath);
+
+    // Valid path
+    const validResult = validatePathForService('GET', '/api/1/deals', 'accounting');
+    expect(validResult.isValid).toBe(true);
+    expect(validResult.baseUrl).toBe('https://api.freee.co.jp');
+
+    // Invalid path
+    const invalidResult = validatePathForService('GET', '/invalid/path', 'accounting');
+    expect(invalidResult.isValid).toBe(false);
+  });
+
+  it('should validate HR API paths correctly', async () => {
+    const { validatePathForService } = await import(distPath);
+
+    // Valid HR path
+    const result = validatePathForService('GET', '/api/v1/employees', 'hr');
+    expect(result.isValid).toBe(true);
+    expect(result.baseUrl).toBe('https://api.freee.co.jp/hr');
+  });
+
+  it('should list all available paths from dist', async () => {
+    const { listAllAvailablePaths } = await import(distPath);
+
+    const pathsList = listAllAvailablePaths();
+
+    // Should contain paths from all APIs
+    expect(pathsList).toContain('freee会計 API');
+    expect(pathsList).toContain('freee人事労務 API');
+    expect(pathsList).toContain('freee請求書 API');
+    expect(pathsList).toContain('freee工数管理 API');
+    expect(pathsList).toContain('freee販売 API');
+  });
+});

--- a/vitest.config.e2e-dist.ts
+++ b/vitest.config.e2e-dist.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Vitest configuration for testing built dist files
+ * Tests dynamic file loading and ensures dist is self-contained
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['test/e2e-dist/**/*.test.ts'],
+    // No mocks - we want to test the real dist files
+    // No setup files to avoid interference
+  },
+});


### PR DESCRIPTION
Add test infrastructure to verify that dynamic file loading works
correctly with dist-only files (no source dependencies).

- Create lib.ts as a library entrypoint that exports internal functions
  without starting the MCP server
- Build dist/lib.esm.js for testing schema-loader functionality
- Add vitest.config.e2e-dist.ts for dist-specific tests
- Add test:e2e-dist npm script
- Create e2e tests that validate:
  - All 5 API schemas load from dist/openapi/minimal/
  - Path validation works correctly
  - listAllAvailablePaths works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Library exports are now available for programmatic use, allowing developers to integrate core functionality into their own applications without starting the server.

* **Tests**
  * Added comprehensive end-to-end test coverage for distribution builds to validate library exports, schema loading, and API configuration handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->