### PR TITLE
docs: add Discord community section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ TypeScript / Model Context Protocol SDK / OAuth 2.0 + PKCE / Zod / esbuild
 
 ISC
 
+## コミュニティ
+
+質問や情報交換は Discord サーバーで行っています。お気軽にご参加ください。
+
+- [Discord サーバー](https://discord.gg/fPA75nHp)
+
 ## 関連リンク
 
 - [freee API ドキュメント](https://developer.freee.co.jp/docs)


### PR DESCRIPTION
## Summary

- READMEに「コミュニティ」セクションを追加
- Discordサーバーへの招待リンクを掲載

## Test plan

- [x] READMEの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a community section with Discord invitation link to facilitate user engagement and community participation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->