### PR TITLE
fix: remove unused code and placeholder tests

### DIFF
--- a/src/auth/tokens.ts
+++ b/src/auth/tokens.ts
@@ -16,10 +16,6 @@ function getTokenFilePath(): string {
   return path.join(getConfigDir(), 'tokens.json');
 }
 
-function getLegacyTokenFilePath(companyId: string): string {
-  return path.join(getConfigDir(), `tokens-${companyId}.json`);
-}
-
 export async function saveTokens(tokens: TokenData): Promise<void> {
   const tokenPath = getTokenFilePath();
   const configDir = path.dirname(tokenPath);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -23,10 +23,4 @@ describe('index', () => {
 
     expect(mockCreateAndStartServer.createAndStartServer).toHaveBeenCalled();
   });
-
-  it('should handle server startup error', async () => {
-    // This test is complex due to the module structure, but the main function is covered
-    // The error handling logic is simple and likely to work correctly
-    expect(true).toBe(true);
-  });
 });

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -151,12 +151,6 @@ describe('tools', () => {
         expect(result.content[0].text).toContain('https://auth.url');
       });
 
-      it('should handle missing client ID', async () => {
-        // Skip this test as it's hard to properly mock the config import in this test environment
-        // The main functionality is already tested in other tests
-        expect(true).toBe(true);
-      });
-
     });
 
     describe('freee_auth_status', () => {


### PR DESCRIPTION
- Remove unused getLegacyTokenFilePath function from src/auth/tokens.ts
- Remove placeholder test (should handle missing client ID) from src/mcp/tools.test.ts
- Remove placeholder test (should handle server startup error) from src/index.test.ts

Closes #136