### PR TITLE
chore: remove unused @types/crypto-js dependency

### DIFF
--- a/.changeset/remove-unused-deps.md
+++ b/.changeset/remove-unused-deps.md
@@ -1,0 +1,5 @@
+---
+"@him0/freee-mcp": patch
+---
+
+Remove unused @types/crypto-js from devDependencies to reduce package size

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
     "@modelcontextprotocol/inspector": "^0.17.2",
-    "@types/crypto-js": "^4.2.2",
     "@types/node": "^24.10.1",
     "@types/prompts": "^2.4.9",
     "@typescript-eslint/eslint-plugin": "^8.48.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
       '@modelcontextprotocol/inspector':
         specifier: ^0.17.2
         version: 0.17.2(@types/node@24.10.1)(typescript@5.9.3)
-      '@types/crypto-js':
-        specifier: ^4.2.2
-        version: 4.2.2
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.1
@@ -1333,9 +1330,6 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
-
-  '@types/crypto-js@4.2.2':
-    resolution: {integrity: sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -4197,8 +4191,6 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
-
-  '@types/crypto-js@4.2.2': {}
 
   '@types/deep-eql@4.0.2': {}
 


### PR DESCRIPTION
The codebase uses Node.js built-in crypto module, making this TypeScript
type package unnecessary. This reduces package size.

Fixes #137