### PR TITLE
refactor: extract duplicate patterns into utility functions

### DIFF
--- a/.changeset/refactor-duplicate-patterns.md
+++ b/.changeset/refactor-duplicate-patterns.md
@@ -1,0 +1,9 @@
+---
+"@him0/freee-mcp": patch
+---
+
+refactor: extract duplicate patterns into utility functions
+
+- Add createTextResponse() for MCP text response wrapper pattern
+- Add formatErrorMessage() for error message formatting
+- Refactor tools.ts and client-mode.ts to use new utilities

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -8,3 +8,41 @@
 export async function safeParseJson(response: Response): Promise<Record<string, unknown>> {
   return response.json().catch(() => ({}));
 }
+
+/**
+ * MCP text response type
+ */
+export interface TextResponse {
+  content: {
+    type: 'text';
+    text: string;
+  }[];
+}
+
+/**
+ * Creates a standardized MCP text response.
+ *
+ * @param text - The text content for the response
+ * @returns MCP-formatted text response object
+ */
+export function createTextResponse(text: string): TextResponse {
+  return {
+    content: [
+      {
+        type: 'text',
+        text,
+      },
+    ],
+  };
+}
+
+/**
+ * Formats an error into a string message.
+ * Handles both Error instances and other thrown values.
+ *
+ * @param error - The error to format
+ * @returns Formatted error message string
+ */
+export function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
- Add createTextResponse() to reduce MCP text response boilerplate
- Add formatErrorMessage() for consistent error handling
- Refactor tools.ts and client-mode.ts to use new utilities
- Reduces code by ~130 lines while improving maintainability

Closes #138