### PR TITLE
refactor: migrate deprecated config export to getConfig() function

### DIFF
--- a/.changeset/migrate-config-to-getconfig.md
+++ b/.changeset/migrate-config-to-getconfig.md
@@ -1,0 +1,5 @@
+---
+"@him0/freee-mcp": patch
+---
+
+refactor: migrate deprecated config export to getConfig() function

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -9,12 +9,12 @@ const TEST_ACCESS_TOKEN = 'test-access-token';
 const TEST_DOWNLOAD_DIR = '/tmp';
 
 vi.mock('../config.js', () => ({
-  config: {
+  getConfig: (): { freee: { apiUrl: string; companyId: string } } => ({
     freee: {
       apiUrl: 'https://api.freee.co.jp',
       companyId: '12345'
     }
-  }
+  })
 }));
 
 vi.mock('../config/companies.js', () => ({

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,4 @@
-import { config } from '../config.js';
+import { getConfig } from '../config.js';
 import { getValidAccessToken } from '../auth/tokens.js';
 import { getCurrentCompanyId, getDownloadDir } from '../config/companies.js';
 import { safeParseJson } from '../utils/error.js';
@@ -60,7 +60,7 @@ export async function makeApiRequest(
   body?: Record<string, unknown>,
   baseUrl?: string,
 ): Promise<unknown | BinaryFileResponse> {
-  const apiUrl = baseUrl || config.freee.apiUrl;
+  const apiUrl = baseUrl || getConfig().freee.apiUrl;
   const companyId = await getCurrentCompanyId();
 
   const accessToken = await getValidAccessToken();

--- a/src/auth/oauth.test.ts
+++ b/src/auth/oauth.test.ts
@@ -4,7 +4,10 @@ import { generatePKCE, buildAuthUrl, exchangeCodeForTokens } from './oauth.js';
 
 vi.mock('crypto');
 vi.mock('../config.js', () => ({
-  config: {
+  getConfig: (): {
+    freee: { clientId: string; clientSecret: string };
+    oauth: { authorizationEndpoint: string; tokenEndpoint: string; redirectUri: string; scope: string };
+  } => ({
     freee: {
       clientId: 'test-client-id',
       clientSecret: 'test-client-secret'
@@ -15,7 +18,7 @@ vi.mock('../config.js', () => ({
       redirectUri: 'http://127.0.0.1:54321/callback',
       scope: 'read write'
     }
-  }
+  })
 }));
 
 vi.mock('./tokens.js', () => ({

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -1,7 +1,7 @@
 import http from 'http';
 import { URL } from 'url';
 import net from 'net';
-import { config } from '../config.js';
+import { getConfig } from '../config.js';
 import { TokenData } from './tokens.js';
 import { exchangeCodeForTokens } from './oauth.js';
 
@@ -33,7 +33,7 @@ export class AuthenticationManager {
     const timeout = setTimeout(() => {
       this.pendingAuthentications.delete(state);
       console.error(`Authentication timeout for state: ${state.substring(0, 10)}...`);
-    }, config.auth.timeoutMs);
+    }, getConfig().auth.timeoutMs);
 
     this.pendingAuthentications.set(state, {
       codeVerifier,
@@ -120,7 +120,7 @@ class CallbackServer {
       return;
     }
 
-    const preferredPort = config.oauth.callbackPort;
+    const preferredPort = getConfig().oauth.callbackPort;
     const port = await this.findAvailablePort(preferredPort);
     this.port = port;
 

--- a/src/auth/tokens.test.ts
+++ b/src/auth/tokens.test.ts
@@ -18,7 +18,10 @@ const { tempDir, setup: setupTempDir, cleanup: cleanupTempDir } = setupTestTempD
 
 vi.mock('fs/promises');
 vi.mock('../config.js', () => ({
-  config: {
+  getConfig: (): {
+    oauth: { tokenEndpoint: string; scope: string };
+    freee: { clientId: string; clientSecret: string };
+  } => ({
     oauth: {
       tokenEndpoint: 'https://test.freee.co.jp/token',
       scope: 'read write'
@@ -27,7 +30,7 @@ vi.mock('../config.js', () => ({
       clientId: 'test-client-id',
       clientSecret: 'test-client-secret'
     }
-  }
+  })
 }));
 
 const mockFs = vi.mocked(fs);

--- a/src/auth/tokens.ts
+++ b/src/auth/tokens.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { z } from 'zod';
-import { config } from '../config.js';
+import { getConfig } from '../config.js';
 import { CONFIG_FILE_PERMISSION, getConfigDir } from '../constants.js';
 import { safeParseJson } from '../utils/error.js';
 
@@ -114,7 +114,8 @@ async function tryMigrateLegacyTokens(): Promise<TokenData | null> {
 }
 
 export async function refreshAccessToken(refreshToken: string): Promise<TokenData> {
-  const response = await fetch(config.oauth.tokenEndpoint, {
+  const cfg = getConfig();
+  const response = await fetch(cfg.oauth.tokenEndpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -122,8 +123,8 @@ export async function refreshAccessToken(refreshToken: string): Promise<TokenDat
     body: new URLSearchParams({
       grant_type: 'refresh_token',
       refresh_token: refreshToken,
-      client_id: config.freee.clientId,
-      client_secret: config.freee.clientSecret,
+      client_id: cfg.freee.clientId,
+      client_secret: cfg.freee.clientSecret,
     }),
   });
 
@@ -138,7 +139,7 @@ export async function refreshAccessToken(refreshToken: string): Promise<TokenDat
     refresh_token: tokenResponse.refresh_token || refreshToken,
     expires_at: Date.now() + (tokenResponse.expires_in * 1000),
     token_type: tokenResponse.token_type || 'Bearer',
-    scope: tokenResponse.scope || config.oauth.scope,
+    scope: tokenResponse.scope || cfg.oauth.scope,
   };
 
   await saveTokens(tokens);

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,15 +102,12 @@ export async function loadConfig(): Promise<Config> {
 }
 
 /**
- * Legacy export for backward compatibility
- * @deprecated Use loadConfig() or getConfig() instead
+ * Get cached configuration synchronously
+ * Throws if loadConfig() has not been called yet
  */
-export const config = new Proxy({} as Config, {
-  get(_target, prop): unknown {
-    if (!cachedConfig) {
-      throw new Error('Config not loaded. Call loadConfig() first in async context.');
-    }
-    return cachedConfig[prop as keyof Config];
-  },
-});
-
+export function getConfig(): Config {
+  if (!cachedConfig) {
+    throw new Error('Config not loaded. Call loadConfig() first in async context.');
+  }
+  return cachedConfig;
+}

--- a/src/e2e/auth-flow.e2e.test.ts
+++ b/src/e2e/auth-flow.e2e.test.ts
@@ -20,7 +20,10 @@ let mockCompanyId: string = '12345';
 
 // Mock config module
 vi.mock('../config.js', () => ({
-  config: {
+  getConfig: (): {
+    freee: { clientId: string; clientSecret: string; apiUrl: string; companyId: string };
+    oauth: { callbackPort: number };
+  } => ({
     freee: {
       clientId: 'test-client-id',
       clientSecret: 'test-client-secret',
@@ -30,7 +33,7 @@ vi.mock('../config.js', () => ({
     oauth: {
       callbackPort: 54321,
     },
-  },
+  }),
 }));
 
 // Mock companies module

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -5,7 +5,10 @@ import { addAuthenticationTools } from './tools.js';
 
 vi.mock('crypto');
 vi.mock('../config.js', () => ({
-  config: {
+  getConfig: (): {
+    freee: { clientId: string; clientSecret: string; companyId: string };
+    oauth: { redirectUri: string; callbackPort: number };
+  } => ({
     freee: {
       clientId: 'test-client-id',
       clientSecret: 'test-client-secret',
@@ -15,7 +18,7 @@ vi.mock('../config.js', () => ({
       redirectUri: 'http://127.0.0.1:54321/callback',
       callbackPort: 54321
     }
-  }
+  })
 }));
 
 vi.mock('../config/companies.js', () => ({

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import crypto from 'crypto';
 import { z } from 'zod';
-import { config } from '../config.js';
+import { getConfig } from '../config.js';
 import { makeApiRequest } from '../api/client.js';
 import { loadTokens, clearTokens } from '../auth/tokens.js';
 import { generatePKCE, buildAuthUrl } from '../auth/oauth.js';
@@ -47,7 +47,7 @@ export function addAuthenticationTools(server: McpServer): void {
     {},
     async () => {
       try {
-        if (!config.freee.clientId) {
+        if (!getConfig().freee.clientId) {
           return createTextResponse(
             'FREEE_CLIENT_ID環境変数が設定されていません。\n' +
             'OAuth認証を行うには、freee developersでアプリケーションを作成し、\n' +
@@ -55,7 +55,7 @@ export function addAuthenticationTools(server: McpServer): void {
           );
         }
 
-        if (!config.freee.clientSecret) {
+        if (!getConfig().freee.clientSecret) {
           return createTextResponse(
             'FREEE_CLIENT_SECRET環境変数が設定されていません。\n' +
             'OAuth認証を行うには、freee developersでアプリケーションを作成し、\n' +


### PR DESCRIPTION
- Add getConfig() function to src/config.ts for synchronous access to cached config
- Replace all config imports with getConfig() calls in:
  - src/api/client.ts
  - src/mcp/tools.ts
  - src/auth/tokens.ts
  - src/auth/server.ts
  - src/auth/oauth.ts
- Remove deprecated config Proxy export from src/config.ts
- Update test mocks to use getConfig() instead of config

Closes #139