### PR TITLE
docs: update README to use add-skill for plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ npx @him0/freee-mcp configure
 Claude Code でプラグインとしてインストールすると、API リファレンス付きのスキルが利用できます:
 
 ```bash
-claude plugin marketplace add him0/freee-mcp
-claude plugin install freee-api
+npx add-skill him0/freee-mcp
 ```
+
+[add-skill](https://github.com/anthropics/add-skill) は Claude Code、Cursor、OpenCode など複数のコーディングエージェントに対応したスキルインストーラーです。グローバルインストール(`-g`)や特定スキルのみのインストール(`-s`)も可能です。
 
 ### 含まれるリファレンス
 


### PR DESCRIPTION
## 概要

README.md の「Claude Plugin として使う」セクションを更新し、add-skill パッケージを使った簡単なインストール方法を案内するように変更しました。

変更内容:
- インストールコマンドを `npx add-skill him0/freee-mcp` の1行に簡略化
- add-skill パッケージについての説明を追加（Claude Code、Cursor、OpenCode など複数のコーディングエージェント対応、`-g` や `-s` オプションの説明）

## 変更種別

- [x] ドキュメント