### PR TITLE
fix: improve token error handling with Result type pattern

### DIFF
--- a/.changeset/improve-token-error-handling.md
+++ b/.changeset/improve-token-error-handling.md
@@ -1,0 +1,9 @@
+---
+"@him0/freee-mcp": patch
+---
+
+fix: improve token error handling with Result type pattern
+
+- Replace safeParseJson with parseJsonResponse that returns a Result type, preserving error context instead of silently returning empty object
+- Propagate token refresh errors in getValidAccessToken instead of returning null, allowing callers to understand failure reasons
+- Add comprehensive tests for parseJsonResponse and token refresh failure scenarios

--- a/packages/freee-mcp/src/api/client.test.ts
+++ b/packages/freee-mcp/src/api/client.test.ts
@@ -271,7 +271,7 @@ describe('client', () => {
       });
 
       await expect(makeApiRequest('GET', '/api/1/users/me')).rejects.toThrow(
-        'API request failed: 500\n\n詳細: {}'
+        'API request failed: 500\n\n詳細: (JSON parse failed: Invalid JSON)'
       );
     });
 

--- a/packages/freee-mcp/src/auth/oauth.ts
+++ b/packages/freee-mcp/src/auth/oauth.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import { getConfig } from '../config.js';
 import { saveTokens, TokenData, OAuthTokenResponseSchema } from './tokens.js';
 import { createTokenData } from './token-utils.js';
-import { safeParseJson } from '../utils/error.js';
+import { parseJsonResponse } from '../utils/error.js';
 
 export function generatePKCE(): { codeVerifier: string; codeChallenge: string } {
   const codeVerifier = crypto.randomBytes(32).toString('base64url');
@@ -43,8 +43,11 @@ export async function exchangeCodeForTokens(code: string, codeVerifier: string, 
   });
 
   if (!response.ok) {
-    const errorData = await safeParseJson(response);
-    throw new Error(`Token exchange failed: ${response.status} ${JSON.stringify(errorData)}`);
+    const result = await parseJsonResponse(response);
+    const errorInfo = result.success
+      ? JSON.stringify(result.data)
+      : `(JSON parse failed: ${result.error})`;
+    throw new Error(`Token exchange failed: ${response.status} ${errorInfo}`);
   }
 
   const jsonData: unknown = await response.json();

--- a/packages/freee-mcp/src/auth/tokens.test.ts
+++ b/packages/freee-mcp/src/auth/tokens.test.ts
@@ -284,7 +284,7 @@ describe('tokens', () => {
         ...mockTokenData,
         expires_at: Date.now() - 3600000
       };
-      
+
       mockFs.readFile.mockResolvedValue(JSON.stringify(expiredToken));
       mockFetch.mockResolvedValue({
         ok: true,
@@ -300,6 +300,22 @@ describe('tokens', () => {
       const result = await getValidAccessToken();
 
       expect(result).toBe('new-access-token');
+    });
+
+    it('should throw error when token refresh fails', async () => {
+      const expiredToken = {
+        ...mockTokenData,
+        expires_at: Date.now() - 3600000
+      };
+
+      mockFs.readFile.mockResolvedValue(JSON.stringify(expiredToken));
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error: 'invalid_grant' })
+      });
+
+      await expect(getValidAccessToken()).rejects.toThrow('Token refresh failed: 401');
     });
   });
 });

--- a/packages/freee-mcp/src/auth/tokens.ts
+++ b/packages/freee-mcp/src/auth/tokens.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { z } from 'zod';
 import { getConfig } from '../config.js';
 import { CONFIG_FILE_PERMISSION, getConfigDir } from '../constants.js';
-import { safeParseJson } from '../utils/error.js';
+import { parseJsonResponse } from '../utils/error.js';
 import { createTokenData } from './token-utils.js';
 
 export const TokenDataSchema = z.object({
@@ -141,8 +141,11 @@ export async function refreshAccessToken(refreshToken: string): Promise<TokenDat
   });
 
   if (!response.ok) {
-    const errorData = await safeParseJson(response);
-    throw new Error(`Token refresh failed: ${response.status} ${JSON.stringify(errorData)}`);
+    const result = await parseJsonResponse(response);
+    const errorInfo = result.success
+      ? JSON.stringify(result.data)
+      : `(JSON parse failed: ${result.error})`;
+    throw new Error(`Token refresh failed: ${response.status} ${errorInfo}`);
   }
 
   const jsonData: unknown = await response.json();
@@ -211,11 +214,7 @@ export async function getValidAccessToken(): Promise<string | null> {
     return tokens.access_token;
   }
 
-  try {
-    const newTokens = await refreshAccessToken(tokens.refresh_token);
-    return newTokens.access_token;
-  } catch (error) {
-    console.error('[warn] Failed to refresh token:', error);
-    return null;
-  }
+  // Let refresh errors propagate to caller for proper error handling
+  const newTokens = await refreshAccessToken(tokens.refresh_token);
+  return newTokens.access_token;
 }

--- a/packages/freee-mcp/src/cli.ts
+++ b/packages/freee-mcp/src/cli.ts
@@ -18,7 +18,7 @@ import {
   type McpTarget,
 } from './config/mcp-config.js';
 import { DEFAULT_CALLBACK_PORT, AUTH_TIMEOUT_MS, FREEE_API_URL } from './constants.js';
-import { safeParseJson } from './utils/error.js';
+import { parseJsonResponse } from './utils/error.js';
 
 type Credentials = {
   clientId: string;
@@ -60,9 +60,12 @@ async function fetchCompanies(accessToken: string): Promise<Company[]> {
   });
 
   if (!response.ok) {
-    const errorData = await safeParseJson(response);
+    const result = await parseJsonResponse(response);
+    const errorInfo = result.success
+      ? JSON.stringify(result.data)
+      : `(JSON parse failed: ${result.error})`;
     throw new Error(
-      `事業所一覧の取得に失敗しました: ${response.status} ${JSON.stringify(errorData)}`,
+      `事業所一覧の取得に失敗しました: ${response.status} ${errorInfo}`,
     );
   }
 

--- a/packages/freee-mcp/src/utils/error.test.ts
+++ b/packages/freee-mcp/src/utils/error.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseJsonResponse,
+  createTextResponse,
+  formatErrorMessage,
+} from './error.js';
+
+describe('parseJsonResponse', () => {
+  it('should return success with parsed data for valid JSON', async () => {
+    const mockResponse = {
+      json: () => Promise.resolve({ error: 'test_error', message: 'Test message' }),
+    } as Response;
+
+    const result = await parseJsonResponse(mockResponse);
+
+    expect(result).toEqual({
+      success: true,
+      data: { error: 'test_error', message: 'Test message' },
+    });
+  });
+
+  it('should return failure with error message when JSON parsing fails', async () => {
+    const mockResponse = {
+      json: () => Promise.reject(new Error('Invalid JSON')),
+    } as Response;
+
+    const result = await parseJsonResponse(mockResponse);
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Invalid JSON',
+    });
+  });
+
+  it('should handle non-Error throws during JSON parsing', async () => {
+    const mockResponse = {
+      json: () => Promise.reject('String error'),
+    } as Response;
+
+    const result = await parseJsonResponse(mockResponse);
+
+    expect(result).toEqual({
+      success: false,
+      error: 'String error',
+    });
+  });
+});
+
+describe('createTextResponse', () => {
+  it('should create MCP text response with given text', () => {
+    const result = createTextResponse('Hello, world!');
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: 'Hello, world!',
+        },
+      ],
+    });
+  });
+
+  it('should handle empty string', () => {
+    const result = createTextResponse('');
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: 'text',
+          text: '',
+        },
+      ],
+    });
+  });
+});
+
+describe('formatErrorMessage', () => {
+  it('should return error message for Error instances', () => {
+    const error = new Error('Test error message');
+    const result = formatErrorMessage(error);
+
+    expect(result).toBe('Test error message');
+  });
+
+  it('should convert non-Error values to string', () => {
+    expect(formatErrorMessage('string error')).toBe('string error');
+    expect(formatErrorMessage(123)).toBe('123');
+    expect(formatErrorMessage(null)).toBe('null');
+    expect(formatErrorMessage(undefined)).toBe('undefined');
+  });
+});

--- a/packages/freee-mcp/src/utils/error.ts
+++ b/packages/freee-mcp/src/utils/error.ts
@@ -1,12 +1,25 @@
 /**
- * Safely parses JSON from a Response object.
- * Returns an empty object if parsing fails.
+ * Result type for JSON parsing operations.
+ * Allows callers to distinguish between success and failure while preserving error context.
+ */
+export type JsonParseResult =
+  | { success: true; data: Record<string, unknown> }
+  | { success: false; error: string };
+
+/**
+ * Parses JSON from a Response object with Result type pattern.
+ * Preserves error context on failure instead of silently returning empty object.
  *
  * @param response - The fetch Response object to parse
- * @returns Parsed JSON data or empty object on failure
+ * @returns Result object with parsed data or error message
  */
-export async function safeParseJson(response: Response): Promise<Record<string, unknown>> {
-  return response.json().catch(() => ({}));
+export async function parseJsonResponse(response: Response): Promise<JsonParseResult> {
+  try {
+    const data = await response.json();
+    return { success: true, data };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace `safeParseJson` with `parseJsonResponse` that returns a Result type (`{ success: true, data }` or `{ success: false, error }`), preserving error context on JSON parse failures
- Propagate token refresh errors in `getValidAccessToken` instead of returning `null`, allowing callers to understand failure reasons
- Add comprehensive tests for `parseJsonResponse` and token refresh failure scenarios

Closes #153

## Test plan

- [x] Run `pnpm typecheck` - passes
- [x] Run `pnpm lint` - passes
- [x] Run `pnpm test:run` - 192 tests pass
- [x] Run `pnpm build` - builds successfully