### PR TITLE
feat: add Zod validation for external API responses

### DIFF
--- a/.changeset/add-zod-validation.md
+++ b/.changeset/add-zod-validation.md
@@ -1,0 +1,5 @@
+---
+"@him0/freee-mcp": patch
+---
+
+Add Zod validation for external API responses to prevent silent failures from invalid response formats

--- a/packages/freee-mcp/src/api/client.test.ts
+++ b/packages/freee-mcp/src/api/client.test.ts
@@ -39,6 +39,7 @@ interface MockJsonResponse {
   ok: true;
   headers: MockHeaders;
   json: () => Promise<unknown>;
+  text: () => Promise<string>;
 }
 
 interface MockErrorResponse {
@@ -69,7 +70,8 @@ function createJsonResponse(data: unknown): MockJsonResponse {
   return {
     ok: true,
     headers: createMockHeaders('application/json'),
-    json: () => Promise.resolve(data)
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data))
   };
 }
 

--- a/packages/freee-mcp/src/api/client.ts
+++ b/packages/freee-mcp/src/api/client.ts
@@ -183,5 +183,12 @@ export async function makeApiRequest(
     } as BinaryFileResponse;
   }
 
-  return response.json();
+  const text = await response.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(
+      `Failed to parse API response as JSON. Status: ${response.status}, Content-Type: ${contentType}, Body preview: ${text.slice(0, 200)}`
+    );
+  }
 }

--- a/packages/freee-mcp/src/auth/oauth.test.ts
+++ b/packages/freee-mcp/src/auth/oauth.test.ts
@@ -21,9 +21,13 @@ vi.mock('../config.js', () => ({
   })
 }));
 
-vi.mock('./tokens.js', () => ({
-  saveTokens: vi.fn()
-}));
+vi.mock('./tokens.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    saveTokens: vi.fn()
+  };
+});
 
 const mockCrypto = vi.mocked(crypto);
 const mockFetch = vi.fn();


### PR DESCRIPTION
## Summary

- Add runtime validation using Zod for external API responses to prevent silent failures from invalid response formats
- Add `OAuthTokenResponseSchema` for OAuth token responses validation in `tokens.ts` and `oauth.ts`
- Add `CompanySchema` and `CompaniesResponseSchema` for companies API validation in `cli.ts`
- Improve JSON parse error handling in `api/client.ts` with detailed error messages including status, content-type, and body preview

## Test plan

- [x] Run `pnpm typecheck` - passed
- [x] Run `pnpm lint` - passed
- [x] Run `pnpm test:run` - 184 tests passed
- [x] Run `pnpm build` - passed

Fixes #155