### PR TITLE
fix: mark freee-agent as private to exclude from npm publish

### DIFF
--- a/.changeset/freee-agent-private.md
+++ b/.changeset/freee-agent-private.md
@@ -1,0 +1,5 @@
+---
+"@him0/freee-mcp": patch
+---
+
+freee-agent パッケージを private に設定し、npm publish 対象から除外

--- a/packages/freee-agent/package.json
+++ b/packages/freee-agent/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "type": "module",
   "name": "@him0/freee-agent",
   "version": "0.1.0",


### PR DESCRIPTION
## Summary
- freee-agent パッケージに `private: true` を追加
- npm publish 時のエラーを防止

## Changes
- `packages/freee-agent/package.json` に `private: true` を追加
- changeset を追加（0.6.3 リリース用）

🤖 Generated with [Claude Code](https://claude.ai/code)