### PR TITLE
chore: remove auto-trigger from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,18 +1,15 @@
 name: Publish
 
 on:
-  pull_request:
-    types: [closed]
   workflow_dispatch:
+    branches:
+      - main
 
 jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true &&
-       contains(github.event.pull_request.labels.*.name, 'release'))
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
## Summary
- publish.yml から pull_request トリガーを削除
- 手動実行（workflow_dispatch）のみに変更

## Reason
GITHUB_TOKEN で作成された PR（changesets/action による Release PR）がマージされても、
GitHub のセキュリティ制限により新しいワークフローはトリガーされない。
そのため、自動トリガーロジックは実質的に機能していなかった。

## Release Process
1. Release CI を手動実行 → Release PR が作成される
2. Release PR をマージ
3. Publish CI を手動実行（`gh workflow run publish.yml`）

🤖 Generated with [Claude Code](https://claude.ai/code)