### PR TITLE
fix: publish CI の grep マッチなし時の失敗を修正

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,7 +102,7 @@ jobs:
               --search "closed:>=$PREV_DATE" \
               --json body \
               --jq '.[].body' \
-            | grep -oP 'by @\K[^\s)+]+' \
+            | { grep -oP 'by @\K[^\s)+]+' || true; } \
             | sort -u)
 
             if [ -n "$USERS" ]; then


### PR DESCRIPTION
## 概要

Publish ワークフローの「Collect contributors from community PRs」ステップで、`from-pr` ラベルの issue が存在しない場合に CI が失敗する問題を修正。

`grep -oP` はマッチなしで exit code 1 を返すが、スクリプトが `bash -e -o pipefail` で実行されているため、パイプライン全体が失敗していた。`{ grep ... || true; }` で囲むことで、マッチなしでもスクリプトが継続するようにした。

## 変更種別

- [x] バグ修正