### PR TITLE
feat: .worktreeinclude ファイルを追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,11 @@
+# Claude Code local settings
+.claude/settings.local.json
+
+# Local project memory
+CLAUDE.local.md
+
+# mise local config
+mise.local.toml
+
+# VSCode settings
+.vscode/settings.json


### PR DESCRIPTION
## 概要

worktree 作成時に gitignore されたローカル設定ファイルを自動コピーする `.worktreeinclude` を追加。
Claude Desktop の worktree 機能で、以下のファイルが新しい worktree にコピーされるようになる。

- `.claude/settings.local.json` - ローカルの権限設定やMCPサーバー設定
- `CLAUDE.local.md` - 個人用のプロジェクトメモリ
- `mise.local.toml` - mise のローカル設定
- `.vscode/settings.json` - VSCode 設定

## 変更種別

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他