### PR TITLE
コールバックURLの表示を分かりやすく改善

### DIFF
--- a/.changeset/clarify-callback-url.md
+++ b/.changeset/clarify-callback-url.md
@@ -1,0 +1,5 @@
+---
+"@him0/freee-mcp": patch
+---
+
+configure コマンドでコールバックURLを分かりやすく表示するように改善

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -184,7 +184,7 @@ class CallbackServer {
       });
 
       this.server.listen(port, '127.0.0.1', () => {
-        console.error(`OAuth callback server listening on http://127.0.0.1:${port}`);
+        console.error(`OAuth callback server listening on http://127.0.0.1:${port} (callback URL: http://127.0.0.1:${port}/callback)`);
         resolve();
       });
     });

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -21,6 +21,9 @@ export async function collectCredentials(): Promise<Credentials> {
 
   console.log('ステップ 1/3: OAuth認証情報の入力\n');
 
+  const defaultPort = existingConfig.callbackPort || DEFAULT_CALLBACK_PORT;
+  console.log(`freee アプリのコールバックURLには http://127.0.0.1:${defaultPort}/callback を設定してください。\n`);
+
   const credentials = await prompts([
     {
       type: 'text',
@@ -46,8 +49,8 @@ export async function collectCredentials(): Promise<Credentials> {
     {
       type: 'text',
       name: 'callbackPort',
-      message: 'FREEE_CALLBACK_PORT:',
-      initial: String(existingConfig.callbackPort || DEFAULT_CALLBACK_PORT),
+      message: `コールバックポート (コールバックURL: http://127.0.0.1:<port>/callback):`,
+      initial: String(defaultPort),
     },
   ]);
 


### PR DESCRIPTION
## 概要

OAuth認証設定時のコールバックURL表示を改善しました。ユーザーが freee アプリに設定すべきコールバックURLを明確に理解できるようにしました。

## 変更内容

### src/cli/prompts.ts
- `collectCredentials()` 関数で、OAuth認証情報入力前にコールバックURLの設定値を表示するようにしました
- コールバックポート入力プロンプトのメッセージを `FREEE_CALLBACK_PORT:` から `コールバックポート (コールバックURL: http://127.0.0.1:<port>/callback):` に変更し、ユーザーが設定すべきURLを直感的に理解できるようにしました

### src/auth/server.ts
- OAuth callback サーバー起動時のログメッセージに `/callback` パスを明示し、完全なコールバックURLを表示するようにしました

## 変更種別

- [x] リファクタリング

## テスト

configure コマンド実行時にコールバックURLが正しく表示されることを確認済みです。

https://claude.ai/code/session_013BTV3QChtPn4mC37TgpqHQ