### PR TITLE
fix: パッケージ名とリポジトリURLをfreee organizationに更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @him0/freee-mcp
+# freee-mcp
 
 freee API を Claude から使えるようにする MCP サーバー & Claude Plugin です。
 
@@ -84,7 +84,7 @@ npx @him0/freee-mcp configure
   "mcpServers": {
     "freee": {
       "command": "npx",
-      "args": ["@him0/freee-mcp"]
+      "args": ["freee-mcp"]
     }
   }
 }
@@ -92,7 +92,7 @@ npx @him0/freee-mcp configure
 
 > ⚠️ 環境変数での設定について
 > 環境変数（`FREEE_CLIENT_ID`、`FREEE_CLIENT_SECRET` など）を使った設定は非推奨です。
-> 代わりに `npx @him0/freee-mcp configure` を実行して設定ファイルに移行してください。
+> 代わりに `npx freee-mcp configure` を実行して設定ファイルに移行してください。
 > 環境変数設定は将来のバージョンで削除される予定です。
 
 ## Claude Plugin として使う
@@ -100,7 +100,7 @@ npx @him0/freee-mcp configure
 Claude Code でプラグインとしてインストールすると、API リファレンス付きのスキルが利用できます:
 
 ```bash
-npx add-skill him0/freee-mcp
+npx add-skill freee/freee-mcp
 ```
 
 [add-skill](https://github.com/anthropics/add-skill) は Claude Code、Cursor、OpenCode など複数のコーディングエージェントに対応したスキルインストーラーです。グローバルインストール(`-g`)や特定スキルのみのインストール(`-s`)も可能です。
@@ -187,7 +187,7 @@ Issue での不具合報告や機能要望、フィードバックは大歓迎�
 ## 開発者向け
 
 ```bash
-git clone https://github.com/him0/freee-mcp.git
+git clone https://github.com/freee/freee-mcp.git
 cd freee-mcp
 pnpm install
 
@@ -211,7 +211,7 @@ TypeScript / Model Context Protocol SDK / OAuth 2.0 + PKCE / Zod / esbuild
 
 ## ライセンス
 
-ISC
+Apache-2.0
 
 ## コミュニティ
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "name": "@him0/freee-mcp",
+  "name": "freee-mcp",
   "version": "0.7.0",
   "bin": {
     "freee-mcp": "./bin/cli.js"
@@ -26,8 +26,8 @@
     "version": "changeset version",
     "release": "pnpm build && changeset publish"
   },
-  "author": "him0",
-  "license": "ISC",
+  "author": "freee_jp",
+  "license": "Apache-2.0",
   "description": "Model Context Protocol (MCP) server for freee API integration",
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
@@ -64,7 +64,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/him0/freee-mcp.git"
+    "url": "https://github.com/freee/freee-mcp.git"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
## 概要

パッケージ名とリポジトリURLをhim0の個人アカウントからfreee organizationに移行します。


## やったこと

- パッケージ名を`@him0/freee-mcp`から`freee-mcp`に変更
- リポジトリURLを`https://github.com/him0/freee-mcp.git`から`https://github.com/freee/freee-mcp.git`に変更
- README内の全てのパッケージ名参照を更新
- add-skillコマンドの引数を`him0/freee-mcp`から`freee/freee-mcp`に更新
- package.jsonのauthorを`him0`から`freee_jp`に変更
- ライセンスをISCからApache-2.0に変更

## 確認方法

- [ ] パッケージがnpmに正常に公開できることを確認
- [ ] `npx freee-mcp configure`コマンドが正常に動作することを確認
- [ ] `npx add-skill freee/freee-mcp`コマンドが正常に動作することを確認
- [ ] README内のリンクが正しく機能することを確認

## 影響範囲と注意事項

- 既存のユーザーは`@him0/freee-mcp`から`freee-mcp`への移行が必要になります
- 公開後は、旧パッケージ名での参照を更新するアナウンスが必要です