### PR TITLE
chore: rename package and repository references for freee org migration

### DIFF
--- a/.changeset/modern-hounds-learn.md
+++ b/.changeset/modern-hounds-learn.md
@@ -1,2 +1,5 @@
 ---
+"freee-mcp": patch
 ---
+
+npm パッケージ名を @him0/freee-mcp から freee-mcp に変更したことに伴い、全ファイルの参照を更新

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,7 +10,7 @@
     "freee": {
       "command": "npx",
       "args": [
-        "@him0/freee-mcp",
+        "freee-mcp",
         "client"
       ]
     }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -154,8 +154,8 @@ jobs:
             See [CHANGELOG.md](./CHANGELOG.md) for details.
             ${{ steps.contributors.outputs.list != '' && format('\n## Contributors\n\nThank you to the following contributors for their suggestions!\n\n{0}\n', steps.contributors.outputs.list) || '' }}
             ## Package
-            - npm: https://www.npmjs.com/package/@him0/freee-mcp/v/${{ steps.version.outputs.version }}
-            - Install: `npm install @him0/freee-mcp@${{ steps.version.outputs.version }}`
+            - npm: https://www.npmjs.com/package/freee-mcp/v/${{ steps.version.outputs.version }}
+            - Install: `npm install freee-mcp@${{ steps.version.outputs.version }}`
 
             ## Claude Plugin
             This repository can also be used as a Claude Code plugin:
@@ -173,11 +173,11 @@ jobs:
         id: check-npm
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          if npm view @him0/freee-mcp@$VERSION version 2>/dev/null; then
-            echo "ℹ️  npm package @him0/freee-mcp@$VERSION already exists - skipping"
+          if npm view freee-mcp@$VERSION version 2>/dev/null; then
+            echo "ℹ️  npm package freee-mcp@$VERSION already exists - skipping"
             echo "skip=true" >> $GITHUB_OUTPUT
           else
-            echo "✅ npm package @him0/freee-mcp@$VERSION does not exist - will publish"
+            echo "✅ npm package freee-mcp@$VERSION does not exist - will publish"
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @him0/freee-mcp
+# freee-mcp
 
 ## 0.7.0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ After running `freee-mcp configure`:
   "mcpServers": {
     "freee": {
       "command": "npx",
-      "args": ["@him0/freee-mcp"]
+      "args": ["freee-mcp"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ freee API を Claude から使えるようにする MCP サーバー & Claude Pl
 
 MCP サーバー（API 呼び出し機能）と skill（API リファレンス）を組み合わせて利用することを想定しています。
 
-[![npm version](https://badge.fury.io/js/@him0%2Ffreee-mcp.svg)](https://www.npmjs.com/package/@him0/freee-mcp)
+[![npm version](https://badge.fury.io/js/freee-mcp.svg)](https://www.npmjs.com/package/freee-mcp)
 
 > Note: このプロジェクトは開発中であり、予期せぬ不具合が発生する可能性があります。問題を発見された場合は [Issue](https://github.com/him0/freee-mcp/issues) として報告していただけると幸いです。
 
@@ -64,7 +64,7 @@ sequenceDiagram
 ### 2. セットアップ
 
 ```bash
-npx @him0/freee-mcp configure
+npx freee-mcp configure
 ```
 
 対話式ウィザードが認証情報の設定、OAuth認証、事業所選択を行います。
@@ -177,11 +177,13 @@ Issue での不具合報告や機能要望、フィードバックは大歓迎�
 ### Contributors
 
 <!-- CONTRIBUTORS-START -->
+<a href="https://github.com/him0"><img src="https://github.com/him0.png" width="40" height="40" alt="@him0"></a>
 <a href="https://github.com/dais0n"><img src="https://github.com/dais0n.png" width="40" height="40" alt="@dais0n"></a>
 <a href="https://github.com/HikaruEgashira"><img src="https://github.com/HikaruEgashira.png" width="40" height="40" alt="@HikaruEgashira"></a>
 <a href="https://github.com/nakanoasaservice"><img src="https://github.com/nakanoasaservice.png" width="40" height="40" alt="@nakanoasaservice"></a>
 <a href="https://github.com/tackeyy"><img src="https://github.com/tackeyy.png" width="40" height="40" alt="@tackeyy"></a>
 <a href="https://github.com/worldscandy"><img src="https://github.com/worldscandy.png" width="40" height="40" alt="@worldscandy"></a>
+<a href="https://github.com/akhr77"><img src="https://github.com/akhr77.png" width="40" height="40" alt="@akhr77"></a>
 <!-- CONTRIBUTORS-END -->
 
 ## 開発者向け

--- a/skills/freee-api-skill/SKILL.md
+++ b/skills/freee-api-skill/SKILL.md
@@ -7,7 +7,7 @@ description: "freee API を MCP 経由で操作するスキル。会計・人事
 
 ## 概要
 
-[@him0/freee-mcp](https://www.npmjs.com/package/@him0/freee-mcp) (MCP サーバー) を通じて freee API と連携。
+[freee-mcp](https://www.npmjs.com/package/freee-mcp) (MCP サーバー) を通じて freee API と連携。
 
 このスキルの役割:
 
@@ -21,7 +21,7 @@ description: "freee API を MCP 経由で操作するスキル。会計・人事
 ### 1. OAuth 認証（あなたのターミナルで実行）
 
 ```bash
-npx @him0/freee-mcp configure
+npx freee-mcp configure
 ```
 
 ブラウザで freee にログインし、事業所を選択します。設定は `~/.config/freee-mcp/config.json` に保存されます。
@@ -128,5 +128,5 @@ serviceパラメータ (必須):
 
 ## 関連リンク
 
-- [freee-mcp](https://www.npmjs.com/package/@him0/freee-mcp)
+- [freee-mcp](https://www.npmjs.com/package/freee-mcp)
 - [freee API ドキュメント](https://developer.freee.co.jp/docs)

--- a/src/config/mcp-config.test.ts
+++ b/src/config/mcp-config.test.ts
@@ -109,7 +109,7 @@ describe('mcp-config', () => {
       mockFs.readFile.mockResolvedValue(
         JSON.stringify({
           mcpServers: {
-            'freee-mcp': { command: 'npx', args: ['@him0/freee-mcp'] },
+            'freee-mcp': { command: 'npx', args: ['freee-mcp'] },
           },
         })
       );
@@ -151,7 +151,7 @@ describe('mcp-config', () => {
       );
       expect(writtenContent.mcpServers['freee-mcp']).toEqual({
         command: 'npx',
-        args: ['@him0/freee-mcp'],
+        args: ['freee-mcp'],
       });
     });
 
@@ -178,7 +178,7 @@ describe('mcp-config', () => {
       });
       expect(writtenContent.mcpServers['freee-mcp']).toEqual({
         command: 'npx',
-        args: ['@him0/freee-mcp'],
+        args: ['freee-mcp'],
       });
     });
 
@@ -224,7 +224,7 @@ describe('mcp-config', () => {
         JSON.stringify({
           mcpServers: {
             'other-mcp': { command: 'npx', args: ['other-mcp'] },
-            'freee-mcp': { command: 'npx', args: ['@him0/freee-mcp'] },
+            'freee-mcp': { command: 'npx', args: ['freee-mcp'] },
           },
         })
       );
@@ -245,7 +245,7 @@ describe('mcp-config', () => {
         JSON.stringify({
           someOtherSetting: true,
           mcpServers: {
-            'freee-mcp': { command: 'npx', args: ['@him0/freee-mcp'] },
+            'freee-mcp': { command: 'npx', args: ['freee-mcp'] },
           },
         })
       );
@@ -281,7 +281,7 @@ describe('mcp-config', () => {
       mockFs.readFile.mockResolvedValueOnce(
         JSON.stringify({
           mcpServers: {
-            'freee-mcp': { command: 'npx', args: ['@him0/freee-mcp'] },
+            'freee-mcp': { command: 'npx', args: ['freee-mcp'] },
           },
         })
       );
@@ -293,7 +293,7 @@ describe('mcp-config', () => {
       mockFs.readFile.mockResolvedValueOnce(
         JSON.stringify({
           mcpServers: {
-            'freee-mcp': { command: 'npx', args: ['@him0/freee-mcp'] },
+            'freee-mcp': { command: 'npx', args: ['freee-mcp'] },
           },
         })
       );

--- a/src/config/mcp-config.ts
+++ b/src/config/mcp-config.ts
@@ -32,7 +32,7 @@ const FREEE_MCP_SERVER_NAME = 'freee-mcp';
 
 const FREEE_MCP_SERVER_CONFIG: McpServerEntry = {
   command: 'npx',
-  args: ['@him0/freee-mcp'],
+  args: ['freee-mcp'],
 };
 
 /**


### PR DESCRIPTION
## 概要

npm パッケージを `@him0/freee-mcp` から `freee-mcp` に移管し、リポジトリを `freee/freee-mcp` に移管したことに伴い、コードベース全体の参照を更新。

- npm パッケージ名: `@him0/freee-mcp` → `freee-mcp`
- GitHub リポジトリ URL: `him0/freee-mcp` → `freee/freee-mcp`
- コントリビューターに him0 と akhr77 を追加

## 変更種別

- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント
- [x] その他