### PR TITLE
chore: update GitHub repository URLs from him0/freee-mcp to freee/freee-mcp

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "him0"
   },
-  "repository": "https://github.com/him0/freee-mcp",
+  "repository": "https://github.com/freee/freee-mcp",
   "mcpServers": {
     "freee": {
       "command": "npx",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -160,7 +160,7 @@ jobs:
             ## Claude Plugin
             This repository can also be used as a Claude Code plugin:
             ```bash
-            claude plugin add him0/freee-mcp
+            claude plugin add freee/freee-mcp
             ```
           files: freee-skill.zip
           draft: false

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ MCP サーバー（API 呼び出し機能）と skill（API リファレンス�
 
 [![npm version](https://badge.fury.io/js/freee-mcp.svg)](https://www.npmjs.com/package/freee-mcp)
 
-> Note: このプロジェクトは開発中であり、予期せぬ不具合が発生する可能性があります。問題を発見された場合は [Issue](https://github.com/him0/freee-mcp/issues) として報告していただけると幸いです。
+> Note: このプロジェクトは開発中であり、予期せぬ不具合が発生する可能性があります。問題を発見された場合は [Issue](https://github.com/freee/freee-mcp/issues) として報告していただけると幸いです。
 
 ## 特徴
 

--- a/skills/freee-api-skill/docs/troubleshooting.md
+++ b/skills/freee-api-skill/docs/troubleshooting.md
@@ -291,7 +291,7 @@ https://developer.freee.co.jp/docs
 
 ### GitHub Issues
 
-https://github.com/him0/freee-mcp/issues
+https://github.com/freee/freee-mcp/issues
 
 ### 問い合わせ前に確認すること
 

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -162,7 +162,7 @@ async function configureMcpTarget(target: McpTarget): Promise<boolean> {
   }
 }
 
-const SKILL_RELEASES_URL = 'https://github.com/him0/freee-mcp/releases/latest';
+const SKILL_RELEASES_URL = 'https://github.com/freee/freee-mcp/releases/latest';
 
 function showSkillInstallGuide(claudeCodeConfigured: boolean, claudeDesktopConfigured: boolean): void {
   if (!claudeCodeConfigured && !claudeDesktopConfigured) {
@@ -175,7 +175,7 @@ function showSkillInstallGuide(claudeCodeConfigured: boolean, claudeDesktopConfi
   if (claudeCodeConfigured) {
     console.log('[Claude Code]');
     console.log('  以下のコマンドで freee API スキルをインストールできます:\n');
-    console.log('  npx add-skill him0/freee-mcp\n');
+    console.log('  npx add-skill freee/freee-mcp\n');
   }
 
   if (claudeDesktopConfigured) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -58,4 +58,4 @@ export const PACKAGE_VERSION = typeof __PACKAGE_VERSION__ !== 'undefined' ? __PA
  * Format follows RFC 7231: ProductName/Version (comments)
  * @see https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3
  */
-export const USER_AGENT = `freee-mcp/${PACKAGE_VERSION} (MCP Server; +https://github.com/him0/freee-mcp)`;
+export const USER_AGENT = `freee-mcp/${PACKAGE_VERSION} (MCP Server; +https://github.com/freee/freee-mcp)`;


### PR DESCRIPTION
## 概要

リポジトリを `freee/freee-mcp` に移管したことに伴い、コードベース内の GitHub URL 参照を更新。

- User-Agent の GitHub URL
- skill リリース URL、add-skill コマンド
- plugin.json の repository URL
- publish workflow の claude plugin add コマンド
- README、troubleshooting の Issue リンク

## 変更種別

- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント
- [x] その他