### PR TITLE
ci: migrate npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.changeset/bright-doors-taste.md
+++ b/.changeset/bright-doors-taste.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+npm publish を Trusted Publishing (OIDC) に移行し、NPM_TOKEN シークレットを不要に

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -181,12 +181,11 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Publish to npm
+      - name: Publish to npm (Trusted Publishing)
         if: steps.check-npm.outputs.skip != 'true'
         run: pnpm run release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
 
       - name: Sync plugin.json version
         if: steps.check-npm.outputs.skip != 'true'


### PR DESCRIPTION
## 概要

npm publish を NPM_TOKEN ベースから Trusted Publishing (OIDC) に移行。
GitHub Actions の OIDC トークンで認証するため、NPM_TOKEN シークレットが不要になります。

前提: npmjs.com で freee-mcp パッケージに Trusted Publisher として `freee/freee-mcp` リポジトリの `publish.yml` を登録する必要があります。

## 変更種別

- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [x] その他