### PR TITLE
docs: 勤怠操作ガイドを新設し、人事労務ガイドを従業員・給与に整理

### DIFF
--- a/.changeset/add-attendance-guide.md
+++ b/.changeset/add-attendance-guide.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+勤怠操作ガイド(hr-attendance-operations.md)を新設し、hr-operations.mdをhr-employee-operations.mdにリネーム・整理

--- a/skills/freee-api-skill/SKILL.md
+++ b/skills/freee-api-skill/SKILL.md
@@ -101,7 +101,8 @@ serviceパラメータ (必須):
 
 - `docs/expense-application-operations.md` - 経費申請
 - `docs/deal-operations.md` - 取引（収入・支出）
-- `docs/hr-operations.md` - 人事労務（従業員・勤怠）
+- `docs/hr-employee-operations.md` - 人事労務（従業員・給与）
+- `docs/hr-attendance-operations.md` - 勤怠（出退勤・打刻・休憩の登録）
 - `docs/invoice-operations.md` - 請求書・見積書・納品書
 
 ## エラー対応

--- a/skills/freee-api-skill/docs/hr-attendance-operations.md
+++ b/skills/freee-api-skill/docs/hr-attendance-operations.md
@@ -1,0 +1,100 @@
+# 勤怠の操作
+
+freee人事労務APIを使った勤怠管理ガイド。
+
+## 利用可能なパス
+
+| パス | 説明 |
+|------|------|
+| `/api/v1/employees/{id}/work_records/{date}` | 勤怠記録（GET/PUT/DELETE） |
+| `/api/v1/employees/{id}/time_clocks` | 打刻（POST） |
+| `/api/v1/employees/{id}/work_record_summaries/{year}/{month}` | 勤怠サマリ（GET） |
+
+## 使用例
+
+### 勤怠記録を取得
+
+```
+freee_api_get {
+  "service": "hr",
+  "path": "/api/v1/employees/{employee_id}/work_records/2025-01-15",
+  "query": { "company_id": 123456 }
+}
+```
+
+`is_editable: true` であれば更新可能です。
+
+### 打刻を登録
+
+```
+freee_api_post {
+  "service": "hr",
+  "path": "/api/v1/employees/{employee_id}/time_clocks",
+  "body": {
+    "company_id": 123456,
+    "type": "clock_in",
+    "datetime": "2025-01-15T09:00:00+09:00"
+  }
+}
+```
+
+### 出退勤時刻と休憩時間を登録・更新
+
+`work_record_segments` で出退勤時刻、`break_records` で休憩時間を指定します。
+
+```
+freee_api_put {
+  "service": "hr",
+  "path": "/api/v1/employees/{employee_id}/work_records/2025-01-15",
+  "body": {
+    "company_id": 123456,
+    "work_record_segments": [
+      {
+        "clock_in_at": "2025-01-15 10:40:00",
+        "clock_out_at": "2025-01-15 20:15:00"
+      }
+    ],
+    "break_records": [
+      {
+        "clock_in_at": "2025-01-15 12:00:00",
+        "clock_out_at": "2025-01-15 13:00:00"
+      }
+    ]
+  }
+}
+```
+
+- 時刻はJST（`+09:00`）として扱われる（タイムゾーン省略可）
+- `break_records` を空配列にすると休憩なしになる
+- 複数回の出退勤がある場合は `work_record_segments` に複数要素を指定する
+- 既に登録済みの勤怠も同じAPIで上書き更新できる
+
+## Tips
+
+### 打刻タイプ
+
+| type | 説明 |
+|------|------|
+| `clock_in` | 出勤 |
+| `clock_out` | 退勤 |
+| `break_begin` | 休憩開始 |
+| `break_end` | 休憩終了 |
+
+### self_only 権限について
+
+`/api/v1/employees` は管理者権限が必要ですが、`/api/v1/users/me` で自分の `employee_id` を取得すれば、自分の勤怠は操作可能です。
+
+```
+freee_api_get {
+  "service": "hr",
+  "path": "/api/v1/users/me",
+  "query": { "company_id": 123456 }
+}
+```
+
+レスポンスの `companies[].employee_id` が自分の従業員IDです。
+
+## リファレンス
+
+- `references/hr-attendances.md` - 勤怠API詳細
+- `references/hr-time-clocks.md` - 打刻API詳細

--- a/skills/freee-api-skill/docs/hr-employee-operations.md
+++ b/skills/freee-api-skill/docs/hr-employee-operations.md
@@ -1,4 +1,4 @@
-# 人事労務の操作
+# 従業員・給与の操作
 
 freee人事労務APIを使った従業員・勤怠管理ガイド。
 
@@ -15,14 +15,6 @@ freee人事労務APIを使った従業員・勤怠管理ガイド。
 | `/api/v1/employees` | 従業員一覧（対象年月指定） |
 | `/api/v1/companies/{company_id}/employees` | 全期間の従業員一覧 |
 | `/api/v1/employees/{id}` | 従業員詳細 |
-
-### 勤怠関連
-
-| パス | 説明 |
-|------|------|
-| `/api/v1/employees/{id}/work_records/{date}` | 勤怠記録 |
-| `/api/v1/employees/{id}/time_clocks` | 打刻 |
-| `/api/v1/employees/{id}/work_record_summaries/{year}/{month}` | 勤怠サマリ |
 
 ### 給与関連
 
@@ -59,29 +51,6 @@ freee_api_get {
 }
 ```
 
-### 従業員の勤怠記録を取得
-
-```
-freee_api_get {
-  "service": "hr",
-  "path": "/api/v1/employees/1/work_records/2025-01-15"
-}
-```
-
-### 打刻を登録
-
-```
-freee_api_post {
-  "service": "hr",
-  "path": "/api/v1/employees/1/time_clocks",
-  "body": {
-    "company_id": 123456,
-    "type": "clock_in",
-    "datetime": "2025-01-15T09:00:00+09:00"
-  }
-}
-```
-
 ### 給与明細一覧を取得
 
 ```
@@ -104,15 +73,6 @@ freee_api_get {
 | 種類 | URL形式 |
 |------|---------|
 | 従業員詳細 | `https://p.secure.freee.co.jp/employees/{id}` |
-
-### 打刻タイプ
-
-| type | 説明 |
-|------|------|
-| `clock_in` | 出勤 |
-| `clock_out` | 退勤 |
-| `break_begin` | 休憩開始 |
-| `break_end` | 休憩終了 |
 
 ### 翌月払いの従業員情報取得
 
@@ -142,6 +102,4 @@ freee_api_get {
 詳細なAPIパラメータは以下を参照:
 
 - `references/hr-employees.md` - 従業員
-- `references/hr-attendances.md` - 勤怠
-- `references/hr-time-clocks.md` - 打刻
 - `references/hr-payroll-statements.md` - 給与明細


### PR DESCRIPTION
- hr-attendance-operations.md を新規作成（出退勤・打刻・休憩の登録ガイド）
- hr-operations.md を hr-employee-operations.md にリネームし勤怠セクションを削除
- SKILL.md の操作ガイド一覧を更新

Closes #214

https://claude.ai/code/session_01DNzZaeyM6J8zzgX4NKAinT