### PR TITLE
README の skills インストーラー CLI 参照を新名称に更新

### DIFF
--- a/.changeset/update-skills-installer-ref.md
+++ b/.changeset/update-skills-installer-ref.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+README.md の skills インストーラー CLI の参照を `add-skill` から `skills` に更新

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ npx freee-mcp configure
 Claude Code でプラグインとしてインストールすると、API リファレンス付きのスキルが利用できます:
 
 ```bash
-npx add-skill freee/freee-mcp
+npx skills add freee/freee-mcp
 ```
 
-[add-skill](https://github.com/anthropics/add-skill) は Claude Code、Cursor、OpenCode など複数のコーディングエージェントに対応したスキルインストーラーです。グローバルインストール(`-g`)や特定スキルのみのインストール(`-s`)も可能です。
+[skills](https://www.npmjs.com/package/skills) は Claude Code、Cursor、OpenCode など複数のコーディングエージェントに対応したスキルインストーラーです。グローバルインストール(`-g`)や特定スキルのみのインストール(`-s`)も可能です。
 
 ### 含まれるリファレンス
 
@@ -179,6 +179,7 @@ Issue での不具合報告や機能要望、フィードバックは大歓迎�
 <a href="https://github.com/worldscandy"><img src="https://github.com/worldscandy.png" width="40" height="40" alt="@worldscandy"></a>
 <a href="https://github.com/akhr77"><img src="https://github.com/akhr77.png" width="40" height="40" alt="@akhr77"></a>
 <a href="https://github.com/trpfrog"><img src="https://github.com/trpfrog.png" width="40" height="40" alt="@trpfrog"></a>
+<a href="https://github.com/hoshinotsuyoshi"><img src="https://github.com/hoshinotsuyoshi.png" width="40" height="40" alt="@hoshinotsuyoshi"></a>
 <!-- CONTRIBUTORS-END -->
 
 ## 開発者向け


### PR DESCRIPTION
- `npx add-skill` を `npx skills add` に変更
- リンク先を GitHub リポジトリから npm パッケージページに変更
- hoshinotsuyoshi を Contributors に追加

Closes #224

https://claude.ai/code/session_013kpgdAAe2YNVBhxXE2iiCX