### PR TITLE
Add validation for FREEE_CALLBACK_PORT configuration

### DIFF
--- a/.changeset/validate-callback-port.md
+++ b/.changeset/validate-callback-port.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+FREEE_CALLBACK_PORT の値検証を追加し、不正な値（NaN、範囲外）の場合はデフォルトポートにフォールバックするようにした

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,6 +1,72 @@
-import { describe, it, expect } from 'vitest';
-import { loadConfig } from './config.js';
-import { AUTH_TIMEOUT_MS } from './constants.js';
+import { describe, it, expect, vi } from 'vitest';
+import { loadConfig, parseCallbackPort } from './config.js';
+import { AUTH_TIMEOUT_MS, DEFAULT_CALLBACK_PORT } from './constants.js';
+
+describe('parseCallbackPort', () => {
+  it('should return default port when value is undefined', () => {
+    expect(parseCallbackPort(undefined)).toBe(DEFAULT_CALLBACK_PORT);
+  });
+
+  it('should parse valid string port', () => {
+    expect(parseCallbackPort('8080')).toBe(8080);
+  });
+
+  it('should return valid number port as-is', () => {
+    expect(parseCallbackPort(3000)).toBe(3000);
+  });
+
+  it('should accept port 1 (minimum)', () => {
+    expect(parseCallbackPort(1)).toBe(1);
+  });
+
+  it('should accept port 65535 (maximum)', () => {
+    expect(parseCallbackPort(65535)).toBe(65535);
+  });
+
+  it('should fallback to default for NaN string', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(parseCallbackPort('not-a-number')).toBe(DEFAULT_CALLBACK_PORT);
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('FREEE_CALLBACK_PORT の値が不正です')
+    );
+    spy.mockRestore();
+  });
+
+  it('should fallback to default for empty string', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(parseCallbackPort('')).toBe(DEFAULT_CALLBACK_PORT);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('should fallback to default for port 0', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(parseCallbackPort(0)).toBe(DEFAULT_CALLBACK_PORT);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('should fallback to default for negative port', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(parseCallbackPort(-1)).toBe(DEFAULT_CALLBACK_PORT);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('should fallback to default for port exceeding 65535', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(parseCallbackPort(70000)).toBe(DEFAULT_CALLBACK_PORT);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('should fallback to default for floating point number', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(parseCallbackPort(3000.5)).toBe(DEFAULT_CALLBACK_PORT);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
 
 describe('config', () => {
   it('should have correct OAuth configuration', async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,28 @@
 import { loadFullConfig } from './config/companies.js';
 import { DEFAULT_CALLBACK_PORT, AUTH_TIMEOUT_MS, FREEE_API_URL } from './constants.js';
 
+/**
+ * Validate and parse a callback port value.
+ * Returns DEFAULT_CALLBACK_PORT with a warning if the value is invalid.
+ */
+export function parseCallbackPort(value: string | number | undefined): number {
+  if (value === undefined || value === null) {
+    return DEFAULT_CALLBACK_PORT;
+  }
+
+  const port = typeof value === 'string' ? parseInt(value, 10) : value;
+
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    console.error(
+      `Warning: FREEE_CALLBACK_PORT の値が不正です (${String(value)})。` +
+      `デフォルトポート ${DEFAULT_CALLBACK_PORT} を使用します。`
+    );
+    return DEFAULT_CALLBACK_PORT;
+  }
+
+  return port;
+}
+
 export interface Config {
   freee: {
     clientId: string;
@@ -58,9 +80,7 @@ export async function loadConfig(): Promise<Config> {
 
     clientId = process.env.FREEE_CLIENT_ID || '';
     clientSecret = process.env.FREEE_CLIENT_SECRET || '';
-    callbackPort = process.env.FREEE_CALLBACK_PORT
-      ? parseInt(process.env.FREEE_CALLBACK_PORT, 10)
-      : DEFAULT_CALLBACK_PORT;
+    callbackPort = parseCallbackPort(process.env.FREEE_CALLBACK_PORT);
   } else {
     // Load from config file
     if (!fullConfig.clientId || !fullConfig.clientSecret) {
@@ -72,7 +92,7 @@ export async function loadConfig(): Promise<Config> {
 
     clientId = fullConfig.clientId;
     clientSecret = fullConfig.clientSecret;
-    callbackPort = fullConfig.callbackPort || DEFAULT_CALLBACK_PORT;
+    callbackPort = parseCallbackPort(fullConfig.callbackPort);
   }
 
   cachedConfig = {


### PR DESCRIPTION
## 概要

`FREEE_CALLBACK_PORT` の値検証機能を追加しました。不正な値（NaN、範囲外など）が指定された場合、デフォルトポートにフォールバックし、警告メッセージを出力するようにしました。

## 変更内容

### src/config.ts
- `parseCallbackPort()` 関数を新規追加
  - 文字列または数値のポート値を検証
  - 有効な範囲（1～65535）のチェック
  - 整数値のチェック
  - 不正な値の場合はデフォルトポートを返し、エラーログを出力
- `loadConfig()` 関数内でポート解析を `parseCallbackPort()` に統一

### src/config.test.ts
- `parseCallbackPort()` の包括的なユニットテストを追加
  - 正常系：undefined、文字列、数値、最小値（1）、最大値（65535）
  - 異常系：NaN文字列、空文字列、0、負数、65535超過、小数値
  - 各異常系でデフォルトポートへのフォールバックと警告ログを検証

### .changeset/validate-callback-port.md
- 変更内容をchangesetに記録（patch版）

## 変更種別

- [ ] 新機能
- [x] バグ修正
- [x] リファクタリング
- [ ] ドキュメント
- [ ] その他

## テスト

新規追加した `parseCallbackPort()` 関数に対して、正常系・異常系を網羅した7つのユニットテストを実装しました。すべてのテストケースがカバーされています。

https://claude.ai/code/session_01TvgFt3y7uUN9nS2wz8fmEJ