### PR TITLE
Fix CSV response handling to save as file instead of JSON

### DIFF
--- a/.changeset/fix-csv-response-handling.md
+++ b/.changeset/fix-csv-response-handling.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+CSVレスポンスがJSONとして処理される不整合を修正。isBinaryContentType に text/csv を追加し、CSVレスポンスが正しくファイルとして保存されるようにしました。

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -305,6 +305,28 @@ describe('client', () => {
       await fs.unlink(binaryResult.filePath).catch(() => {});
     });
 
+    it('should save CSV response to file with correct extension', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+
+      const csvData = new TextEncoder().encode('id,name\n1,Test');
+      mockFetch.mockResolvedValue(createBinaryResponse('text/csv', csvData));
+
+      const result = await makeApiRequest('GET', '/api/1/reports/csv');
+
+      expect(isBinaryFileResponse(result)).toBe(true);
+      const binaryResult = result as BinaryFileResponse;
+      expect(binaryResult.type).toBe('binary');
+      expect(binaryResult.mimeType).toBe('text/csv');
+      expect(binaryResult.size).toBe(csvData.byteLength);
+      expect(binaryResult.filePath).toContain('.csv');
+
+      // Verify file content
+      const fileContent = await fs.readFile(binaryResult.filePath, 'utf-8');
+      expect(fileContent).toBe('id,name\n1,Test');
+
+      await fs.unlink(binaryResult.filePath).catch(() => {});
+    });
+
     it('should save image response to file with correct extension', async () => {
       await setupAccessToken(TEST_ACCESS_TOKEN);
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -36,6 +36,7 @@ function isBinaryContentType(contentType: string): boolean {
     'application/pdf',
     'application/octet-stream',
     'image/',
+    'text/csv',
   ];
   return binaryTypes.some(type => contentType.includes(type));
 }


### PR DESCRIPTION
## 概要

CSVレスポンスがJSONとして処理される不整合を修正しました。`isBinaryContentType`関数に`text/csv`を追加することで、CSVレスポンスが正しくバイナリファイルとして保存されるようになります。

## 変更内容

- `src/api/client.ts`: `isBinaryContentType`関数に`text/csv`を追加
- `src/api/client.test.ts`: CSV形式のレスポンスが正しくファイルとして保存されることを検証するテストケースを追加

## 変更種別

- [x] バグ修正

## テスト

新しいテストケース「should save CSV response to file with correct extension」を追加し、以下を検証しています：
- CSVレスポンスがバイナリファイルレスポンスとして認識されること
- MIMEタイプが`text/csv`として正しく設定されること
- ファイルが`.csv`拡張子で保存されること
- ファイルの内容が正しく保存されること

https://claude.ai/code/session_01CKFY9iCpcouRoTyPanPSR7