### PR TITLE
Fix API path examples in freee API client tool descriptions

### DIFF
--- a/src/openapi/client-mode.ts
+++ b/src/openapi/client-mode.ts
@@ -74,7 +74,7 @@ export function generateClientModeTool(server: McpServer): void {
     `freee API GET。${SERVICE_HINT}`,
     {
       service: serviceSchema,
-      path: z.string().describe('APIパス (例: /api/1/deals, /invoices)'),
+      path: z.string().describe('APIパス (例: /api/1/deals)'),
       query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ (オプション)'),
     },
     createMethodTool('GET')
@@ -86,7 +86,7 @@ export function generateClientModeTool(server: McpServer): void {
     `freee API POST。${SERVICE_HINT}`,
     {
       service: serviceSchema,
-      path: z.string().describe('APIパス (例: /api/1/deals, /invoices)'),
+      path: z.string().describe('APIパス (例: /api/1/deals)'),
       body: z.record(z.string(), z.unknown()).describe('リクエストボディ'),
       query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ (オプション)'),
     },
@@ -99,7 +99,7 @@ export function generateClientModeTool(server: McpServer): void {
     `freee API PUT。${SERVICE_HINT}`,
     {
       service: serviceSchema,
-      path: z.string().describe('APIパス (例: /api/1/deals/123, /invoices/123)'),
+      path: z.string().describe('APIパス (例: /api/1/deals/123)'),
       body: z.record(z.string(), z.unknown()).describe('リクエストボディ'),
       query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ (オプション)'),
     },


### PR DESCRIPTION
## 概要

freee API クライアントツールの説明文に記載されているAPIパスの例を修正しました。

- GET/POST メソッドの説明から `/invoices` の例を削除し、`/api/1/deals` に統一
- PUT メソッドの説明から `/invoices/123` の例を削除し、`/api/1/deals/123` に統一
- 使用例のセクションで、より実践的なクエリパラメータを含む例に更新

これにより、ドキュメント内の例がより一貫性を持ち、ユーザーが正しいAPIパスのフォーマットを理解しやすくなります。

## 変更種別

- [ ] 新機能
- [x] バグ修正
- [ ] リファクタリング
- [x] ドキュメント
- [ ] その他

https://claude.ai/code/session_01PBupoTCq5NzBWQLU6U2rQM