### PR TITLE
Claude Desktop のスキルアップロード手順の UI パスを更新

### DIFF
--- a/.changeset/fix-claude-desktop-skill-upload-path.md
+++ b/.changeset/fix-claude-desktop-skill-upload-path.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+Claude Desktop のスキルアップロード手順の UI パスを最新のものに更新

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -183,7 +183,7 @@ function showSkillInstallGuide(claudeCodeConfigured: boolean, claudeDesktopConfi
     console.log('  1. 以下の URL から freee-skill.zip をダウンロード:');
     console.log(`     ${SKILL_RELEASES_URL}\n`);
     console.log('  2. Claude Desktop でスキルをアップロード:');
-    console.log('     Settings > Features > Skills > 「Upload skill」から zip ファイルを選択\n');
+    console.log('     カスタマイズ > スキル > 「スキルをアップロード」から zip ファイルを選択\n');
   }
 }
 


### PR DESCRIPTION
## 概要

Claude Desktop のスキルアップロード手順における UI パスを最新のものに更新しました。

従来の「Settings > Features > Skills > 「Upload skill」」から「カスタマイズ > スキル > 「スキルをアップロード」」に変更されたため、ユーザーガイドの表示内容を修正しています。

## 変更内容

- `src/cli/prompts.ts` の `showSkillInstallGuide` 関数内で表示されるスキルアップロード手順のパスを更新
- Claude Desktop の最新 UI に対応した日本語表記に修正

## 変更種別

- [ ] 新機能
- [x] バグ修正
- [ ] リファクタリング
- [x] ドキュメント
- [ ] その他

## テスト

CLI の実行時にスキルインストールガイドが正しく表示されることを確認済み。

https://claude.ai/code/session_01E4fAu8Q12UiaFh91y7KPSS