### PR TITLE
fix: README の誤ったツール名を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ HTTPメソッドごとのシンプルなツール構成:
 リクエスト（パラメータまたはボディ）に `company_id` を含める場合、現在の事業所と一致している必要があります。不一致の場合はエラーになります。
 
 - 事業所の確認: `freee_get_current_company`
-- 事業所の切り替え: `freee_set_company`
+- 事業所の切り替え: `freee_set_current_company`
 - company_id を含まない API（例: `/api/1/companies`）はそのまま実行可能
 
 ## コントリビューション


### PR DESCRIPTION
## Summary
- README.md の事業所切り替えツール名が `freee_set_company` と記載されていたのを、正しい `freee_set_current_company` に修正

## Test plan
- [x] README.md の該当箇所を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)