### PR TITLE
Fix JSON parse error for 204 No Content responses

### DIFF
--- a/.changeset/fix-delete-204-response.md
+++ b/.changeset/fix-delete-204-response.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+freee_api_delete が HTTP 204 No Content レスポンスで JSON パースエラーとなる問題を修正

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ HTTPメソッドごとのシンプルなツール構成:
 <a href="https://github.com/akiras-ssrd"><img src="https://github.com/akiras-ssrd.png" width="40" height="40" alt="@akiras-ssrd"></a>
 <a href="https://github.com/inoue2002"><img src="https://github.com/inoue2002.png" width="40" height="40" alt="@inoue2002"></a>
 <a href="https://github.com/jacknocode"><img src="https://github.com/jacknocode.png" width="40" height="40" alt="@jacknocode"></a>
+<a href="https://github.com/tnj"><img src="https://github.com/tnj.png" width="40" height="40" alt="@tnj"></a>
 <!-- CONTRIBUTORS-END -->
 
 ## 開発者向け

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -287,6 +287,33 @@ describe('client', () => {
       );
     });
 
+    it('should return null for 204 No Content response', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 204,
+        headers: createMockHeaders(''),
+      });
+
+      const result = await makeApiRequest('DELETE', '/api/1/deals/123');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for empty response body', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: createMockHeaders('application/json'),
+        text: () => Promise.resolve(''),
+      });
+
+      const result = await makeApiRequest('DELETE', '/api/1/deals/123');
+
+      expect(result).toBeNull();
+    });
+
     it('should save binary response to file and return file info', async () => {
       await setupAccessToken(TEST_ACCESS_TOKEN);
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -176,7 +176,16 @@ export async function makeApiRequest(
     } as BinaryFileResponse;
   }
 
+  // Handle empty responses (e.g., 204 No Content from DELETE)
+  if (response.status === 204) {
+    return null;
+  }
+
   const text = await response.text();
+  if (!text) {
+    return null;
+  }
+
   try {
     return JSON.parse(text);
   } catch {

--- a/src/openapi/client-mode.ts
+++ b/src/openapi/client-mode.ts
@@ -57,6 +57,11 @@ function createMethodTool(method: string): (args: {
         return createTextResponse(formatBinaryResponse(result));
       }
 
+      // Handle empty response (e.g., 204 No Content)
+      if (result === null) {
+        return createTextResponse('リクエストが正常に完了しました。');
+      }
+
       return createTextResponse(JSON.stringify(result, null, 2));
     } catch (error) {
       return createTextResponse(`APIリクエストエラー: ${formatErrorMessage(error)}`);


### PR DESCRIPTION
## 概要

DELETE リクエストなどで HTTP 204 No Content レスポンスが返される場合に JSON パースエラーが発生する問題を修正しました。また、レスポンスボディが空の場合にも対応しています。

## 変更内容

### src/api/client.ts
- HTTP 204 No Content レスポンスを明示的に処理し、`null` を返すようにしました
- レスポンスボディが空の場合も `null` を返すようにしました
- JSON パース前にこれらのチェックを行うことで、不要なパースエラーを防ぎます

### src/openapi/client-mode.ts
- API クライアントから `null` が返された場合（204 No Content など）に、ユーザーフレンドリーなメッセージ「リクエストが正常に完了しました。」を返すようにしました

### テスト
- 204 No Content レスポンスのテストケースを追加
- 空のレスポンスボディのテストケースを追加

## 変更種別

- [x] バグ修正

## テスト計画

追加されたユニットテストで、204 No Content と空のレスポンスボディの両方のケースをカバーしています。既存のテストも引き続き通過します。

https://claude.ai/code/session_014Z99njqF8vfRoToGMwTKhY