### PR TITLE
freee-mcp configure コマンドのバナーにバージョン番号を表示

### DIFF
--- a/.changeset/add-version-display.md
+++ b/.changeset/add-version-display.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+`freee-mcp configure` 実行時のバナーにバージョン番号を表示するようにした

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { stopCallbackServer } from '../auth/server.js';
 import { clearTokens } from '../auth/tokens.js';
-import { getConfigDir } from '../constants.js';
+import { getConfigDir, PACKAGE_VERSION } from '../constants.js';
 import { collectCredentials, selectCompany, configureMcpIntegration } from './prompts.js';
 import { performOAuth } from './oauth-flow.js';
 import { saveConfig } from './configuration.js';
@@ -23,7 +23,7 @@ async function clearConfig(): Promise<void> {
 }
 
 export async function configure(options: ConfigureOptions = {}): Promise<void> {
-  console.log('\n=== freee-mcp Configuration Setup ===\n');
+  console.log(`\n=== freee-mcp v${PACKAGE_VERSION} Configuration Setup ===\n`);
 
   if (options.force) {
     console.log('保存済みのログイン情報をリセットしています...');


### PR DESCRIPTION
## 概要

`freee-mcp configure` コマンド実行時に表示されるバナーにバージョン番号を表示するようにしました。

## 変更内容

- `src/cli/index.ts` で `PACKAGE_VERSION` を `constants.js` からインポート
- 設定画面のバナーメッセージを `=== freee-mcp Configuration Setup ===` から `=== freee-mcp v${PACKAGE_VERSION} Configuration Setup ===` に変更

これにより、ユーザーが設定を実行する際に使用しているバージョンを一目で確認できるようになります。

## 変更種別

- [ ] 新機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント
- [ ] その他

https://claude.ai/code/session_01C8cYgykAGsRnZ6AzpQFuCR