### PR TITLE
docs: CLAUDE.md に開発環境での Skill バージョンに関する注意事項を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,11 @@ Common issues:
 - Missing return type annotations on exported functions
 - Undefined environment variables in tests
 
+## Skill について
+
+- `skills/freee-api-skill/` 内の `VERSION.md` は npm publish 時に自動生成されるため、開発環境（ローカル）には存在しない
+- 開発環境では `freee_server_info` のバージョンが `dev` と返る（正常動作）。実際のバージョンは `package.json` の `version` を参照する
+
 ## Writing Style
 
 - Do not use markdown bold syntax (`**`)  in any files


### PR DESCRIPTION
## Summary

- 開発環境では `skills/freee-api-skill/VERSION.md` が存在しないこと（npm publish 時に自動生成される）を記載
- 開発環境では `freee_server_info` のバージョンが `dev` と返ることを記載
- 実際のバージョン確認には `package.json` を参照する旨を追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)