### PR TITLE
chore: apply Biome formatter to fix line length violations

### DIFF
--- a/src/server/oauth-store.ts
+++ b/src/server/oauth-store.ts
@@ -78,7 +78,9 @@ export class OAuthStateStore {
   }
 
   async getAuthCode(code: string): Promise<AuthCodeData | null> {
-    const raw = await withRedis('getAuthCode', () => this.redis.get(`${OAUTH_KEY_PREFIX}:code:${code}`));
+    const raw = await withRedis('getAuthCode', () =>
+      this.redis.get(`${OAUTH_KEY_PREFIX}:code:${code}`),
+    );
     if (!raw) return null;
     return tryParseJson<AuthCodeData>(raw, 'authCode');
   }
@@ -121,6 +123,8 @@ export class OAuthStateStore {
   }
 
   async revokeRefreshToken(token: string): Promise<void> {
-    await withRedis('revokeRefreshToken', () => this.redis.del(`${OAUTH_KEY_PREFIX}:refresh:${token}`));
+    await withRedis('revokeRefreshToken', () =>
+      this.redis.del(`${OAUTH_KEY_PREFIX}:refresh:${token}`),
+    );
   }
 }

--- a/src/storage/redis-token-store.ts
+++ b/src/storage/redis-token-store.ts
@@ -46,7 +46,12 @@ export class RedisTokenStore implements TokenStore {
 
   async saveTokens(userId: string, tokens: TokenData): Promise<void> {
     await withRedis('saveTokens', () =>
-      this.redis.set(this.tokenKey(userId), JSON.stringify(tokens), 'EX', REFRESH_TOKEN_TTL_SECONDS),
+      this.redis.set(
+        this.tokenKey(userId),
+        JSON.stringify(tokens),
+        'EX',
+        REFRESH_TOKEN_TTL_SECONDS,
+      ),
     );
   }
 


### PR DESCRIPTION
## 概要

`bun run format` を実行し、Biome フォーマッターによる行長違反を修正した。

対象ファイル:
- `src/server/oauth-store.ts` - `withRedis()` コールバック内の長い行を複数行に分割
- `src/storage/redis-token-store.ts` - `withRedis()` コールバック内の `redis.set()` 呼び出しを複数行に分割

ロジックの変更はなく、コードフォーマットのみの修正。

## 変更種別

- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [x] その他