### PR TITLE
chore: リリースノートから不要な Install 行と Claude Plugin セクションを削除

### DIFF
--- a/.changeset/remove-release-note-clutter.md
+++ b/.changeset/remove-release-note-clutter.md
@@ -1,5 +1,0 @@
----
-"freee-mcp": patch
----
-
-リリースノートから不要な Install 行と Claude Plugin セクションを削除


### PR DESCRIPTION
## Summary
- publish.yml のリリースノート body から `- Install: npm install freee-mcp@...` 行を削除
- `## Claude Plugin` セクション（`claude plugin install freee/freee-mcp`）を削除

## Test plan
- [ ] publish.yml の YAML 構文が正しいことを確認
- [ ] リリース作成時にリリースノートが正しく生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)