### PR TITLE
feat: MCPツール定義に tool annotations を追加

### DIFF
--- a/.changeset/add-tool-annotations.md
+++ b/.changeset/add-tool-annotations.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": minor
+---
+
+MCPツール定義に tool annotations を追加

--- a/src/e2e/auth-flow.e2e.test.ts
+++ b/src/e2e/auth-flow.e2e.test.ts
@@ -123,6 +123,7 @@ describe('E2E: Authentication Flow', () => {
           name: string,
           description: string,
           schema: unknown,
+          _annotations: unknown,
           handler: (args: Record<string, unknown>) => Promise<unknown>,
         ) => {
           registeredTools.set(name, { description, schema, handler });

--- a/src/e2e/client-mode.e2e.test.ts
+++ b/src/e2e/client-mode.e2e.test.ts
@@ -110,6 +110,7 @@ describe('E2E: Client Mode Tools', () => {
           name: string,
           _description: string,
           _schema: unknown,
+          _annotations: unknown,
           handler: (args: Record<string, unknown>) => Promise<unknown>,
         ) => {
           registeredTools.set(name, { handler });

--- a/src/mcp/file-upload-tool.test.ts
+++ b/src/mcp/file-upload-tool.test.ts
@@ -35,6 +35,7 @@ describe('file-upload-tool', () => {
         expect.objectContaining({
           file_path: expect.anything(),
         }),
+        expect.any(Object),
         expect.any(Function),
       );
     });
@@ -44,7 +45,7 @@ describe('file-upload-tool', () => {
       vi.mocked(uploadReceipt).mockResolvedValue(mockResult);
 
       addFileUploadTool(mockServer);
-      const handler = mockTool.mock.calls[0][3];
+      const handler = mockTool.mock.calls[0][4];
 
       const result = await handler({ file_path: '/path/to/test.pdf' });
 
@@ -62,7 +63,7 @@ describe('file-upload-tool', () => {
       vi.mocked(uploadReceipt).mockResolvedValue({ receipt: { id: '1' } });
 
       addFileUploadTool(mockServer);
-      const handler = mockTool.mock.calls[0][3];
+      const handler = mockTool.mock.calls[0][4];
 
       await handler({
         file_path: '/path/to/test.pdf',
@@ -94,7 +95,7 @@ describe('file-upload-tool', () => {
       );
 
       addFileUploadTool(mockServer);
-      const handler = mockTool.mock.calls[0][3];
+      const handler = mockTool.mock.calls[0][4];
 
       const result = await handler({ file_path: '/missing.pdf' });
 

--- a/src/mcp/file-upload-tool.ts
+++ b/src/mcp/file-upload-tool.ts
@@ -25,6 +25,7 @@ export function addFileUploadTool(server: McpServer): void {
         .describe('適格請求書等の区分'),
       document_type: z.enum(['receipt', 'invoice', 'other']).optional().describe('書類の種類'),
     },
+    { destructiveHint: false },
     async (
       args: {
         file_path: string;

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -87,30 +87,35 @@ describe('tools', () => {
         'freee_current_user',
         expect.any(String),
         {},
+        expect.any(Object),
         expect.any(Function),
       );
       expect(mockTool).toHaveBeenCalledWith(
         'freee_authenticate',
         expect.any(String),
         {},
+        expect.any(Object),
         expect.any(Function),
       );
       expect(mockTool).toHaveBeenCalledWith(
         'freee_auth_status',
         expect.any(String),
         {},
+        expect.any(Object),
         expect.any(Function),
       );
       expect(mockTool).toHaveBeenCalledWith(
         'freee_clear_auth',
         expect.any(String),
         {},
+        expect.any(Object),
         expect.any(Function),
       );
       expect(mockTool).toHaveBeenCalledWith(
         'freee_server_info',
         expect.any(String),
         {},
+        expect.any(Object),
         expect.any(Function),
       );
     });
@@ -118,7 +123,7 @@ describe('tools', () => {
     describe('freee_server_info', () => {
       it('should return server info including version', async () => {
         addAuthenticationTools(mockServer);
-        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_server_info')?.[3];
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_server_info')?.[4];
 
         const result = await handler();
 
@@ -134,7 +139,7 @@ describe('tools', () => {
         vi.mocked(mockMakeApiRequest.makeApiRequest).mockResolvedValue(mockUserInfo);
 
         addAuthenticationTools(mockServer);
-        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_current_user')?.[3];
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_current_user')?.[4];
 
         const result = await handler();
 
@@ -150,7 +155,7 @@ describe('tools', () => {
         );
 
         addAuthenticationTools(mockServer);
-        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_current_user')?.[3];
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_current_user')?.[4];
 
         const result = await handler();
 
@@ -179,7 +184,7 @@ describe('tools', () => {
         });
 
         addAuthenticationTools(mockServer);
-        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_authenticate')?.[3];
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_authenticate')?.[4];
 
         const result = await handler();
 
@@ -213,7 +218,7 @@ describe('tools', () => {
         vi.mocked(mockLoadTokens.loadTokens).mockResolvedValue(mockTokens);
 
         addAuthenticationTools(mockServer);
-        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_auth_status')?.[3];
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_auth_status')?.[4];
 
         const result = await handler();
 
@@ -233,7 +238,7 @@ describe('tools', () => {
         vi.mocked(mockLoadTokens.loadTokens).mockResolvedValue(mockTokens);
 
         addAuthenticationTools(mockServer);
-        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_auth_status')?.[3];
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_auth_status')?.[4];
 
         const result = await handler();
 
@@ -246,7 +251,7 @@ describe('tools', () => {
         vi.mocked(mockLoadTokens.loadTokens).mockResolvedValue(null);
 
         addAuthenticationTools(mockServer);
-        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_auth_status')?.[3];
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_auth_status')?.[4];
 
         const result = await handler();
 
@@ -260,7 +265,7 @@ describe('tools', () => {
         vi.mocked(mockClearTokens.clearTokens).mockResolvedValue();
 
         addAuthenticationTools(mockServer);
-        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_clear_auth')?.[3];
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_clear_auth')?.[4];
 
         const result = await handler();
 
@@ -273,7 +278,7 @@ describe('tools', () => {
         vi.mocked(mockClearTokens.clearTokens).mockRejectedValue(new Error('Permission denied'));
 
         addAuthenticationTools(mockServer);
-        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_clear_auth')?.[3];
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_clear_auth')?.[4];
 
         const result = await handler();
 
@@ -294,7 +299,7 @@ describe('tools', () => {
         vi.mocked(mockMakeApiRequest.makeApiRequest).mockResolvedValue(validResponse);
 
         addAuthenticationTools(mockServer);
-        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_list_companies')?.[3];
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_list_companies')?.[4];
 
         const result = await handler();
 
@@ -309,7 +314,7 @@ describe('tools', () => {
         vi.mocked(mockMakeApiRequest.makeApiRequest).mockResolvedValue(invalidResponse);
 
         addAuthenticationTools(mockServer);
-        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_list_companies')?.[3];
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_list_companies')?.[4];
 
         const result = await handler();
 
@@ -326,7 +331,7 @@ describe('tools', () => {
         vi.mocked(mockMakeApiRequest.makeApiRequest).mockResolvedValue(invalidResponse);
 
         addAuthenticationTools(mockServer);
-        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_list_companies')?.[3];
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_list_companies')?.[4];
 
         const result = await handler();
 
@@ -338,7 +343,7 @@ describe('tools', () => {
         vi.mocked(mockMakeApiRequest.makeApiRequest).mockRejectedValue(new Error('API Error'));
 
         addAuthenticationTools(mockServer);
-        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_list_companies')?.[3];
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_list_companies')?.[4];
 
         const result = await handler();
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -19,6 +19,7 @@ export function addAuthenticationTools(server: McpServer): void {
     'freee_current_user',
     '現在のユーザー情報を取得 (詳細ガイドはfreee-api-skill skillを参照)',
     {},
+    { readOnlyHint: true },
     async (_args: Record<string, unknown>, extra?: AuthExtra) => {
       try {
         const { tokenStore, userId } = extractTokenContext(extra);
@@ -54,6 +55,7 @@ export function addAuthenticationTools(server: McpServer): void {
     'freee_authenticate',
     'OAuth認証を開始、初回のみ必要 (詳細ガイドはfreee-api-skill skillを参照)',
     {},
+    { destructiveHint: false },
     async (_args: Record<string, unknown>, extra?: AuthExtra) => {
       try {
         // Remote mode: OAuth already handled by MCP protocol
@@ -103,6 +105,7 @@ export function addAuthenticationTools(server: McpServer): void {
     'freee_auth_status',
     '認証状態を確認 (詳細ガイドはfreee-api-skill skillを参照)',
     {},
+    { readOnlyHint: true },
     async (_args: Record<string, unknown>, extra?: AuthExtra) => {
       try {
         const { tokenStore, userId } = extractTokenContext(extra);
@@ -128,6 +131,7 @@ export function addAuthenticationTools(server: McpServer): void {
     'freee_clear_auth',
     '認証情報をクリア (詳細ガイドはfreee-api-skill skillを参照)',
     {},
+    { idempotentHint: true, openWorldHint: false },
     async (_args: Record<string, unknown>, extra?: AuthExtra) => {
       try {
         const { tokenStore, userId } = extractTokenContext(extra);
@@ -150,6 +154,7 @@ export function addAuthenticationTools(server: McpServer): void {
       name: z.string().optional().describe('事業所名'),
       description: z.string().optional().describe('説明'),
     },
+    { destructiveHint: false, idempotentHint: true, openWorldHint: false },
     async (
       args: { company_id: string; name?: string; description?: string },
       extra?: AuthExtra,
@@ -173,6 +178,7 @@ export function addAuthenticationTools(server: McpServer): void {
     'freee_get_current_company',
     '現在の事業所情報を表示 (詳細ガイドはfreee-api-skill skillを参照)',
     {},
+    { readOnlyHint: true, openWorldHint: false },
     async (_args: Record<string, unknown>, extra?: AuthExtra) => {
       try {
         const { tokenStore, userId } = extractTokenContext(extra);
@@ -194,6 +200,7 @@ export function addAuthenticationTools(server: McpServer): void {
     'freee_list_companies',
     '事業所一覧を表示 (詳細ガイドはfreee-api-skill skillを参照)',
     {},
+    { readOnlyHint: true },
     async (_args: Record<string, unknown>, extra?: AuthExtra) => {
       try {
         const { tokenStore, userId } = extractTokenContext(extra);
@@ -251,6 +258,7 @@ export function addAuthenticationTools(server: McpServer): void {
     'freee_server_info',
     'freee-mcp サーバーの情報を取得（バージョンなど）',
     {},
+    { readOnlyHint: true, openWorldHint: false },
     async () => {
       return createTextResponse(`freee-mcp server info:\n- version: ${PACKAGE_VERSION}`);
     },

--- a/src/openapi/client-mode.ts
+++ b/src/openapi/client-mode.ts
@@ -93,6 +93,7 @@ export function generateClientModeTool(server: McpServer): void {
       path: z.string().describe('APIパス (例: /api/1/deals)'),
       query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ (オプション)'),
     },
+    { readOnlyHint: true },
     createMethodTool('GET'),
   );
 
@@ -106,6 +107,7 @@ export function generateClientModeTool(server: McpServer): void {
       body: z.record(z.string(), z.unknown()).describe('リクエストボディ'),
       query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ (オプション)'),
     },
+    { destructiveHint: false },
     createMethodTool('POST'),
   );
 
@@ -119,6 +121,7 @@ export function generateClientModeTool(server: McpServer): void {
       body: z.record(z.string(), z.unknown()).describe('リクエストボディ'),
       query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ (オプション)'),
     },
+    { destructiveHint: false, idempotentHint: true },
     createMethodTool('PUT'),
   );
 
@@ -131,6 +134,7 @@ export function generateClientModeTool(server: McpServer): void {
       path: z.string().describe('APIパス (例: /api/1/deals/123)'),
       query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ (オプション)'),
     },
+    { idempotentHint: true },
     createMethodTool('DELETE'),
   );
 
@@ -144,6 +148,7 @@ export function generateClientModeTool(server: McpServer): void {
       body: z.record(z.string(), z.unknown()).describe('リクエストボディ'),
       query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ (オプション)'),
     },
+    { destructiveHint: false },
     createMethodTool('PATCH'),
   );
 
@@ -152,6 +157,7 @@ export function generateClientModeTool(server: McpServer): void {
     'freee_api_list_paths',
     'freee API エンドポイント一覧 (詳細ガイドはfreee-api-skill skillを参照)',
     {},
+    { readOnlyHint: true, openWorldHint: false },
     async () => {
       const pathsList = listAllAvailablePaths();
       return createTextResponse(

--- a/src/types/mcp-overrides.d.ts
+++ b/src/types/mcp-overrides.d.ts
@@ -3,11 +3,12 @@
 // This file simplifies the McpServer.tool method signature to avoid deep type inference
 
 import '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 
 declare module '@modelcontextprotocol/sdk/server/mcp.js' {
   interface McpServer {
     // Override tool method with simplified signature to avoid OOM
     // biome-ignore lint/suspicious/noExplicitAny: intentional override to prevent deep type inference OOM
-    tool(name: string, description: string, schema: any, handler: any): void;
+    tool(name: string, description: string, schema: any, annotations: ToolAnnotations, handler: any): void;
   }
 }


### PR DESCRIPTION
## 概要

MCP spec (2025-03-26) の ToolAnnotations に準拠し、全15ツールに annotations を追加。
Claude のカスタマイズ画面などで「その他のツール」ではなく、読み取り専用/破壊的操作などの区分が適切に表示されるようになる。

Closes #323

## 変更種別

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他

## 設計根拠

MCP spec における ToolAnnotations の各フィールドのデフォルト値:

| フィールド | デフォルト | 適用条件 |
|---|---|---|
| readOnlyHint | false | 常に有効 |
| destructiveHint | true | readOnlyHint=false のときのみ有効 |
| idempotentHint | false | readOnlyHint=false のときのみ有効 |
| openWorldHint | true | 常に有効 |

設定方針: デフォルト値と異なる場合のみ明示し、無意味な値(readOnlyHint=true のツールへの destructiveHint/idempotentHint)は設定しない。

各ツールの annotations:

| ツール | 設定値 | 根拠 |
|---|---|---|
| freee_current_user | readOnlyHint: true | freee API から読み取りのみ |
| freee_authenticate | destructiveHint: false | OAuth フロー開始、トークン保存するが破壊的ではない |
| freee_auth_status | readOnlyHint: true | トークンストアの読み取りのみ |
| freee_clear_auth | idempotentHint: true, openWorldHint: false | ローカルトークン削除。破壊的(デフォルト)かつ冪等 |
| freee_set_current_company | destructiveHint: false, idempotentHint: true, openWorldHint: false | ローカル設定の上書き。非破壊的で冪等 |
| freee_get_current_company | readOnlyHint: true, openWorldHint: false | ローカルストレージ読み取りのみ |
| freee_list_companies | readOnlyHint: true | freee API から読み取りのみ |
| freee_server_info | readOnlyHint: true, openWorldHint: false | ローカル情報のみ返却 |
| freee_file_upload | destructiveHint: false | ファイルボックスへの新規追加のみ |
| freee_api_get | readOnlyHint: true | HTTP GET |
| freee_api_post | destructiveHint: false | リソース作成(非破壊的) |
| freee_api_put | destructiveHint: false, idempotentHint: true | 全体置換(冪等、非破壊的) |
| freee_api_delete | idempotentHint: true | リソース削除。破壊的(デフォルト)かつ冪等 |
| freee_api_patch | destructiveHint: false | 部分更新(非破壊的、非冪等) |
| freee_api_list_paths | readOnlyHint: true, openWorldHint: false | ローカルの OpenAPI スキーマ参照のみ |

## テスト

- typecheck, lint, 全392テスト通過
- ローカルで MCP サーバーを起動し `tools/list` レスポンスで全15ツールの annotations を確認済み