### PR TITLE
feat: バイナリレスポンスを MCP ImageContent として返却

### DIFF
--- a/.changeset/remote-binary-inline.md
+++ b/.changeset/remote-binary-inline.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": minor
+---
+
+バイナリレスポンスをファイル保存せず MCP ImageContent (base64) としてインライン返却

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ HTTPメソッドごとのシンプルなツール構成:
 <a href="https://github.com/jaxx2104"><img src="https://github.com/jaxx2104.png" width="40" height="40" alt="@jaxx2104"></a>
 <a href="https://github.com/kbyk004"><img src="https://github.com/kbyk004.png" width="40" height="40" alt="@kbyk004"></a>
 <a href="https://github.com/k4200"><img src="https://github.com/k4200.png" width="40" height="40" alt="@k4200"></a>
+<a href="https://github.com/fukumayuta"><img src="https://github.com/fukumayuta.png" width="40" height="40" alt="@fukumayuta"></a>
 <!-- CONTRIBUTORS-END -->
 
 ## 開発者向け

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs/promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { USER_AGENT } from '../constants.js';
 import { type BinaryFileResponse, isBinaryFileResponse, makeApiRequest } from './client.js';
@@ -314,7 +313,7 @@ describe('client', () => {
       expect(result).toBeNull();
     });
 
-    it('should save binary response to file and return file info', async () => {
+    it('should return binary response with buffer data for PDF', async () => {
       await setupAccessToken(TEST_ACCESS_TOKEN);
 
       const pdfMagicBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
@@ -327,12 +326,11 @@ describe('client', () => {
       expect(binaryResult.type).toBe('binary');
       expect(binaryResult.mimeType).toBe('application/pdf');
       expect(binaryResult.size).toBe(4);
-      expect(binaryResult.filePath).toContain('.pdf');
-
-      await fs.unlink(binaryResult.filePath).catch(() => {});
+      expect(Buffer.isBuffer(binaryResult.data)).toBe(true);
+      expect(binaryResult.data).toEqual(Buffer.from(pdfMagicBytes));
     });
 
-    it('should save CSV response to file with correct extension', async () => {
+    it('should return binary response with buffer data for CSV', async () => {
       await setupAccessToken(TEST_ACCESS_TOKEN);
 
       const csvData = new TextEncoder().encode('id,name\n1,Test');
@@ -345,16 +343,10 @@ describe('client', () => {
       expect(binaryResult.type).toBe('binary');
       expect(binaryResult.mimeType).toBe('text/csv');
       expect(binaryResult.size).toBe(csvData.byteLength);
-      expect(binaryResult.filePath).toContain('.csv');
-
-      // Verify file content
-      const fileContent = await fs.readFile(binaryResult.filePath, 'utf-8');
-      expect(fileContent).toBe('id,name\n1,Test');
-
-      await fs.unlink(binaryResult.filePath).catch(() => {});
+      expect(binaryResult.data.toString('utf-8')).toBe('id,name\n1,Test');
     });
 
-    it('should save image response to file with correct extension', async () => {
+    it('should return binary response with buffer data for PNG', async () => {
       await setupAccessToken(TEST_ACCESS_TOKEN);
 
       const pngMagicBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
@@ -366,9 +358,7 @@ describe('client', () => {
       const binaryResult = result as BinaryFileResponse;
       expect(binaryResult.type).toBe('binary');
       expect(binaryResult.mimeType).toBe('image/png');
-      expect(binaryResult.filePath).toContain('.png');
-
-      await fs.unlink(binaryResult.filePath).catch(() => {});
+      expect(binaryResult.data).toEqual(Buffer.from(pngMagicBytes));
     });
   });
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,7 +1,5 @@
-import fs from 'node:fs/promises';
-import path from 'node:path';
 import { getValidAccessToken } from '../auth/tokens.js';
-import { getCurrentCompanyId, getDownloadDir } from '../config/companies.js';
+import { getCurrentCompanyId } from '../config/companies.js';
 import { getConfig } from '../config.js';
 import { FETCH_TIMEOUT_API_MS, USER_AGENT } from '../constants.js';
 import type { TokenContext } from '../storage/context.js';
@@ -12,7 +10,7 @@ import { formatApiErrorMessage, formatResponseErrorInfo } from '../utils/error.j
  */
 export interface BinaryFileResponse {
   type: 'binary';
-  filePath: string;
+  data: Buffer;
   mimeType: string;
   size: number;
 }
@@ -35,32 +33,6 @@ export function isBinaryFileResponse(result: unknown): result is BinaryFileRespo
 function isBinaryContentType(contentType: string): boolean {
   const binaryTypes = ['application/pdf', 'application/octet-stream', 'image/', 'text/csv'];
   return binaryTypes.some((type) => contentType.includes(type));
-}
-
-/**
- * Get file extension from Content-Type
- */
-function getExtensionFromContentType(contentType: string): string {
-  const typeMap: Record<string, string> = {
-    'application/pdf': '.pdf',
-    'image/png': '.png',
-    'image/jpeg': '.jpg',
-    'image/gif': '.gif',
-    'image/webp': '.webp',
-    'text/csv': '.csv',
-  };
-
-  for (const [type, ext] of Object.entries(typeMap)) {
-    if (contentType.includes(type)) {
-      return ext;
-    }
-  }
-
-  if (contentType.includes('image/')) {
-    return '.bin';
-  }
-
-  return '.bin';
 }
 
 export async function makeApiRequest(
@@ -159,22 +131,13 @@ export async function makeApiRequest(
   const contentType = response.headers.get('content-type') || '';
 
   if (isBinaryContentType(contentType)) {
-    // Handle binary response: save to file and return path
-    const downloadDir = await getDownloadDir();
-    const extension = getExtensionFromContentType(contentType);
-    const timestamp = Date.now();
-    const fileName = `freee_download_${timestamp}${extension}`;
-    const filePath = path.join(downloadDir, fileName);
-
-    const buffer = await response.arrayBuffer();
-    await fs.writeFile(filePath, Buffer.from(buffer));
-
+    const buffer = Buffer.from(await response.arrayBuffer());
     return {
       type: 'binary',
-      filePath,
+      data: buffer,
       mimeType: contentType,
       size: buffer.byteLength,
-    } as BinaryFileResponse;
+    };
   }
 
   // Handle empty responses (e.g., 204 No Content from DELETE)

--- a/src/e2e/client-mode.e2e.test.ts
+++ b/src/e2e/client-mode.e2e.test.ts
@@ -402,4 +402,47 @@ describe('E2E: Client Mode Tools', () => {
       expect(result.content[0].text).toContain('パス検証エラー');
     });
   });
+
+  describe('Binary Response', () => {
+    it('should return base64 ImageContent for binary response', async () => {
+      const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      mockApiResponse = {
+        type: 'binary',
+        data: pngBytes,
+        mimeType: 'image/png',
+        size: pngBytes.byteLength,
+      };
+
+      const handler = registeredTools.get('freee_api_get')?.handler;
+      const result = (await handler({
+        service: 'accounting',
+        path: '/api/1/receipts/123/download',
+      })) as { content: Array<{ type: string; data?: string; mimeType?: string }> };
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('image');
+      expect(result.content[0].mimeType).toBe('image/png');
+      expect(result.content[0].data).toBe(pngBytes.toString('base64'));
+    });
+
+    it('should return base64 ImageContent for PDF binary response', async () => {
+      const pdfBytes = Buffer.from([0x25, 0x50, 0x44, 0x46]);
+      mockApiResponse = {
+        type: 'binary',
+        data: pdfBytes,
+        mimeType: 'application/pdf',
+        size: pdfBytes.byteLength,
+      };
+
+      const handler = registeredTools.get('freee_api_get')?.handler;
+      const result = (await handler({
+        service: 'accounting',
+        path: '/api/1/receipts/456/download',
+      })) as { content: Array<{ type: string; data?: string; mimeType?: string }> };
+
+      expect(result.content[0].type).toBe('image');
+      expect(result.content[0].mimeType).toBe('application/pdf');
+      expect(Buffer.from(result.content[0].data ?? '', 'base64')).toEqual(pdfBytes);
+    });
+  });
 });

--- a/src/openapi/client-mode.ts
+++ b/src/openapi/client-mode.ts
@@ -1,23 +1,10 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { type BinaryFileResponse, isBinaryFileResponse, makeApiRequest } from '../api/client.js';
+import { isBinaryFileResponse, makeApiRequest } from '../api/client.js';
 import type { AuthExtra } from '../storage/context.js';
 import { extractTokenContext } from '../storage/context.js';
-import { createTextResponse, formatErrorMessage, type TextResponse } from '../utils/error.js';
+import { createTextResponse, formatErrorMessage } from '../utils/error.js';
 import { type ApiType, listAllAvailablePaths, validatePathForService } from './schema-loader.js';
-
-/**
- * Format binary file response for display
- */
-function formatBinaryResponse(response: BinaryFileResponse): string {
-  const sizeInKB = (response.size / 1024).toFixed(2);
-  return (
-    `ファイルをダウンロードしました\n\n` +
-    `保存場所: ${response.filePath}\n` +
-    `MIMEタイプ: ${response.mimeType}\n` +
-    `サイズ: ${sizeInKB} KB`
-  );
-}
 
 const SERVICE_HINT = 'service: accounting/hr/invoice/pm/sm';
 const SKILL_HINT = '詳細ガイドはfreee-api-skill skillを参照';
@@ -38,12 +25,11 @@ function createMethodTool(method: string) {
       body?: Record<string, unknown>;
     },
     extra?: AuthExtra,
-  ): Promise<TextResponse> => {
+  ) => {
     try {
       const { service, path, query, body } = args;
       const { tokenStore, userId } = extractTokenContext(extra);
 
-      // Validate path against the specified service's OpenAPI schema
       const validation = validatePathForService(method, path, service);
       if (!validation.isValid) {
         return createTextResponse(
@@ -52,7 +38,6 @@ function createMethodTool(method: string) {
         );
       }
 
-      // Make API request with the correct base URL
       const actualPath = validation.actualPath ?? path;
       const result = await makeApiRequest(
         method,
@@ -63,12 +48,12 @@ function createMethodTool(method: string) {
         { tokenStore, userId },
       );
 
-      // Handle binary file response
       if (isBinaryFileResponse(result)) {
-        return createTextResponse(formatBinaryResponse(result));
+        return {
+          content: [{ type: 'image', data: result.data.toString('base64'), mimeType: result.mimeType }],
+        };
       }
 
-      // Handle empty response (e.g., 204 No Content)
       if (result === null) {
         return createTextResponse('リクエストが正常に完了しました。');
       }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -22,23 +22,12 @@ export async function parseJsonResponse(response: Response): Promise<JsonParseRe
   }
 }
 
-/**
- * MCP text response type
- */
-export interface TextResponse {
-  content: {
-    type: 'text';
-    text: string;
-  }[];
-}
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 /**
  * Creates a standardized MCP text response.
- *
- * @param text - The text content for the response
- * @returns MCP-formatted text response object
  */
-export function createTextResponse(text: string): TextResponse {
+export function createTextResponse(text: string): CallToolResult {
   return {
     content: [
       {


### PR DESCRIPTION
## 概要

バイナリレスポンス（証憑ファイル等）をサーバー側のファイルシステムに保存せず、base64 エンコードした MCP ImageContent としてインライン返却するように変更。

リモート MCP 利用時に `/tmp/` のファイルパスのみ返されてクライアントからアクセスできない問題を解決する。stdio モードでも同一の動作となり、AI がバイナリデータを直接読み取れるようになる。

Closes #324

## 変更種別

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他

## 設計

変更前: `makeApiRequest` がバイナリを `/tmp/` にファイル保存し、パス文字列をテキストで返却
変更後: `makeApiRequest` がバイナリを `Buffer` で返し、`client-mode.ts` が `{ type: "image", data: base64, mimeType }` として MCP レスポンスに含める

- remote/stdio のモード分岐なし
- `BinaryFileResponse` から `filePath` を削除し `data: Buffer` に統一
- ツールハンドラの戻り値型は SDK の `CallToolResult` を使用（自前の型定義を排除）
- ファイル保存に使っていた `fs`, `path`, `getDownloadDir`, `getExtensionFromContentType` を削除

## テスト

- typecheck, lint, 全394テスト通過
- バイナリ→base64 変換の E2E テスト追加（PNG, PDF）
- ローカルで MCP サーバーを起動しツール登録を確認済み