### PR TITLE
fix: freee_list_companies で company name が null の場合のバリデーションエラーを修正

### DIFF
--- a/.changeset/fix-nullable-company-name.md
+++ b/.changeset/fix-nullable-company-name.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+freee_list_companies で事業所名が null の場合にバリデーションエラーになる問題を修正

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -333,6 +333,28 @@ describe('tools', () => {
         expect(result.content[0].text).toContain('APIレスポンスの形式が不正です');
       });
 
+      it('should handle companies with null name', async () => {
+        const mockMakeApiRequest = await import('../api/client.js');
+        const responseWithNullName = {
+          companies: [
+            { id: 123, name: 'Company A' },
+            { id: 456, name: null },
+            { id: 789, name: 'Company C' },
+          ],
+        };
+        vi.mocked(mockMakeApiRequest.makeApiRequest).mockResolvedValue(responseWithNullName);
+
+        addAuthenticationTools(mockServer);
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_list_companies')?.[3];
+
+        const result = await handler();
+
+        expect(result.content[0].text).toContain('事業所一覧:');
+        expect(result.content[0].text).toContain('Company A');
+        expect(result.content[0].text).toContain('(名称未設定) (456)');
+        expect(result.content[0].text).toContain('Company C');
+      });
+
       it('should handle API error', async () => {
         const mockMakeApiRequest = await import('../api/client.js');
         vi.mocked(mockMakeApiRequest.makeApiRequest).mockRejectedValue(new Error('API Error'));

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -202,7 +202,7 @@ export function addAuthenticationTools(server: McpServer): void {
             .array(
               z.object({
                 id: z.number(),
-                name: z.string(),
+                name: z.string().nullable(),
               }),
             )
             .optional(),
@@ -236,7 +236,7 @@ export function addAuthenticationTools(server: McpServer): void {
         const companyList = apiCompanies.companies
           .map((company) => {
             const current = company.id === parseInt(currentCompanyId, 10) ? ' *' : '';
-            return `${company.name} (${company.id})${current}`;
+            return `${company.name ?? '(名称未設定)'} (${company.id})${current}`;
           })
           .join('\n');
 


### PR DESCRIPTION
freee API の OpenAPI スキーマでは companies[].name は nullable: true だが、
Zod バリデーションが z.string() (null 不可) だったため、name が null の事業所が
あると全事業所一覧が表示できなかった。z.string().nullable() に修正し、
表示時は '(名称未設定)' をフォールバックとして使用する。

https://claude.ai/code/session_01ScmjhTaQFz6YKMRbRtpEPc