### PR TITLE
feat: バイナリレスポンスをMIMEタイプに応じた適切なMCPコンテンツタイプで返却

### DIFF
--- a/.changeset/binary-response-mime-handling.md
+++ b/.changeset/binary-response-mime-handling.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": minor
+---
+
+バイナリレスポンスをMIMEタイプに応じて適切なMCPコンテンツタイプで返却するように改善。画像(JPEG/PNG/GIF/WebP)はImageContent、PDFはEmbeddedResource、CSVはテキスト、その他はエラーメッセージを返却。

--- a/src/e2e/client-mode.e2e.test.ts
+++ b/src/e2e/client-mode.e2e.test.ts
@@ -426,7 +426,7 @@ describe('E2E: Client Mode Tools', () => {
       expect(result.content[0].data).toBe(pngBytes.toString('base64'));
     });
 
-    it('should return base64 ImageContent for PDF binary response', async () => {
+    it('should return EmbeddedResource for PDF binary response', async () => {
       const pdfBytes = Buffer.from([0x25, 0x50, 0x44, 0x46]);
       mockApiResponse = {
         type: 'binary',
@@ -439,11 +439,102 @@ describe('E2E: Client Mode Tools', () => {
       const result = (await handler({
         service: 'accounting',
         path: '/api/1/receipts/456/download',
+      })) as {
+        content: Array<{
+          type: string;
+          resource?: { uri: string; mimeType: string; blob: string };
+        }>;
+      };
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('resource');
+      expect(result.content[0].resource?.uri).toBe('freee://api/api/1/receipts/456/download');
+      expect(result.content[0].resource?.mimeType).toBe('application/pdf');
+      expect(Buffer.from(result.content[0].resource?.blob ?? '', 'base64')).toEqual(pdfBytes);
+    });
+
+    it('should return ImageContent for JPEG binary response', async () => {
+      const jpegBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+      mockApiResponse = {
+        type: 'binary',
+        data: jpegBytes,
+        mimeType: 'image/jpeg',
+        size: jpegBytes.byteLength,
+      };
+
+      const handler = registeredTools.get('freee_api_get')?.handler;
+      const result = (await handler({
+        service: 'accounting',
+        path: '/api/1/receipts/789/download',
       })) as { content: Array<{ type: string; data?: string; mimeType?: string }> };
 
+      expect(result.content).toHaveLength(1);
       expect(result.content[0].type).toBe('image');
-      expect(result.content[0].mimeType).toBe('application/pdf');
-      expect(Buffer.from(result.content[0].data ?? '', 'base64')).toEqual(pdfBytes);
+      expect(result.content[0].mimeType).toBe('image/jpeg');
+      expect(result.content[0].data).toBe(jpegBytes.toString('base64'));
+    });
+
+    it('should return decoded text for CSV binary response', async () => {
+      const csvText = 'id,name,amount\n1,テスト,1000\n2,サンプル,2000';
+      const csvBytes = Buffer.from(csvText, 'utf-8');
+      mockApiResponse = {
+        type: 'binary',
+        data: csvBytes,
+        mimeType: 'text/csv',
+        size: csvBytes.byteLength,
+      };
+
+      const handler = registeredTools.get('freee_api_get')?.handler;
+      const result = (await handler({
+        service: 'accounting',
+        path: '/api/1/receipts/789/download',
+      })) as { content: Array<{ type: string; text?: string }> };
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toBe(csvText);
+    });
+
+    it('should return error message for unsupported binary type', async () => {
+      const bytes = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+      mockApiResponse = {
+        type: 'binary',
+        data: bytes,
+        mimeType: 'application/octet-stream',
+        size: bytes.byteLength,
+      };
+
+      const handler = registeredTools.get('freee_api_get')?.handler;
+      const result = (await handler({
+        service: 'accounting',
+        path: '/api/1/receipts/999/download',
+      })) as { content: Array<{ type: string; text?: string }> };
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('application/octet-stream');
+      expect(result.content[0].text).toContain('表示できません');
+      expect(result.content[0].text).toContain(`${bytes.byteLength} bytes`);
+    });
+
+    it('should handle MIME type with parameters', async () => {
+      const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      mockApiResponse = {
+        type: 'binary',
+        data: pngBytes,
+        mimeType: 'image/png; charset=utf-8',
+        size: pngBytes.byteLength,
+      };
+
+      const handler = registeredTools.get('freee_api_get')?.handler;
+      const result = (await handler({
+        service: 'accounting',
+        path: '/api/1/receipts/123/download',
+      })) as { content: Array<{ type: string; data?: string; mimeType?: string }> };
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('image');
+      expect(result.content[0].mimeType).toBe('image/png');
     });
   });
 });

--- a/src/openapi/client-mode.ts
+++ b/src/openapi/client-mode.ts
@@ -6,6 +6,8 @@ import { extractTokenContext } from '../storage/context.js';
 import { createTextResponse, formatErrorMessage } from '../utils/error.js';
 import { type ApiType, listAllAvailablePaths, validatePathForService } from './schema-loader.js';
 
+const SUPPORTED_IMAGE_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+
 const SERVICE_HINT = 'service: accounting/hr/invoice/pm/sm';
 const SKILL_HINT = '詳細ガイドはfreee-api-skill skillを参照';
 
@@ -49,9 +51,39 @@ function createMethodTool(method: string) {
       );
 
       if (isBinaryFileResponse(result)) {
-        return {
-          content: [{ type: 'image', data: result.data.toString('base64'), mimeType: result.mimeType }],
-        };
+        const baseMimeType = result.mimeType.split(';')[0].trim();
+
+        if (SUPPORTED_IMAGE_MIME_TYPES.has(baseMimeType)) {
+          return {
+            content: [{ type: 'image', data: result.data.toString('base64'), mimeType: baseMimeType }],
+          };
+        }
+
+        if (baseMimeType === 'application/pdf') {
+          return {
+            content: [
+              {
+                type: 'resource',
+                resource: {
+                  uri: `freee://api${actualPath}`,
+                  mimeType: baseMimeType,
+                  blob: result.data.toString('base64'),
+                },
+              },
+            ],
+          };
+        }
+
+        if (baseMimeType === 'text/csv') {
+          return createTextResponse(result.data.toString('utf-8'));
+        }
+
+        return createTextResponse(
+          `バイナリファイルを受信しました。このファイル形式（${baseMimeType}）は表示できません。\n\n` +
+            `Content-Type: ${result.mimeType}\n` +
+            `ファイルサイズ: ${result.size} bytes\n\n` +
+            `このファイルを取得するには、freee Webアプリから直接ダウンロードしてください。`,
+        );
       }
 
       if (result === null) {


### PR DESCRIPTION
## 概要

全バイナリレスポンスを一律 `ImageContent` として返却していたため、Claude API がサポートしない形式（PDF, CSV 等）で "Could not process image" エラーが発生していた問題を修正。

MIMEタイプに応じて適切な MCP コンテンツタイプで返却するように改善:

| MIMEタイプ | 返却方法 |
|---|---|
| `image/jpeg`, `image/png`, `image/gif`, `image/webp` | `ImageContent` |
| `application/pdf` | `EmbeddedResource` (`BlobResourceContents`) |
| `text/csv` | `TextContent`（UTF-8デコード） |
| その他 | エラーメッセージ（MIMEタイプ・サイズ情報付き） |

## 変更種別

- [x] バグ修正
- [x] 新機能

🤖 Generated with [Claude Code](https://claude.ai/claude-code)