### PR TITLE
ci: api-request ラベルで Issue を自動クローズする GitHub Actions を追加

### DIFF
--- a/.github/workflows/close-issue-by-label.yml
+++ b/.github/workflows/close-issue-by-label.yml
@@ -1,0 +1,38 @@
+name: Close issue by label
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  close-as-api-request:
+    if: github.event.label.name == 'api-request'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Comment and close
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                'ご要望ありがとうございます。',
+                '',
+                'こちらは freee API 自体の機能に関するご要望のため、freee-mcp（クライアント）側では対応が難しい内容となります。',
+                '',
+                'freee API の機能拡充や改善のご要望は、freee Public API リクエストフォームより送信をお願いいたします:',
+                'https://docs.google.com/forms/d/e/1FAIpQLSdG19OrIdc0nbI-F5L1hkYRAfh4l-qD0ugvuFqxvaOUdXVqXg/viewform',
+              ].join('\n'),
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            });


### PR DESCRIPTION
## 概要

freee API 自体への要望 Issue に `api-request` ラベルを付けると、freee Public API リクエストフォームを案内するコメントを自動投稿し、not planned でクローズする GitHub Actions ワークフローを追加。

関連: #312 #313 #322

## 変更種別

- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [x] その他