### PR TITLE
docs: プラグインインストール手順を修正し Remote MCP を追加

### DIFF
--- a/.changeset/fix-plugin-install-docs.md
+++ b/.changeset/fix-plugin-install-docs.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+README の Claude Code プラグインインストール手順を修正（marketplace 追加 → プラグインインストールの2段階手順に更新）

--- a/README.md
+++ b/README.md
@@ -119,8 +119,11 @@ npx skills add freee/freee-mcp
 
 Claude Code でプラグインとしてインストールすると、MCP サーバーと Agent Skills（API リファレンス・操作レシピ）がまとめて利用できます。
 
-```bash
-claude plugin install freee/freee-mcp
+Claude Code のプロンプト内で以下の2つのコマンドを順に実行してください:
+
+```
+/plugin marketplace add freee/freee-mcp
+/plugin install freee-api@freee-api-marketplace
 ```
 
 ## Agent Skills の内容
@@ -212,6 +215,7 @@ HTTPメソッドごとのシンプルなツール構成:
 <a href="https://github.com/kbyk004"><img src="https://github.com/kbyk004.png" width="40" height="40" alt="@kbyk004"></a>
 <a href="https://github.com/k4200"><img src="https://github.com/k4200.png" width="40" height="40" alt="@k4200"></a>
 <a href="https://github.com/fukumayuta"><img src="https://github.com/fukumayuta.png" width="40" height="40" alt="@fukumayuta"></a>
+<a href="https://github.com/kenchan"><img src="https://github.com/kenchan.png" width="40" height="40" alt="@kenchan"></a>
 <!-- CONTRIBUTORS-END -->
 
 ## 開発者向け


### PR DESCRIPTION
## 概要

README の「Claude Code Plugin として使う」セクションのインストール手順を修正し、プラグイン設定を改善。

- インストール手順を正しい2段階手順（marketplace 追加 → プラグインインストール）に修正
- CLI 版とスラッシュコマンド版の両方を併記
- プラグイン名を `freee-api` → `freee-mcp` に変更（リポジトリ名と統一）
- marketplace 名を `freee-api-marketplace` → `freee-mcp-marketplace` に変更
- plugin.json に Remote MCP サーバー (`https://mcp.freee.co.jp/mcp`) を追加
- Contributors に @kenchan を追加

## 変更種別

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント
- [ ] その他

Closes #311