### PR TITLE
docs: CLAUDE.md に Skill 更新は patch バージョンである旨を追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ Common issues:
 
 - `skills/freee-api-skill/` 内の `VERSION.md` は npm publish 時に自動生成されるため、開発環境（ローカル）には存在しない
 - 開発環境では `freee_server_info` のバージョンが `dev` と返る（正常動作）。実際のバージョンは `package.json` の `version` を参照する
+- Skill の更新（レシピ・リファレンスの追加・修正など）は changeset で `patch` バージョンとする
 
 ## Skill レシピの書き方
 


### PR DESCRIPTION
## 概要

CLAUDE.md の「Skill について」セクションに、Skill の更新（レシピ・リファレンスの追加・修正など）は changeset で patch バージョンとする旨を追記。

## 変更種別

- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [x] ドキュメント
- [ ] その他