### PR TITLE
feat: adopt canonical log line pattern for remote mode (1 request = 1 log = 1 trace)

### DIFF
--- a/.changeset/canonical-log-line.md
+++ b/.changeset/canonical-log-line.md
@@ -1,0 +1,15 @@
+---
+"freee-mcp": minor
+---
+
+Remote モードのロギングを canonical log line パターンに再構成
+
+1 HTTP リクエスト = 1 ログ行 = 1 trace の形式で、リクエスト単位のメタデータ
+(method, status, duration, tool_calls, api_calls, errors) を 1 本の JSON ログに集約して出力します。
+既存の個別イベントログ (API request completed, Tool call completed 等) は削除。
+
+- 新規ログフィールド: request_id, source_ip, user_id, session_id, http.*, mcp.tool_calls[], api_calls[], errors[]
+- エラー発生時は `Error.cause` チェーンと stack trace を `errors[].chain` に含める (serialize-error 経由)
+- プライバシー保護: query 値や request body などユーザー入力はログに一切含まれない (型システムで強制)
+- 400/500 エラーも canonical log で自動捕捉 (従来ログに残らなかった 400 系をカバー)
+- pino.redact による defense-in-depth で stray log 経路からの漏洩も防止

--- a/.changeset/user-agent-logging.md
+++ b/.changeset/user-agent-logging.md
@@ -1,0 +1,9 @@
+---
+"freee-mcp": patch
+---
+
+Remote モードの canonical log line に inbound `user_agent` フィールドを追加、外部 freee API 向けの outbound User-Agent に transport mode (`stdio` / `remote`) を含めた
+
+- Remote: MCP クライアントから届いた `User-Agent` ヘッダを 256 文字に切り詰め、`scrubErrorMessage` で数値 ID とメールをマスクした上で canonical log line に記録。Datadog で `@user_agent:ClaudeDesktop*` のように MCP クライアント別の分析が可能になる
+- Outbound: freee API への fetch で送る User-Agent を `freee-mcp/<version> (MCP Server; stdio; +url)` / `freee-mcp/<version> (MCP Server; remote; +url)` の 2 形式に分離。freee 側ログでどの transport からの呼び出しかを区別できる
+- 新モジュール `src/server/user-agent.ts` (`getUserAgent()` / `setUserAgentTransportMode()`) が `src/constants.ts` の旧 `USER_AGENT` 定数を置き換える。初期化はエントリポイント (`src/index.ts`, `src/sign/index.ts`, `src/server/http-server.ts`) で 1 度だけ実行

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Remote (`mcp.freee.co.jp`) モードでは 1 HTTP リクエスト = 1 ログ行 
   "request_id": "...",
   "trace_id": "...",
   "source_ip": "...",
+  "user_agent": "ClaudeDesktop/1.2.3 (macOS 15.1)",
   "user_id": "...",
   "http": { "method": "POST", "path": "/mcp", "status": 200, "duration_ms": 842 },
   "mcp": { "tool_calls": [...], "tool_call_count": 1 },
@@ -108,6 +109,8 @@ Remote (`mcp.freee.co.jp`) モードでは 1 HTTP リクエスト = 1 ログ行 
 - エラー発生時は `serializeErrorChain()` (`src/server/error-serializer.ts`) で `Error.cause` チェーンを展開し、`errors[].chain[]` に stack trace 付きで格納される
 - プライバシー: `ToolCallInfo` の型が query 値や body を表現できないよう設計されており、型システムで漏洩を防止する。pino.redact と `scrubErrorMessage()` (6 桁以上の数値 ID とメールアドレスをマスク) が二重の防御層として働く
 - `http.status` はクライアントへの最終応答コード、`api_calls[].status_code` は内部 freee API の応答コードで意味が異なる。freee API が 500 でも MCP 応答は 200 で包む場合があるため両方を参照する
+- Inbound `User-Agent` ヘッダは `src/telemetry/middleware.ts` の `normalizeUserAgent()` で scrub → 256 文字切り詰めを行った上で `user_agent` フィールドに記録される。どの MCP クライアント (Claude Desktop / Cursor / 自作スクリプトなど) が呼び出したかを Datadog で分析可能。UA に 6 桁以上の連続数字が含まれる場合は `[REDACTED_ID]` に置換される点に注意 (例: `Chrome/120.0.987654.1` → `Chrome/120.0.[REDACTED_ID].1`)。4 桁以下のビルド番号 (実際の Chrome, Safari など) は素通し
+- Outbound の User-Agent (freee API 向け) は `src/server/user-agent.ts` の `getUserAgent()` が transport mode を含む文字列を返す: `freee-mcp/<version> (MCP Server; stdio|remote; +url)`。エントリポイントで `initUserAgentTransportMode('remote' | 'stdio')` を起動時 1 回だけ呼ぶ
 - 詳細な個別イベントを見たい場合は環境変数 `LOG_LEVEL=debug` で再起動する (ただし現在 debug ログは運用では用意していない)
 
 Datadog 検索例:
@@ -116,6 +119,7 @@ Datadog 検索例:
 - `@api_calls.error_type:timeout` — 外部 API タイムアウトの集計 (envoy アラームとの相関分析用)
 - `@http.status:200 @errors:*` — 見かけ上は成功だが内部的に失敗した (MCP 応答に error content を wrap したもの)
 - `@request_id:<uuid>` — 特定リクエストのすべての情報 (1 行にまとまっている)
+- `@user_agent:ClaudeDesktop*` — 特定の MCP クライアント種別だけを抽出 (クライアント別のタイムアウト / エラー分布分析)
 
 ## PR Creation Pre-flight Checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,42 +83,20 @@ Sign development mode: Use `"command": "bun", "args": ["run", "src/sign/index.ts
 
 ### Remote モードのロギング (canonical log line)
 
-Remote (`mcp.freee.co.jp`) モードでは 1 HTTP リクエスト = 1 ログ行 = 1 trace のパターンで JSON 構造化ログを出力する。個別イベントログ (`API request completed` 等) は存在せず、`src/telemetry/middleware.ts` の `res.on('finish')` で 1 本にまとめて emit される。
+Remote モードは「1 HTTP リクエスト = 1 ログ行 = 1 trace」パターン。ペイロード形状は `CanonicalLogPayload` (`src/server/request-context.ts`)、emit は `src/telemetry/middleware.ts` の `res.on('finish')`。
 
-ログ行の構造:
+読み落としやすい注意点:
 
-```json
-{
-  "msg": "mcp request completed",
-  "request_id": "...",
-  "trace_id": "...",
-  "source_ip": "...",
-  "user_agent": "ClaudeDesktop/1.2.3 (macOS 15.1)",
-  "user_id": "...",
-  "http": { "method": "POST", "path": "/mcp", "status": 200, "duration_ms": 842 },
-  "mcp": { "tool_calls": [...], "tool_call_count": 1 },
-  "api_calls": [...],
-  "api_call_count": 1,
-  "errors": []
-}
-```
-
-実装の要点:
-
-- tool handler・API client・エラーハンドラは `getCurrentRecorder()?.recordX(...)` でリクエスト単位バッファ (`src/server/request-context.ts`) に情報を追記する。AsyncLocalStorage 経由で伝播
-- エラーは `serializeErrorChain()` (`src/server/error-serializer.ts`) で `Error.cause` チェーンを展開。実際の `Error` オブジェクトを持たない synthetic error (validation 失敗、routing 404 等) は `makeErrorChain(name, message)` 経由で登録すること。素の `[{ name, message }]` リテラルは `scrubErrorMessage()` を通らず privacy 漏洩の原因になる
-- プライバシー: `ToolCallInfo` の型が query 値や body を表現できないよう設計されており、型システムで漏洩を防止する。pino.redact と `scrubErrorMessage()` (6 桁以上の数値 ID とメールアドレスをマスク) が二重の防御層として働く
-- `http.status` はクライアントへの最終応答コード、`api_calls[].status_code` は内部 freee API の応答コードで意味が異なる。freee API が 500 でも MCP 応答は 200 で包む場合があるため両方を参照する
-- Inbound `User-Agent` は `normalizeUserAgent()` (`src/telemetry/middleware.ts`) で scrub → 256 文字切り詰め。UA に 6 桁以上の連続数字が含まれる場合は `[REDACTED_ID]` に置換される (例: `Chrome/120.0.987654.1` → `Chrome/120.0.[REDACTED_ID].1`)。4 桁以下のビルド番号は素通し
-- Outbound の User-Agent (freee API 向け) は `getUserAgent()` (`src/server/user-agent.ts`) が返す。エントリポイントで `initUserAgentTransportMode('remote' | 'stdio')` を起動時 1 回だけ呼ぶこと
+- synthetic error (validation 失敗、routing 404 等) は `makeErrorChain(name, message)` 経由で登録すること。素の `[{ name, message }]` リテラルは `scrubErrorMessage()` を通らず privacy 漏洩の原因になる
+- `http.status` は MCP クライアントへの最終応答、`api_calls[].status_code` は freee API からの応答。freee API 500 でも MCP 応答は 200 で wrap する場合があり、両方を見る必要がある
 
 Datadog 検索例:
 
 - `@http.status:500` — MCP サーバー自体の 5xx
-- `@api_calls.error_type:timeout` — 外部 API タイムアウトの集計 (envoy アラームとの相関分析用)
-- `@http.status:200 @errors:*` — 見かけ上は成功だが内部的に失敗した (MCP 応答に error content を wrap したもの)
-- `@request_id:<uuid>` — 特定リクエストのすべての情報 (1 行にまとまっている)
-- `@user_agent:ClaudeDesktop*` — 特定の MCP クライアント種別だけを抽出 (クライアント別のタイムアウト / エラー分布分析)
+- `@api_calls.error_type:timeout` — 外部 API タイムアウト
+- `@http.status:200 @errors:*` — 見かけ上は成功だが内部的に失敗
+- `@request_id:<uuid>` — 特定リクエストの全情報
+- `@user_agent:ClaudeDesktop*` — MCP クライアント種別でフィルタ
 
 ## PR Creation Pre-flight Checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,42 @@ Sign development mode: Use `"command": "bun", "args": ["run", "src/sign/index.ts
 - `FREEE_API_BASE_URL_SM` - 販売API
 - `FREEE_SIGN_API_URL` - サインAPI（`src/sign/config.ts` で処理）
 
+### Remote モードのロギング (canonical log line)
+
+Remote (`mcp.freee.co.jp`) モードでは 1 HTTP リクエスト = 1 ログ行 = 1 trace のパターンで JSON 構造化ログを出力する。個別イベントログ (`API request completed` 等) は存在せず、`src/telemetry/middleware.ts` の `res.on('finish')` で 1 本にまとめて emit される。
+
+ログ行の構造:
+
+```json
+{
+  "msg": "mcp request completed",
+  "request_id": "...",
+  "trace_id": "...",
+  "source_ip": "...",
+  "user_id": "...",
+  "http": { "method": "POST", "path": "/mcp", "status": 200, "duration_ms": 842 },
+  "mcp": { "tool_calls": [...], "tool_call_count": 1 },
+  "api_calls": [...],
+  "api_call_count": 1,
+  "errors": []
+}
+```
+
+実装の要点:
+
+- `src/server/request-context.ts` の `RequestRecorder` が AsyncLocalStorage 経由でリクエスト単位の状態を保持する。tool handler・API client・エラーハンドラは `getCurrentRecorder()?.recordToolCall(...)` / `recordApiCall(...)` / `recordError(...)` で情報を追記する
+- エラー発生時は `serializeErrorChain()` (`src/server/error-serializer.ts`) で `Error.cause` チェーンを展開し、`errors[].chain[]` に stack trace 付きで格納される
+- プライバシー: `ToolCallInfo` の型が query 値や body を表現できないよう設計されており、型システムで漏洩を防止する。pino.redact と `scrubErrorMessage()` (6 桁以上の数値 ID とメールアドレスをマスク) が二重の防御層として働く
+- `http.status` はクライアントへの最終応答コード、`api_calls[].status_code` は内部 freee API の応答コードで意味が異なる。freee API が 500 でも MCP 応答は 200 で包む場合があるため両方を参照する
+- 詳細な個別イベントを見たい場合は環境変数 `LOG_LEVEL=debug` で再起動する (ただし現在 debug ログは運用では用意していない)
+
+Datadog 検索例:
+
+- `@http.status:500` — MCP サーバー自体の 5xx
+- `@api_calls.error_type:timeout` — 外部 API タイムアウトの集計 (envoy アラームとの相関分析用)
+- `@http.status:200 @errors:*` — 見かけ上は成功だが内部的に失敗した (MCP 応答に error content を wrap したもの)
+- `@request_id:<uuid>` — 特定リクエストのすべての情報 (1 行にまとまっている)
+
 ## PR Creation Pre-flight Checklist
 
 Always run before creating a PR:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,13 +105,12 @@ Remote (`mcp.freee.co.jp`) モードでは 1 HTTP リクエスト = 1 ログ行 
 
 実装の要点:
 
-- `src/server/request-context.ts` の `RequestRecorder` が AsyncLocalStorage 経由でリクエスト単位の状態を保持する。tool handler・API client・エラーハンドラは `getCurrentRecorder()?.recordToolCall(...)` / `recordApiCall(...)` / `recordError(...)` で情報を追記する
-- エラー発生時は `serializeErrorChain()` (`src/server/error-serializer.ts`) で `Error.cause` チェーンを展開し、`errors[].chain[]` に stack trace 付きで格納される
+- tool handler・API client・エラーハンドラは `getCurrentRecorder()?.recordX(...)` でリクエスト単位バッファ (`src/server/request-context.ts`) に情報を追記する。AsyncLocalStorage 経由で伝播
+- エラーは `serializeErrorChain()` (`src/server/error-serializer.ts`) で `Error.cause` チェーンを展開。実際の `Error` オブジェクトを持たない synthetic error (validation 失敗、routing 404 等) は `makeErrorChain(name, message)` 経由で登録すること。素の `[{ name, message }]` リテラルは `scrubErrorMessage()` を通らず privacy 漏洩の原因になる
 - プライバシー: `ToolCallInfo` の型が query 値や body を表現できないよう設計されており、型システムで漏洩を防止する。pino.redact と `scrubErrorMessage()` (6 桁以上の数値 ID とメールアドレスをマスク) が二重の防御層として働く
 - `http.status` はクライアントへの最終応答コード、`api_calls[].status_code` は内部 freee API の応答コードで意味が異なる。freee API が 500 でも MCP 応答は 200 で包む場合があるため両方を参照する
-- Inbound `User-Agent` ヘッダは `src/telemetry/middleware.ts` の `normalizeUserAgent()` で scrub → 256 文字切り詰めを行った上で `user_agent` フィールドに記録される。どの MCP クライアント (Claude Desktop / Cursor / 自作スクリプトなど) が呼び出したかを Datadog で分析可能。UA に 6 桁以上の連続数字が含まれる場合は `[REDACTED_ID]` に置換される点に注意 (例: `Chrome/120.0.987654.1` → `Chrome/120.0.[REDACTED_ID].1`)。4 桁以下のビルド番号 (実際の Chrome, Safari など) は素通し
-- Outbound の User-Agent (freee API 向け) は `src/server/user-agent.ts` の `getUserAgent()` が transport mode を含む文字列を返す: `freee-mcp/<version> (MCP Server; stdio|remote; +url)`。エントリポイントで `initUserAgentTransportMode('remote' | 'stdio')` を起動時 1 回だけ呼ぶ
-- 詳細な個別イベントを見たい場合は環境変数 `LOG_LEVEL=debug` で再起動する (ただし現在 debug ログは運用では用意していない)
+- Inbound `User-Agent` は `normalizeUserAgent()` (`src/telemetry/middleware.ts`) で scrub → 256 文字切り詰め。UA に 6 桁以上の連続数字が含まれる場合は `[REDACTED_ID]` に置換される (例: `Chrome/120.0.987654.1` → `Chrome/120.0.[REDACTED_ID].1`)。4 桁以下のビルド番号は素通し
+- Outbound の User-Agent (freee API 向け) は `getUserAgent()` (`src/server/user-agent.ts`) が返す。エントリポイントで `initUserAgentTransportMode('remote' | 'stdio')` を起動時 1 回だけ呼ぶこと
 
 Datadog 検索例:
 

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "pino": "^10.3.1",
         "prompts": "^2.4.2",
         "rate-limit-redis": "^4.3.1",
+        "serialize-error": "^13.0.1",
         "zod": "^3.25.76",
       },
       "devDependencies": {
@@ -853,6 +854,8 @@
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
+    "non-error": ["non-error@0.1.0", "", {}, "sha512-TMB1uHiGsHRGv1uYclfhivcnf0/PdFp2pNqRxXjncaAsjYMoisaQJI+SSZCqRq+VliwRTC8tsMQfmrWjDMhkPQ=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
@@ -995,6 +998,8 @@
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
+    "serialize-error": ["serialize-error@13.0.1", "", { "dependencies": { "non-error": "^0.1.0", "type-fest": "^5.4.1" } }, "sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA=="],
+
     "serve-handler": ["serve-handler@6.1.7", "", { "dependencies": { "bytes": "3.0.0", "content-disposition": "0.5.2", "mime-types": "2.1.18", "minimatch": "3.1.5", "path-is-inside": "1.0.2", "path-to-regexp": "3.3.0", "range-parser": "1.2.0" } }, "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
@@ -1063,6 +1068,8 @@
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
+    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
     "tailwind-merge": ["tailwind-merge@2.6.1", "", {}, "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ=="],
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
@@ -1096,6 +1103,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "type-fest": ["type-fest@5.5.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "pino": "^10.3.1",
     "prompts": "^2.4.2",
     "rate-limit-redis": "^4.3.1",
+    "serialize-error": "^13.0.1",
     "zod": "^3.25.76"
   },
   "keywords": [

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { USER_AGENT } from '../constants.js';
+import { getUserAgent } from '../server/user-agent.js';
 import { type BinaryFileResponse, isBinaryFileResponse, makeApiRequest } from './client.js';
 
 // Test constants (defined after mocks due to hoisting)
@@ -132,7 +132,7 @@ describe('client', () => {
           headers: {
             Authorization: `Bearer ${TEST_ACCESS_TOKEN}`,
             'Content-Type': 'application/json',
-            'User-Agent': USER_AGENT,
+            'User-Agent': getUserAgent(),
           },
           body: undefined,
           signal: expect.any(AbortSignal),
@@ -180,7 +180,7 @@ describe('client', () => {
           headers: {
             Authorization: `Bearer ${TEST_ACCESS_TOKEN}`,
             'Content-Type': 'application/json',
-            'User-Agent': USER_AGENT,
+            'User-Agent': getUserAgent(),
           },
           body: JSON.stringify(requestBody),
           signal: expect.any(AbortSignal),

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -361,4 +361,112 @@ describe('client', () => {
       expect(binaryResult.data).toEqual(Buffer.from(pngMagicBytes));
     });
   });
+
+  describe('makeApiRequest - recorder integration', () => {
+    it('records an api_call with the success path pattern', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+      // The shared createJsonResponse helper omits `status`, but the recorder
+      // captures it verbatim — set it explicitly so the assertion is meaningful.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: createMockHeaders('application/json'),
+        json: (): Promise<unknown> => Promise.resolve({ ok: true }),
+        text: (): Promise<string> => Promise.resolve(JSON.stringify({ ok: true })),
+      });
+
+      const { RequestRecorder, withRequestRecorder } = await import(
+        '../server/request-context.js'
+      );
+      const recorder = new RequestRecorder({
+        request_id: 'req-api-success',
+        source_ip: '127.0.0.1',
+        method: 'POST',
+        path: '/mcp',
+      });
+
+      await withRequestRecorder(recorder, () =>
+        makeApiRequest('GET', '/api/1/deals/98765', { limit: 10 }),
+      );
+
+      const payload = recorder.buildPayload({ status: 200, duration_ms: 1 });
+      const apiCalls = payload.api_calls as Array<Record<string, unknown>>;
+      expect(apiCalls).toHaveLength(1);
+      expect(apiCalls[0]).toMatchObject({
+        method: 'GET',
+        path_pattern: '/api/:id/deals/:id',
+        status_code: 200,
+        error_type: null,
+      });
+      // Query values must not be in the path_pattern.
+      expect(JSON.stringify(apiCalls[0])).not.toContain('limit=10');
+    });
+
+    it('records an api_call with error_type=http_error on 500 response', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+      mockFetch.mockResolvedValue(createErrorResponse(500, { error: 'oops' }));
+
+      const { RequestRecorder, withRequestRecorder } = await import(
+        '../server/request-context.js'
+      );
+      const recorder = new RequestRecorder({
+        request_id: 'req-api-500',
+        source_ip: '127.0.0.1',
+        method: 'POST',
+        path: '/mcp',
+      });
+
+      await expect(
+        withRequestRecorder(recorder, () => makeApiRequest('GET', '/api/1/users/me')),
+      ).rejects.toThrow(/API request failed: 500/);
+
+      const payload = recorder.buildPayload({ status: 200, duration_ms: 1 });
+      const apiCalls = payload.api_calls as Array<Record<string, unknown>>;
+      expect(apiCalls).toHaveLength(1);
+      expect(apiCalls[0]).toMatchObject({
+        method: 'GET',
+        status_code: 500,
+        error_type: 'http_error',
+      });
+
+      const errors = payload.errors as Array<{ source: string; chain: Array<{ message: string }> }>;
+      expect(errors).toHaveLength(1);
+      expect(errors[0].source).toBe('api_client');
+      expect(errors[0].chain[0].message).toMatch(/API request failed: 500/);
+    });
+
+    it('records an api_call with error_type=auth_error on 401 response', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+      mockFetch.mockResolvedValue(createErrorResponse(401, { error: 'invalid_token' }));
+
+      const { RequestRecorder, withRequestRecorder } = await import(
+        '../server/request-context.js'
+      );
+      const recorder = new RequestRecorder({
+        request_id: 'req-api-401',
+        source_ip: '127.0.0.1',
+        method: 'POST',
+        path: '/mcp',
+      });
+
+      await expect(
+        withRequestRecorder(recorder, () => makeApiRequest('GET', '/api/1/users/me')),
+      ).rejects.toThrow();
+
+      const apiCalls = recorder.buildPayload({ status: 200, duration_ms: 1 }).api_calls as Array<
+        Record<string, unknown>
+      >;
+      expect(apiCalls[0]).toMatchObject({ status_code: 401, error_type: 'auth_error' });
+    });
+
+    it('does nothing (null-safe) when no recorder is installed', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+      mockFetch.mockResolvedValue(createJsonResponse({ ok: true }));
+
+      // Called OUTSIDE of withRequestRecorder — getCurrentRecorder() returns undefined
+      // (this is the CLI mode path). Must still succeed without throwing.
+      const result = await makeApiRequest('GET', '/api/1/users/me');
+      expect(result).toEqual({ ok: true });
+    });
+  });
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,10 +1,11 @@
 import { getValidAccessToken } from '../auth/tokens.js';
 import { getCurrentCompanyId } from '../config/companies.js';
 import { getConfig } from '../config.js';
-import { FETCH_TIMEOUT_API_MS, USER_AGENT } from '../constants.js';
+import { FETCH_TIMEOUT_API_MS } from '../constants.js';
 import { serializeErrorChain } from '../server/error-serializer.js';
 import { sanitizePath } from '../server/logger.js';
 import { getCurrentRecorder } from '../server/request-context.js';
+import { getUserAgent } from '../server/user-agent.js';
 import { type TokenContext, resolveCompanyId } from '../storage/context.js';
 import { formatApiErrorMessage, formatResponseErrorInfo } from '../utils/error.js';
 
@@ -102,7 +103,7 @@ export async function makeApiRequest(
       headers: {
         Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
-        'User-Agent': USER_AGENT,
+        'User-Agent': getUserAgent(),
       },
       body: body ? JSON.stringify(typeof body === 'string' ? JSON.parse(body) : body) : undefined,
       signal: AbortSignal.timeout(FETCH_TIMEOUT_API_MS),

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -208,8 +208,6 @@ export async function makeApiRequest(
   // Check Content-Type for binary response
   const contentType = response.headers.get('content-type') || '';
 
-  // Shared metadata for all success-path recorder calls. One recorder entry
-  // per fetch attempt — repeated across the four return paths below.
   const successApiCall = {
     method,
     path_pattern: safePath,

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,9 +2,9 @@ import { getValidAccessToken } from '../auth/tokens.js';
 import { getCurrentCompanyId } from '../config/companies.js';
 import { getConfig } from '../config.js';
 import { FETCH_TIMEOUT_API_MS, USER_AGENT } from '../constants.js';
-import { createChildLogger, sanitizePath } from '../server/logger.js';
-
-const getLog = createChildLogger({ component: 'api-client' });
+import { serializeErrorChain } from '../server/error-serializer.js';
+import { sanitizePath } from '../server/logger.js';
+import { getCurrentRecorder } from '../server/request-context.js';
 import { type TokenContext, resolveCompanyId } from '../storage/context.js';
 import { formatApiErrorMessage, formatResponseErrorInfo } from '../utils/error.js';
 
@@ -46,7 +46,7 @@ export async function makeApiRequest(
   baseUrl?: string,
   tokenContext?: TokenContext,
 ): Promise<unknown | BinaryFileResponse> {
-  const log = getLog();
+  const recorder = getCurrentRecorder();
   const startTime = Date.now();
   const safePath = sanitizePath(apiPath);
   const userId = tokenContext?.userId ?? 'local';
@@ -109,22 +109,28 @@ export async function makeApiRequest(
     });
   } catch (fetchError) {
     const durationMs = Date.now() - startTime;
-    const errorType =
+    const errorType: 'timeout' | 'network_error' =
       fetchError instanceof Error && fetchError.name === 'TimeoutError' ? 'timeout' : 'network_error';
-    log.error(
-      { method, path: safePath, duration_ms: durationMs, user_id: userId, company_id: companyId, error_type: errorType, err: fetchError },
-      'API request network error',
-    );
+    recorder?.recordApiCall({
+      method,
+      path_pattern: safePath,
+      status_code: null,
+      duration_ms: durationMs,
+      company_id: String(companyId ?? ''),
+      user_id: userId,
+      error_type: errorType,
+    });
+    recorder?.recordError({
+      source: 'api_client',
+      error_type: errorType,
+      chain: serializeErrorChain(fetchError),
+    });
     throw fetchError;
   }
 
   if (response.status === 401) {
     const errorInfo = await formatResponseErrorInfo(response);
-    log.warn(
-      { method, path: safePath, status: 401, duration_ms: Date.now() - startTime, user_id: userId, company_id: companyId, error_type: 'auth_error', error_detail: errorInfo },
-      'API request failed',
-    );
-    throw new Error(
+    const authError = new Error(
       `認証エラーが発生しました。freee_authenticate ツールを使用して再認証を行ってください。\n` +
         `現在の事業所ID: ${companyId}\n` +
         `エラー詳細: ${response.status} ${errorInfo}\n\n` +
@@ -133,47 +139,88 @@ export async function makeApiRequest(
         `2. トークンの有効期限が切れていないか\n` +
         `3. 事業所IDが正しいか（freee_get_current_company で確認）`,
     );
+    recorder?.recordApiCall({
+      method,
+      path_pattern: safePath,
+      status_code: 401,
+      duration_ms: Date.now() - startTime,
+      company_id: String(companyId ?? ''),
+      user_id: userId,
+      error_type: 'auth_error',
+    });
+    recorder?.recordError({
+      source: 'api_client',
+      status_code: 401,
+      error_type: 'auth_error',
+      chain: serializeErrorChain(authError),
+    });
+    throw authError;
   }
 
   if (response.status === 403) {
     const errorInfo = await formatResponseErrorInfo(response);
-    log.warn(
-      { method, path: safePath, status: 403, duration_ms: Date.now() - startTime, user_id: userId, company_id: companyId, error_type: 'forbidden', error_detail: errorInfo },
-      'API request failed',
-    );
-    throw new Error(
+    const forbiddenError = new Error(
       `アクセス拒否 (403): ${errorInfo}\n` +
         `事業所ID: ${companyId}\n\n` +
         `レートリミットの可能性があります。数分待ってから再試行してください。\n` +
         `それでも解決しない場合は、アプリの権限設定を確認するか、freee_authenticate で再認証してください。`,
     );
+    recorder?.recordApiCall({
+      method,
+      path_pattern: safePath,
+      status_code: 403,
+      duration_ms: Date.now() - startTime,
+      company_id: String(companyId ?? ''),
+      user_id: userId,
+      error_type: 'forbidden',
+    });
+    recorder?.recordError({
+      source: 'api_client',
+      status_code: 403,
+      error_type: 'forbidden',
+      chain: serializeErrorChain(forbiddenError),
+    });
+    throw forbiddenError;
   }
 
   if (!response.ok) {
     const errorMessage = await formatApiErrorMessage(response, response.status);
-    const logLevel = response.status >= 500 ? 'error' : 'warn';
-    log[logLevel](
-      { method, path: safePath, status: response.status, duration_ms: Date.now() - startTime, user_id: userId, company_id: companyId, error_type: 'http_error', error_detail: errorMessage },
-      'API request failed',
-    );
-    throw new Error(errorMessage);
+    const httpError = new Error(errorMessage);
+    recorder?.recordApiCall({
+      method,
+      path_pattern: safePath,
+      status_code: response.status,
+      duration_ms: Date.now() - startTime,
+      company_id: String(companyId ?? ''),
+      user_id: userId,
+      error_type: 'http_error',
+    });
+    recorder?.recordError({
+      source: 'api_client',
+      status_code: response.status,
+      error_type: 'http_error',
+      chain: serializeErrorChain(httpError),
+    });
+    throw httpError;
   }
 
   // Check Content-Type for binary response
   const contentType = response.headers.get('content-type') || '';
 
-  const baseLogFields = {
+  // Shared metadata for all success-path recorder calls. One recorder entry
+  // per fetch attempt — repeated across the four return paths below.
+  const successApiCall = {
     method,
-    path: safePath,
-    status: response.status,
+    path_pattern: safePath,
+    status_code: response.status,
+    company_id: String(companyId ?? ''),
     user_id: userId,
-    company_id: companyId,
-    content_type: contentType || undefined,
+    error_type: null as null,
   };
 
   if (isBinaryContentType(contentType)) {
     const buffer = Buffer.from(await response.arrayBuffer());
-    log.info({ ...baseLogFields, duration_ms: Date.now() - startTime }, 'API request completed');
+    recorder?.recordApiCall({ ...successApiCall, duration_ms: Date.now() - startTime });
     return {
       type: 'binary',
       data: buffer,
@@ -184,27 +231,39 @@ export async function makeApiRequest(
 
   // Handle empty responses (e.g., 204 No Content from DELETE)
   if (response.status === 204) {
-    log.info({ ...baseLogFields, duration_ms: Date.now() - startTime }, 'API request completed');
+    recorder?.recordApiCall({ ...successApiCall, duration_ms: Date.now() - startTime });
     return null;
   }
 
   const text = await response.text();
   if (!text) {
-    log.info({ ...baseLogFields, duration_ms: Date.now() - startTime }, 'API request completed');
+    recorder?.recordApiCall({ ...successApiCall, duration_ms: Date.now() - startTime });
     return null;
   }
 
   try {
     const parsed = JSON.parse(text);
-    log.info({ ...baseLogFields, duration_ms: Date.now() - startTime }, 'API request completed');
+    recorder?.recordApiCall({ ...successApiCall, duration_ms: Date.now() - startTime });
     return parsed;
   } catch {
-    log.error(
-      { method, path: safePath, status: response.status, content_type: contentType, error_type: 'json_parse_error' },
-      'Failed to parse API response',
-    );
-    throw new Error(
+    const parseError = new Error(
       `Failed to parse API response as JSON. Status: ${response.status}, Content-Type: ${contentType}, Body preview: ${text.slice(0, 200)}`,
     );
+    recorder?.recordApiCall({
+      method,
+      path_pattern: safePath,
+      status_code: response.status,
+      duration_ms: Date.now() - startTime,
+      company_id: String(companyId ?? ''),
+      user_id: userId,
+      error_type: 'json_parse_error',
+    });
+    recorder?.recordError({
+      source: 'api_client',
+      status_code: response.status,
+      error_type: 'json_parse_error',
+      chain: serializeErrorChain(parseError),
+    });
+    throw parseError;
   }
 }

--- a/src/api/file-upload.ts
+++ b/src/api/file-upload.ts
@@ -4,10 +4,10 @@ import { getValidAccessToken } from '../auth/tokens.js';
 import { getCurrentCompanyId } from '../config/companies.js';
 import { getConfig } from '../config.js';
 import { USER_AGENT } from '../constants.js';
-import { createChildLogger } from '../server/logger.js';
+import { serializeErrorChain } from '../server/error-serializer.js';
+import type { ApiCallErrorType } from '../server/request-context.js';
+import { getCurrentRecorder } from '../server/request-context.js';
 import { type TokenContext, resolveCompanyId } from '../storage/context.js';
-
-const getLog = createChildLogger({ component: 'api-client' });
 import { formatApiErrorMessage, formatResponseErrorInfo } from '../utils/error.js';
 
 const MAX_FILE_SIZE_BYTES = 64 * 1024 * 1024; // 64MB
@@ -42,7 +42,7 @@ export async function uploadReceipt(
   options?: UploadReceiptOptions,
   tokenContext?: TokenContext,
 ): Promise<unknown> {
-  const log = getLog();
+  const recorder = getCurrentRecorder();
   const startTime = Date.now();
   const safePath = '/api/:id/receipts';
   const userId = tokenContext?.userId ?? 'local';
@@ -114,6 +114,30 @@ export async function uploadReceipt(
   const apiUrl = getConfig().freee.apiUrl;
   const url = `${apiUrl}/api/1/receipts`;
 
+  const recordFailure = (
+    statusCode: number | null,
+    errorType: ApiCallErrorType,
+    err: Error,
+  ): never => {
+    recorder?.recordApiCall({
+      method: 'POST',
+      path_pattern: safePath,
+      status_code: statusCode,
+      duration_ms: Date.now() - startTime,
+      company_id: String(companyId ?? ''),
+      user_id: userId,
+      error_type: errorType,
+      file_size_bytes: buffer.byteLength,
+    });
+    recorder?.recordError({
+      source: 'file_upload',
+      status_code: statusCode ?? undefined,
+      error_type: errorType,
+      chain: serializeErrorChain(err),
+    });
+    throw err;
+  };
+
   let response: Response;
   try {
     response = await fetch(url, {
@@ -125,66 +149,82 @@ export async function uploadReceipt(
       body: formData,
     });
   } catch (fetchError) {
-    const errorType =
+    const errorType: ApiCallErrorType =
       fetchError instanceof Error && fetchError.name === 'TimeoutError' ? 'timeout' : 'network_error';
-    log.error(
-      { method: 'POST', path: safePath, duration_ms: Date.now() - startTime, user_id: userId, company_id: companyId, file_size: buffer.byteLength, error_type: errorType, err: fetchError },
-      'File upload network error',
-    );
+    recorder?.recordApiCall({
+      method: 'POST',
+      path_pattern: safePath,
+      status_code: null,
+      duration_ms: Date.now() - startTime,
+      company_id: String(companyId ?? ''),
+      user_id: userId,
+      error_type: errorType,
+      file_size_bytes: buffer.byteLength,
+    });
+    recorder?.recordError({
+      source: 'file_upload',
+      error_type: errorType,
+      chain: serializeErrorChain(fetchError),
+    });
     throw fetchError;
   }
 
   if (response.status === 401) {
-    log.warn(
-      { method: 'POST', path: safePath, status: 401, duration_ms: Date.now() - startTime, user_id: userId, company_id: companyId, error_type: 'auth_error' },
-      'File upload failed',
-    );
     const errorInfo = await formatResponseErrorInfo(response);
-    throw new Error(
-      `認証エラーが発生しました。freee_authenticate ツールを使用して再認証を行ってください。\n` +
-        `現在の事業所ID: ${companyId}\n` +
-        `エラー詳細: ${response.status} ${errorInfo}`,
+    recordFailure(
+      401,
+      'auth_error',
+      new Error(
+        `認証エラーが発生しました。freee_authenticate ツールを使用して再認証を行ってください。\n` +
+          `現在の事業所ID: ${companyId}\n` +
+          `エラー詳細: ${response.status} ${errorInfo}`,
+      ),
     );
   }
 
   if (response.status === 403) {
-    log.warn(
-      { method: 'POST', path: safePath, status: 403, duration_ms: Date.now() - startTime, user_id: userId, company_id: companyId, error_type: 'forbidden' },
-      'File upload failed',
-    );
     const errorInfo = await formatResponseErrorInfo(response);
-    throw new Error(
-      `アクセス拒否 (403): ${errorInfo}\n` +
-        `事業所ID: ${companyId}\n\n` +
-        `レートリミットの可能性があります。数分待ってから再試行してください。`,
+    recordFailure(
+      403,
+      'forbidden',
+      new Error(
+        `アクセス拒否 (403): ${errorInfo}\n` +
+          `事業所ID: ${companyId}\n\n` +
+          `レートリミットの可能性があります。数分待ってから再試行してください。`,
+      ),
     );
   }
 
   if (!response.ok) {
-    const logLevel = response.status >= 500 ? 'error' : 'warn';
-    log[logLevel](
-      { method: 'POST', path: safePath, status: response.status, duration_ms: Date.now() - startTime, user_id: userId, company_id: companyId, error_type: 'http_error' },
-      'File upload failed',
-    );
     const errorMessage = await formatApiErrorMessage(response, response.status);
-    throw new Error(errorMessage);
+    recordFailure(response.status, 'http_error', new Error(errorMessage));
   }
+
+  // Success path: record the api call once with a null error_type.
+  recorder?.recordApiCall({
+    method: 'POST',
+    path_pattern: safePath,
+    status_code: response.status,
+    duration_ms: Date.now() - startTime,
+    company_id: String(companyId ?? ''),
+    user_id: userId,
+    error_type: null,
+    file_size_bytes: buffer.byteLength,
+  });
 
   const text = await response.text();
   try {
-    const parsed = JSON.parse(text);
-    log.info(
-      { method: 'POST', path: safePath, status: response.status, duration_ms: Date.now() - startTime, user_id: userId, company_id: companyId, file_size: buffer.byteLength },
-      'File upload completed',
-    );
-    return parsed;
+    return JSON.parse(text);
   } catch {
-    log.error(
-      { method: 'POST', path: safePath, status: response.status, error_type: 'json_parse_error' },
-      'Failed to parse upload response',
-    );
-    throw new Error(
+    const parseError = new Error(
       `Failed to parse API response as JSON. Status: ${response.status}, Body preview: ${text.slice(0, 200)}`,
     );
+    recorder?.recordError({
+      source: 'file_upload',
+      status_code: response.status,
+      error_type: 'json_parse_error',
+      chain: serializeErrorChain(parseError),
+    });
+    throw parseError;
   }
 }

--- a/src/api/file-upload.ts
+++ b/src/api/file-upload.ts
@@ -3,10 +3,10 @@ import path from 'node:path';
 import { getValidAccessToken } from '../auth/tokens.js';
 import { getCurrentCompanyId } from '../config/companies.js';
 import { getConfig } from '../config.js';
-import { USER_AGENT } from '../constants.js';
 import { serializeErrorChain } from '../server/error-serializer.js';
 import type { ApiCallErrorType } from '../server/request-context.js';
 import { getCurrentRecorder } from '../server/request-context.js';
+import { getUserAgent } from '../server/user-agent.js';
 import { type TokenContext, resolveCompanyId } from '../storage/context.js';
 import { formatApiErrorMessage, formatResponseErrorInfo } from '../utils/error.js';
 
@@ -144,7 +144,7 @@ export async function uploadReceipt(
       method: 'POST',
       headers: {
         Authorization: `Bearer ${accessToken}`,
-        'User-Agent': USER_AGENT,
+        'User-Agent': getUserAgent(),
       },
       body: formData,
     });

--- a/src/api/file-upload.ts
+++ b/src/api/file-upload.ts
@@ -200,25 +200,36 @@ export async function uploadReceipt(
     recordFailure(response.status, 'http_error', new Error(errorMessage));
   }
 
-  // Success path: record the api call once with a null error_type.
-  recorder?.recordApiCall({
-    method: 'POST',
-    path_pattern: safePath,
-    status_code: response.status,
-    duration_ms: Date.now() - startTime,
-    company_id: String(companyId ?? ''),
-    user_id: userId,
-    error_type: null,
-    file_size_bytes: buffer.byteLength,
-  });
-
   const text = await response.text();
   try {
-    return JSON.parse(text);
+    const parsed = JSON.parse(text);
+    // Record success only after JSON.parse succeeds to avoid a misleading
+    // "successful" api_call entry alongside a json_parse_error in the log.
+    recorder?.recordApiCall({
+      method: 'POST',
+      path_pattern: safePath,
+      status_code: response.status,
+      duration_ms: Date.now() - startTime,
+      company_id: String(companyId ?? ''),
+      user_id: userId,
+      error_type: null,
+      file_size_bytes: buffer.byteLength,
+    });
+    return parsed;
   } catch {
     const parseError = new Error(
       `Failed to parse API response as JSON. Status: ${response.status}, Body preview: ${text.slice(0, 200)}`,
     );
+    recorder?.recordApiCall({
+      method: 'POST',
+      path_pattern: safePath,
+      status_code: response.status,
+      duration_ms: Date.now() - startTime,
+      company_id: String(companyId ?? ''),
+      user_id: userId,
+      error_type: 'json_parse_error',
+      file_size_bytes: buffer.byteLength,
+    });
     recorder?.recordError({
       source: 'file_upload',
       status_code: response.status,

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 import { getConfig } from '../config.js';
-import { USER_AGENT } from '../constants.js';
+import { getUserAgent } from '../server/user-agent.js';
 import { formatResponseErrorInfo } from '../utils/error.js';
 import { createTokenData } from './token-utils.js';
 import { OAuthTokenResponseSchema, saveTokens, type TokenData } from './tokens.js';
@@ -36,7 +36,7 @@ export async function exchangeCodeForTokens(
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
-      'User-Agent': USER_AGENT,
+      'User-Agent': getUserAgent(),
     },
     body: new URLSearchParams({
       grant_type: 'authorization_code',

--- a/src/auth/tokens.ts
+++ b/src/auth/tokens.ts
@@ -6,8 +6,8 @@ import {
   CONFIG_FILE_PERMISSION,
   FETCH_TIMEOUT_TOKEN_MS,
   getConfigDir,
-  USER_AGENT,
 } from '../constants.js';
+import { getUserAgent } from '../server/user-agent.js';
 import { formatResponseErrorInfo } from '../utils/error.js';
 import { clearLegacyTokens, tryMigrateLegacyTokens } from './token-migration.js';
 import { createTokenData } from './token-utils.js';
@@ -106,7 +106,7 @@ export async function refreshFreeeTokenRaw(
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
-      'User-Agent': USER_AGENT,
+      'User-Agent': getUserAgent(),
     },
     body: new URLSearchParams({
       grant_type: 'refresh_token',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,13 +54,6 @@ declare const __PACKAGE_VERSION__: string | undefined;
 export const PACKAGE_VERSION =
   typeof __PACKAGE_VERSION__ !== 'undefined' ? __PACKAGE_VERSION__ : 'dev';
 
-/**
- * User-Agent header value for API requests
- * Format follows RFC 7231: ProductName/Version (comments)
- * @see https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3
- */
-export const USER_AGENT = `freee-mcp/${PACKAGE_VERSION} (MCP Server; +https://github.com/freee/freee-mcp)`;
-
 export const FREEE_AUTHORIZATION_ENDPOINT =
   'https://accounts.secure.freee.co.jp/public_api/authorize';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,15 @@
 import { configure } from './cli.js';
 import { createAndStartServer } from './mcp/handlers.js';
 import { getLogger, initLogger } from './server/logger.js';
+import { initUserAgentTransportMode } from './server/user-agent.js';
 
 const main = async (): Promise<void> => {
+  // Set the transport mode at the very top of main() so both `configure` and
+  // the MCP server code paths share the same outbound User-Agent convention.
+  // `configure` does not currently issue outbound freee API calls, but placing
+  // this here removes the need to re-audit that assumption on every change.
+  initUserAgentTransportMode('stdio');
+
   const args = process.argv.slice(2);
   const subcommand = args.find((arg) => !arg.startsWith('--'));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,6 @@ import { getLogger, initLogger } from './server/logger.js';
 import { initUserAgentTransportMode } from './server/user-agent.js';
 
 const main = async (): Promise<void> => {
-  // Set the transport mode at the very top of main() so both `configure` and
-  // the MCP server code paths share the same outbound User-Agent convention.
-  // `configure` does not currently issue outbound freee API calls, but placing
-  // this here removes the need to re-audit that assumption on every change.
   initUserAgentTransportMode('stdio');
 
   const args = process.argv.slice(2);

--- a/src/mcp/file-upload-tool.ts
+++ b/src/mcp/file-upload-tool.ts
@@ -1,15 +1,14 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { uploadReceipt } from '../api/file-upload.js';
-import { createChildLogger } from '../server/logger.js';
+import { serializeErrorChain } from '../server/error-serializer.js';
+import { getCurrentRecorder } from '../server/request-context.js';
 import type { AuthExtra } from '../storage/context.js';
 import { registerTracedTool } from '../telemetry/tool-tracer.js';
 import { extractTokenContext } from '../storage/context.js';
 import { createTextResponse, formatErrorMessage } from '../utils/error.js';
 
 export function addFileUploadTool(server: McpServer): void {
-  const getLog = createChildLogger({ component: 'tool', tool: 'freee_file_upload' });
-
   registerTracedTool(server,
     'freee_file_upload',
     {
@@ -46,7 +45,8 @@ export function addFileUploadTool(server: McpServer): void {
       },
       extra?: AuthExtra,
     ) => {
-      const log = getLog();
+      const recorder = getCurrentRecorder();
+      const toolStart = Date.now();
       try {
         const { file_path, ...options } = args;
         const tokenContext = extractTokenContext(extra);
@@ -64,10 +64,19 @@ export function addFileUploadTool(server: McpServer): void {
         }
         lines.push('', JSON.stringify(result, null, 2));
 
-        log.info('Tool call completed');
+        recorder?.recordToolCall({
+          tool: 'freee_file_upload',
+          status: 'success',
+          duration_ms: Date.now() - toolStart,
+        });
         return createTextResponse(lines.join('\n'));
       } catch (error) {
-        log.error({ err: error }, 'Tool call failed');
+        recorder?.recordToolCall({
+          tool: 'freee_file_upload',
+          status: 'error',
+          duration_ms: Date.now() - toolStart,
+        });
+        recorder?.recordError({ source: 'tool_handler', chain: serializeErrorChain(error) });
         return createTextResponse(`ファイルアップロードに失敗: ${formatErrorMessage(error)}`);
       }
     },

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -10,7 +10,7 @@ import {
 } from '../auth/server.js';
 import { getConfig } from '../config.js';
 import { AUTH_TIMEOUT_MS, PACKAGE_VERSION } from '../constants.js';
-import { serializeErrorChain } from '../server/error-serializer.js';
+import { makeErrorChain, serializeErrorChain } from '../server/error-serializer.js';
 import { getCurrentRecorder } from '../server/request-context.js';
 import type { AuthExtra } from '../storage/context.js';
 import { registerTracedTool } from '../telemetry/tool-tracer.js';
@@ -341,7 +341,7 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
           recorder?.recordError({
             source: 'tool_handler',
             error_type: 'schema_mismatch',
-            chain: [{ name: 'ZodError', message: parseResult.error.message }],
+            chain: makeErrorChain('ZodError', parseResult.error.message),
           });
           return {
             content: [

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -10,23 +10,14 @@ import {
 } from '../auth/server.js';
 import { getConfig } from '../config.js';
 import { AUTH_TIMEOUT_MS, PACKAGE_VERSION } from '../constants.js';
-import { createChildLogger, getLogger } from '../server/logger.js';
+import { serializeErrorChain } from '../server/error-serializer.js';
+import { getCurrentRecorder } from '../server/request-context.js';
 import type { AuthExtra } from '../storage/context.js';
 import { registerTracedTool } from '../telemetry/tool-tracer.js';
 import { extractTokenContext, resolveCompanyId } from '../storage/context.js';
 import { createTextResponse, formatErrorMessage } from '../utils/error.js';
 
 export function addAuthenticationTools(server: McpServer, options?: { remote?: boolean }): void {
-  const logs = {
-    currentUser: createChildLogger({ component: 'tool', tool: 'freee_current_user' }),
-    authenticate: createChildLogger({ component: 'tool', tool: 'freee_authenticate' }),
-    authStatus: createChildLogger({ component: 'tool', tool: 'freee_auth_status' }),
-    clearAuth: createChildLogger({ component: 'tool', tool: 'freee_clear_auth' }),
-    setCompany: createChildLogger({ component: 'tool', tool: 'freee_set_current_company' }),
-    getCompany: createChildLogger({ component: 'tool', tool: 'freee_get_current_company' }),
-    listCompanies: createChildLogger({ component: 'tool', tool: 'freee_list_companies' }),
-  };
-
   registerTracedTool(server,
     'freee_current_user',
     {
@@ -35,12 +26,18 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
       annotations: { readOnlyHint: true },
     },
     async (extra: AuthExtra) => {
-      const log = logs.currentUser();
+      const recorder = getCurrentRecorder();
+      const toolStart = Date.now();
       try {
         const tokenContext = extractTokenContext(extra);
         const companyId = await resolveCompanyId(tokenContext);
 
         if (!companyId) {
+          recorder?.recordToolCall({
+            tool: 'freee_current_user',
+            status: 'success',
+            duration_ms: Date.now() - toolStart,
+          });
           return createTextResponse(
             '会社IDが設定されていません。freee_set_current_company で設定してください。',
           );
@@ -51,7 +48,11 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
           makeApiRequest('GET', '/api/1/users/me', undefined, undefined, undefined, tokenContext),
         ]);
 
-        log.info({ company_id: companyId }, 'Tool call completed');
+        recorder?.recordToolCall({
+          tool: 'freee_current_user',
+          status: 'success',
+          duration_ms: Date.now() - toolStart,
+        });
         return createTextResponse(
           `現在のユーザー情報:\n` +
             `会社ID: ${companyId}\n` +
@@ -59,7 +60,12 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
             `ユーザー詳細:\n${JSON.stringify(userInfo, null, 2)}`,
         );
       } catch (error) {
-        log.error({ err: error }, 'Tool call failed');
+        recorder?.recordToolCall({
+          tool: 'freee_current_user',
+          status: 'error',
+          duration_ms: Date.now() - toolStart,
+        });
+        recorder?.recordError({ source: 'tool_handler', chain: serializeErrorChain(error) });
         return createTextResponse(`ユーザー情報の取得に失敗: ${formatErrorMessage(error)}`);
       }
     },
@@ -74,11 +80,17 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
         annotations: { destructiveHint: false },
       },
       async () => {
-        const log = logs.authenticate();
+        const recorder = getCurrentRecorder();
+        const toolStart = Date.now();
         try {
           const { clientId, clientSecret } = getConfig().freee;
 
           if (!clientId) {
+            recorder?.recordToolCall({
+              tool: 'freee_authenticate',
+              status: 'success',
+              duration_ms: Date.now() - toolStart,
+            });
             return createTextResponse(
               'クライアントIDが設定されていません。\n' +
                 '`freee-mcp configure` を実行してセットアップしてください。',
@@ -86,6 +98,11 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
           }
 
           if (!clientSecret) {
+            recorder?.recordToolCall({
+              tool: 'freee_authenticate',
+              status: 'success',
+              duration_ms: Date.now() - toolStart,
+            });
             return createTextResponse(
               'クライアントシークレットが設定されていません。\n' +
                 '`freee-mcp configure` を実行してセットアップしてください。',
@@ -101,13 +118,22 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
 
           registerAuthenticationRequest(state, codeVerifier);
 
-          log.info('Authentication URL generated');
+          recorder?.recordToolCall({
+            tool: 'freee_authenticate',
+            status: 'success',
+            duration_ms: Date.now() - toolStart,
+          });
 
           return createTextResponse(
             `認証URL: ${authUrl}\n\nブラウザで開いて認証してください。5分でタイムアウトします。`,
           );
         } catch (error) {
-          log.error({ err: error }, 'Tool call failed');
+          recorder?.recordToolCall({
+            tool: 'freee_authenticate',
+            status: 'error',
+            duration_ms: Date.now() - toolStart,
+          });
+          recorder?.recordError({ source: 'tool_handler', chain: serializeErrorChain(error) });
           return createTextResponse(`認証開始に失敗: ${formatErrorMessage(error)}`);
         }
       },
@@ -122,24 +148,39 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
       annotations: { readOnlyHint: true },
     },
     async (extra: AuthExtra) => {
-      const log = logs.authStatus();
+      const recorder = getCurrentRecorder();
+      const toolStart = Date.now();
       try {
         const tokenContext = extractTokenContext(extra);
         const tokens = await tokenContext.tokenStore.loadTokens(tokenContext.userId);
         if (!tokens) {
+          recorder?.recordToolCall({
+            tool: 'freee_auth_status',
+            status: 'success',
+            duration_ms: Date.now() - toolStart,
+          });
           return createTextResponse('未認証。freee_authenticate で認証してください。');
         }
 
         const isValid = Date.now() < tokens.expires_at;
         const expiryDate = new Date(tokens.expires_at).toLocaleString();
 
-        log.info('Tool call completed');
+        recorder?.recordToolCall({
+          tool: 'freee_auth_status',
+          status: 'success',
+          duration_ms: Date.now() - toolStart,
+        });
         return createTextResponse(
           `認証状態: ${isValid ? '有効' : '期限切れ'}\n有効期限: ${expiryDate}` +
             (isValid ? '' : '\n次回API使用時に自動更新されます。'),
         );
       } catch (error) {
-        log.error({ err: error }, 'Tool call failed');
+        recorder?.recordToolCall({
+          tool: 'freee_auth_status',
+          status: 'error',
+          duration_ms: Date.now() - toolStart,
+        });
+        recorder?.recordError({ source: 'tool_handler', chain: serializeErrorChain(error) });
         return createTextResponse(`認証状態の確認に失敗: ${formatErrorMessage(error)}`);
       }
     },
@@ -153,16 +194,26 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
       annotations: { idempotentHint: true, openWorldHint: false },
     },
     async (extra: AuthExtra) => {
-      const log = logs.clearAuth();
+      const recorder = getCurrentRecorder();
+      const toolStart = Date.now();
       try {
         const tokenContext = extractTokenContext(extra);
         await tokenContext.tokenStore.clearTokens(tokenContext.userId);
-        log.info('Tool call completed');
+        recorder?.recordToolCall({
+          tool: 'freee_clear_auth',
+          status: 'success',
+          duration_ms: Date.now() - toolStart,
+        });
         return createTextResponse(
           '認証情報をクリアしました。再認証するには freee_authenticate を使用。',
         );
       } catch (error) {
-        log.error({ err: error }, 'Tool call failed');
+        recorder?.recordToolCall({
+          tool: 'freee_clear_auth',
+          status: 'error',
+          duration_ms: Date.now() - toolStart,
+        });
+        recorder?.recordError({ source: 'tool_handler', chain: serializeErrorChain(error) });
         return createTextResponse(`認証情報のクリアに失敗: ${formatErrorMessage(error)}`);
       }
     },
@@ -185,7 +236,8 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
       args: { company_id: string; name?: string; description?: string },
       extra?: AuthExtra,
     ) => {
-      const log = logs.setCompany();
+      const recorder = getCurrentRecorder();
+      const toolStart = Date.now();
       try {
         const { company_id, name, description } = args;
         const tokenContext = extractTokenContext(extra);
@@ -194,10 +246,19 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
 
         const companyInfo = await tokenContext.tokenStore.getCompanyInfo(tokenContext.userId, company_id);
 
-        log.info('Tool call completed');
+        recorder?.recordToolCall({
+          tool: 'freee_set_current_company',
+          status: 'success',
+          duration_ms: Date.now() - toolStart,
+        });
         return createTextResponse(`事業所を設定: ${companyInfo?.name || company_id}`);
       } catch (error) {
-        log.error({ err: error }, 'Tool call failed');
+        recorder?.recordToolCall({
+          tool: 'freee_set_current_company',
+          status: 'error',
+          duration_ms: Date.now() - toolStart,
+        });
+        recorder?.recordError({ source: 'tool_handler', chain: serializeErrorChain(error) });
         return createTextResponse(`事業所の設定に失敗: ${formatErrorMessage(error)}`);
       }
     },
@@ -211,20 +272,30 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
       annotations: { readOnlyHint: true, openWorldHint: false },
     },
     async (extra: AuthExtra) => {
-      const log = logs.getCompany();
+      const recorder = getCurrentRecorder();
+      const toolStart = Date.now();
       try {
         const tokenContext = extractTokenContext(extra);
         const companyId = await resolveCompanyId(tokenContext);
         const companyInfo = await tokenContext.tokenStore.getCompanyInfo(tokenContext.userId, companyId);
 
-        log.info('Tool call completed');
+        recorder?.recordToolCall({
+          tool: 'freee_get_current_company',
+          status: 'success',
+          duration_ms: Date.now() - toolStart,
+        });
         if (!companyInfo) {
           return createTextResponse(`事業所ID: ${companyId} (詳細情報なし)`);
         }
 
         return createTextResponse(`事業所: ${companyInfo.name} (ID: ${companyInfo.id})`);
       } catch (error) {
-        log.error({ err: error }, 'Tool call failed');
+        recorder?.recordToolCall({
+          tool: 'freee_get_current_company',
+          status: 'error',
+          duration_ms: Date.now() - toolStart,
+        });
+        recorder?.recordError({ source: 'tool_handler', chain: serializeErrorChain(error) });
         return createTextResponse(`事業所情報の取得に失敗: ${formatErrorMessage(error)}`);
       }
     },
@@ -238,7 +309,8 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
       annotations: { readOnlyHint: true },
     },
     async (extra: AuthExtra) => {
-      const log = logs.listCompanies();
+      const recorder = getCurrentRecorder();
+      const toolStart = Date.now();
       try {
         const tokenContext = extractTokenContext(extra);
         const CompanyResponseSchema = z.object({
@@ -261,6 +333,16 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
         );
         const parseResult = CompanyResponseSchema.safeParse(rawResponse);
         if (!parseResult.success) {
+          recorder?.recordToolCall({
+            tool: 'freee_list_companies',
+            status: 'error',
+            duration_ms: Date.now() - toolStart,
+          });
+          recorder?.recordError({
+            source: 'tool_handler',
+            error_type: 'schema_mismatch',
+            chain: [{ name: 'ZodError', message: parseResult.error.message }],
+          });
           return {
             content: [
               {
@@ -274,6 +356,11 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
         const currentCompanyId = await resolveCompanyId(tokenContext);
 
         if (!apiCompanies?.companies?.length) {
+          recorder?.recordToolCall({
+            tool: 'freee_list_companies',
+            status: 'success',
+            duration_ms: Date.now() - toolStart,
+          });
           return createTextResponse('事業所情報を取得できませんでした。');
         }
 
@@ -284,10 +371,19 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
           })
           .join('\n');
 
-        log.info('Tool call completed');
+        recorder?.recordToolCall({
+          tool: 'freee_list_companies',
+          status: 'success',
+          duration_ms: Date.now() - toolStart,
+        });
         return createTextResponse(`事業所一覧:\n${companyList}`);
       } catch (error) {
-        log.error({ err: error }, 'Tool call failed');
+        recorder?.recordToolCall({
+          tool: 'freee_list_companies',
+          status: 'error',
+          duration_ms: Date.now() - toolStart,
+        });
+        recorder?.recordError({ source: 'tool_handler', chain: serializeErrorChain(error) });
         return createTextResponse(`事業所一覧の取得に失敗: ${formatErrorMessage(error)}`);
       }
     },
@@ -301,8 +397,14 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
       annotations: { readOnlyHint: true, openWorldHint: false },
     },
     async () => {
-      getLogger().info({ component: 'tool', tool: 'freee_server_info' }, 'Tool call completed');
+      const recorder = getCurrentRecorder();
+      const toolStart = Date.now();
       const transport = options?.remote ? 'remote' : 'stdio';
+      recorder?.recordToolCall({
+        tool: 'freee_server_info',
+        status: 'success',
+        duration_ms: Date.now() - toolStart,
+      });
       return createTextResponse(
         `freee-mcp server info:\n- version: ${PACKAGE_VERSION}\n- transport: ${transport}`,
       );

--- a/src/openapi/client-mode.test.ts
+++ b/src/openapi/client-mode.test.ts
@@ -1,0 +1,213 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Privacy regression tests for the generated freee_api_* tools.
+ *
+ * The single most important guarantee of the RequestRecorder design is that
+ * user-supplied query values and request bodies NEVER leave the process via
+ * the canonical log line. The type system already excludes those fields from
+ * `ToolCallInfo`, but a reviewer could still accidentally pass them; these
+ * runtime tests catch that regression.
+ */
+
+type CapturedHandler = (
+  args: Record<string, unknown>,
+  extra?: Record<string, unknown>,
+) => Promise<unknown>;
+
+const capturedHandlers = new Map<string, CapturedHandler>();
+
+vi.mock('../telemetry/tool-tracer.js', () => ({
+  registerTracedTool: (
+    _server: McpServer,
+    name: string,
+    _config: unknown,
+    handler: CapturedHandler,
+  ): void => {
+    capturedHandlers.set(name, handler);
+  },
+  setToolAttributes: vi.fn(),
+}));
+
+vi.mock('./schema-loader.js', () => ({
+  validatePathForService: vi.fn(() => ({ isValid: true, actualPath: undefined, baseUrl: undefined })),
+  listAllAvailablePaths: vi.fn(() => ''),
+}));
+
+vi.mock('../api/client.js', () => ({
+  makeApiRequest: vi.fn(() => Promise.resolve({ ok: true })),
+  isBinaryFileResponse: vi.fn(() => false),
+}));
+
+vi.mock('../storage/context.js', () => ({
+  extractTokenContext: vi.fn(() => ({ userId: 'test-user', tokenStore: {} })),
+}));
+
+const stubServer = {} as McpServer;
+
+beforeEach(() => {
+  capturedHandlers.clear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('generateClientModeTool - privacy', () => {
+  it('captures query keys but never values in the recorder payload', async () => {
+    const { generateClientModeTool } = await import('./client-mode.js');
+    const { RequestRecorder, withRequestRecorder } = await import('../server/request-context.js');
+
+    generateClientModeTool(stubServer);
+    const getHandler = capturedHandlers.get('freee_api_get');
+    expect(getHandler).toBeDefined();
+
+    const recorder = new RequestRecorder({
+      request_id: 'req-priv-1',
+      source_ip: '127.0.0.1',
+      method: 'POST',
+      path: '/mcp',
+    });
+
+    await withRequestRecorder(recorder, () =>
+      getHandler?.(
+        {
+          service: 'accounting',
+          path: '/api/1/deals',
+          query: {
+            start_issue_date: '2024-01-01',
+            partner_name: 'Acme Corp (SECRET)',
+            internal_memo: 'leak-this-sensitive-value',
+          },
+        },
+        undefined,
+      ),
+    );
+
+    const payload = recorder.buildPayload({ status: 200, duration_ms: 10 });
+    const payloadJson = JSON.stringify(payload);
+
+    // Key names are allowed
+    const toolCalls = (payload.mcp as { tool_calls: Array<{ query_keys?: string[] }> }).tool_calls;
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0].query_keys).toEqual(
+      expect.arrayContaining(['start_issue_date', 'partner_name', 'internal_memo']),
+    );
+
+    // Values must NOT appear anywhere in the payload JSON.
+    expect(payloadJson).not.toContain('2024-01-01');
+    expect(payloadJson).not.toContain('Acme Corp');
+    expect(payloadJson).not.toContain('SECRET');
+    expect(payloadJson).not.toContain('leak-this-sensitive-value');
+  });
+
+  it('does not capture request body values in the recorder payload', async () => {
+    const { generateClientModeTool } = await import('./client-mode.js');
+    const { RequestRecorder, withRequestRecorder } = await import('../server/request-context.js');
+
+    generateClientModeTool(stubServer);
+    const postHandler = capturedHandlers.get('freee_api_post');
+    expect(postHandler).toBeDefined();
+
+    const recorder = new RequestRecorder({
+      request_id: 'req-priv-2',
+      source_ip: '127.0.0.1',
+      method: 'POST',
+      path: '/mcp',
+    });
+
+    await withRequestRecorder(recorder, () =>
+      postHandler?.(
+        {
+          service: 'accounting',
+          path: '/api/1/deals',
+          body: {
+            amount: 99999999,
+            memo: 'confidential deal notes',
+            partner_email: 'ceo@example.com',
+          },
+        },
+        undefined,
+      ),
+    );
+
+    const payloadJson = JSON.stringify(recorder.buildPayload({ status: 200, duration_ms: 10 }));
+
+    // No body field in ToolCallInfo means body is not even representable; assert the
+    // actual values are absent so a future refactor that adds `args.body` fails loudly.
+    expect(payloadJson).not.toContain('99999999');
+    expect(payloadJson).not.toContain('confidential');
+    expect(payloadJson).not.toContain('ceo@example.com');
+  });
+
+  it('records api_path_pattern via sanitizePath, not raw path', async () => {
+    const { generateClientModeTool } = await import('./client-mode.js');
+    const { RequestRecorder, withRequestRecorder } = await import('../server/request-context.js');
+
+    generateClientModeTool(stubServer);
+    const getHandler = capturedHandlers.get('freee_api_get');
+
+    const recorder = new RequestRecorder({
+      request_id: 'req-path-1',
+      source_ip: '127.0.0.1',
+      method: 'POST',
+      path: '/mcp',
+    });
+
+    await withRequestRecorder(recorder, () =>
+      getHandler?.(
+        {
+          service: 'accounting',
+          path: '/api/1/deals/54321?limit=5',
+        },
+        undefined,
+      ),
+    );
+
+    const toolCalls = (
+      recorder.buildPayload({ status: 200, duration_ms: 1 }).mcp as {
+        tool_calls: Array<{ api_path_pattern?: string }>;
+      }
+    ).tool_calls;
+
+    // The specific IDs are replaced with :id and the query string is stripped.
+    expect(toolCalls[0].api_path_pattern).toBe('/api/:id/deals/:id');
+    expect(toolCalls[0].api_path_pattern).not.toContain('54321');
+    expect(toolCalls[0].api_path_pattern).not.toContain('limit=5');
+  });
+
+  it('records tool_call with error status when validation fails', async () => {
+    const schemaLoader = await import('./schema-loader.js');
+    vi.mocked(schemaLoader.validatePathForService).mockReturnValueOnce({
+      isValid: false,
+      message: 'path not found',
+    });
+
+    const { generateClientModeTool } = await import('./client-mode.js');
+    const { RequestRecorder, withRequestRecorder } = await import('../server/request-context.js');
+
+    generateClientModeTool(stubServer);
+    const getHandler = capturedHandlers.get('freee_api_get');
+
+    const recorder = new RequestRecorder({
+      request_id: 'req-val-1',
+      source_ip: '127.0.0.1',
+      method: 'POST',
+      path: '/mcp',
+    });
+
+    await withRequestRecorder(recorder, () =>
+      getHandler?.({ service: 'accounting', path: '/api/1/nonexistent' }, undefined),
+    );
+
+    const payload = recorder.buildPayload({ status: 200, duration_ms: 1 });
+    const toolCalls = (payload.mcp as { tool_calls: Array<{ status: string }> }).tool_calls;
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0].status).toBe('error');
+
+    const errors = payload.errors as Array<{ source: string; error_type?: string }>;
+    expect(errors[0].source).toBe('validation');
+    expect(errors[0].error_type).toBe('path_validation_failed');
+  });
+});

--- a/src/openapi/client-mode.ts
+++ b/src/openapi/client-mode.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { isBinaryFileResponse, makeApiRequest } from '../api/client.js';
-import { serializeErrorChain } from '../server/error-serializer.js';
+import { makeErrorChain, serializeErrorChain } from '../server/error-serializer.js';
 import { sanitizePath } from '../server/logger.js';
 import { getCurrentRecorder } from '../server/request-context.js';
 import type { AuthExtra } from '../storage/context.js';
@@ -57,9 +57,7 @@ function createMethodTool(method: string) {
     const recorder = getCurrentRecorder();
     const startTime = Date.now();
     const safePath = sanitizePath(args.path);
-    // PRIVACY: Only key names, never values. Callers of recordToolCall below
-    // must not pass `args.query` or `args.body` themselves — the type of
-    // ToolCallInfo refuses any value-bearing field.
+    // PRIVACY: key names only, never values.
     const queryKeys = args.query ? Object.keys(args.query) : undefined;
     const tokenContext = extractTokenContext(extra);
 
@@ -81,7 +79,7 @@ function createMethodTool(method: string) {
         recorder?.recordError({
           source: 'validation',
           error_type: 'path_validation_failed',
-          chain: [{ name: 'ValidationError', message: validation.message ?? 'unknown validation error' }],
+          chain: makeErrorChain('ValidationError', validation.message ?? 'unknown validation error'),
         });
         return createTextResponse(
           `パス検証エラー: ${validation.message}\n\n` +

--- a/src/openapi/client-mode.ts
+++ b/src/openapi/client-mode.ts
@@ -1,7 +1,9 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { isBinaryFileResponse, makeApiRequest } from '../api/client.js';
-import { createChildLogger, getLogger, sanitizePath } from '../server/logger.js';
+import { serializeErrorChain } from '../server/error-serializer.js';
+import { sanitizePath } from '../server/logger.js';
+import { getCurrentRecorder } from '../server/request-context.js';
 import type { AuthExtra } from '../storage/context.js';
 import { extractTokenContext } from '../storage/context.js';
 import { registerTracedTool, setToolAttributes } from '../telemetry/tool-tracer.js';
@@ -42,7 +44,6 @@ function coercibleRecord(description: string) {
  */
 function createMethodTool(method: string) {
   const toolName = `freee_api_${method.toLowerCase()}`;
-  const getLog = createChildLogger({ component: 'tool', tool: toolName });
 
   return async (
     args: {
@@ -53,9 +54,13 @@ function createMethodTool(method: string) {
     },
     extra?: AuthExtra,
   ) => {
-    const log = getLog();
+    const recorder = getCurrentRecorder();
     const startTime = Date.now();
     const safePath = sanitizePath(args.path);
+    // PRIVACY: Only key names, never values. Callers of recordToolCall below
+    // must not pass `args.query` or `args.body` themselves — the type of
+    // ToolCallInfo refuses any value-bearing field.
+    const queryKeys = args.query ? Object.keys(args.query) : undefined;
     const tokenContext = extractTokenContext(extra);
 
     try {
@@ -64,7 +69,20 @@ function createMethodTool(method: string) {
 
       const validation = validatePathForService(method, path, service);
       if (!validation.isValid) {
-        log.warn({ service, path: safePath, method, user_id: tokenContext.userId }, 'Tool path validation failed');
+        recorder?.recordToolCall({
+          tool: toolName,
+          service,
+          api_method: method,
+          api_path_pattern: safePath,
+          query_keys: queryKeys,
+          status: 'error',
+          duration_ms: Date.now() - startTime,
+        });
+        recorder?.recordError({
+          source: 'validation',
+          error_type: 'path_validation_failed',
+          chain: [{ name: 'ValidationError', message: validation.message ?? 'unknown validation error' }],
+        });
         return createTextResponse(
           `パス検証エラー: ${validation.message}\n\n` +
             `利用可能なパスを確認するには freee_api_list_paths ツールを使用してください。`,
@@ -74,11 +92,15 @@ function createMethodTool(method: string) {
       const actualPath = validation.actualPath ?? path;
       const result = await makeApiRequest(method, actualPath, query, body, validation.baseUrl, tokenContext);
 
-      const resultType = isBinaryFileResponse(result) ? 'binary' : result === null ? 'empty' : 'json';
-      log.info(
-        { service, path: safePath, method, duration_ms: Date.now() - startTime, user_id: tokenContext.userId, result_type: resultType },
-        'Tool call completed',
-      );
+      recorder?.recordToolCall({
+        tool: toolName,
+        service,
+        api_method: method,
+        api_path_pattern: safePath,
+        query_keys: queryKeys,
+        status: 'success',
+        duration_ms: Date.now() - startTime,
+      });
 
       if (isBinaryFileResponse(result)) {
         const baseMimeType = result.mimeType.split(';')[0].trim();
@@ -124,10 +146,16 @@ function createMethodTool(method: string) {
 
       return createTextResponse(JSON.stringify(result, null, 2));
     } catch (error) {
-      log.error(
-        { service: args.service, path: safePath, method, duration_ms: Date.now() - startTime, user_id: tokenContext.userId, err: error },
-        'Tool call failed',
-      );
+      recorder?.recordToolCall({
+        tool: toolName,
+        service: args.service,
+        api_method: method,
+        api_path_pattern: safePath,
+        query_keys: queryKeys,
+        status: 'error',
+        duration_ms: Date.now() - startTime,
+      });
+      recorder?.recordError({ source: 'tool_handler', chain: serializeErrorChain(error) });
       return createTextResponse(`APIリクエストエラー: ${formatErrorMessage(error)}`);
     }
   };
@@ -229,8 +257,14 @@ export function generateClientModeTool(server: McpServer): void {
       annotations: { readOnlyHint: true, openWorldHint: false },
     },
     async () => {
-      getLogger().info({ component: 'tool', tool: 'freee_api_list_paths' }, 'Tool call completed');
+      const recorder = getCurrentRecorder();
+      const toolStart = Date.now();
       const pathsList = listAllAvailablePaths();
+      recorder?.recordToolCall({
+        tool: 'freee_api_list_paths',
+        status: 'success',
+        duration_ms: Date.now() - toolStart,
+      });
       return createTextResponse(
         `# freee API 利用可能なエンドポイント一覧${pathsList}\n\n` +
           `使用例:\n` +

--- a/src/server/cimd-fetcher.ts
+++ b/src/server/cimd-fetcher.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import type { OAuthClientMetadata } from '@modelcontextprotocol/sdk/shared/auth.js';
 import { OAuthClientMetadataSchema } from '@modelcontextprotocol/sdk/shared/auth.js';
-import { USER_AGENT } from '../constants.js';
+import { getUserAgent } from './user-agent.js';
 
 const CIMD_FETCH_TIMEOUT_MS = 5000;
 const MAX_RESPONSE_BYTES = 1_048_576; // 1MB
@@ -79,7 +79,7 @@ export class HttpCIMDFetcher implements CIMDFetcher {
       method: 'GET',
       headers: {
         Accept: 'application/json',
-        'User-Agent': USER_AGENT,
+        'User-Agent': getUserAgent(),
       },
       redirect: 'error', // Do not follow redirects (prevents SSRF via redirect)
       signal: AbortSignal.timeout(CIMD_FETCH_TIMEOUT_MS),

--- a/src/server/error-serializer.test.ts
+++ b/src/server/error-serializer.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { scrubErrorMessage, serializeErrorChain } from './error-serializer.js';
+
+describe('scrubErrorMessage', () => {
+  it('masks 6+ digit numeric IDs', () => {
+    expect(scrubErrorMessage('company_id=12345678 failed')).toBe(
+      'company_id=[REDACTED_ID] failed',
+    );
+  });
+
+  it('leaves short integers (status codes, line numbers) alone', () => {
+    // 3-digit status codes and single/double-digit line numbers must stay readable
+    // so stack traces and error summaries remain useful.
+    expect(scrubErrorMessage('HTTP 500 at line 42')).toBe('HTTP 500 at line 42');
+  });
+
+  it('masks email addresses', () => {
+    expect(scrubErrorMessage('User user@example.com failed')).toBe(
+      'User [REDACTED_EMAIL] failed',
+    );
+  });
+
+  it('masks both emails and numeric IDs in one pass', () => {
+    expect(scrubErrorMessage('user@x.io id=99999999')).toBe(
+      '[REDACTED_EMAIL] id=[REDACTED_ID]',
+    );
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(scrubErrorMessage('')).toBe('');
+  });
+
+  it('returns plain messages unchanged', () => {
+    expect(scrubErrorMessage('timeout waiting for upstream')).toBe(
+      'timeout waiting for upstream',
+    );
+  });
+});
+
+describe('serializeErrorChain', () => {
+  it('serializes a plain Error', () => {
+    const chain = serializeErrorChain(new Error('boom'));
+    expect(chain).toHaveLength(1);
+    expect(chain[0].name).toBe('Error');
+    expect(chain[0].message).toBe('boom');
+    expect(typeof chain[0].stack).toBe('string');
+  });
+
+  it('walks a 2-level Error.cause chain', () => {
+    const root = new Error('root cause');
+    const wrapped = new Error('wrapper', { cause: root });
+
+    const chain = serializeErrorChain(wrapped);
+
+    expect(chain).toHaveLength(2);
+    expect(chain[0].message).toBe('wrapper');
+    expect(chain[1].message).toBe('root cause');
+  });
+
+  it('walks a 3-level Error.cause chain', () => {
+    const leaf = new Error('leaf');
+    const mid = new Error('mid', { cause: leaf });
+    const top = new Error('top', { cause: mid });
+
+    const chain = serializeErrorChain(top);
+
+    expect(chain).toHaveLength(3);
+    expect(chain.map((e) => e.message)).toEqual(['top', 'mid', 'leaf']);
+  });
+
+  it('respects maxDepth', () => {
+    // Construct a 5-deep chain but cap at 2.
+    const e1 = new Error('e1');
+    const e2 = new Error('e2', { cause: e1 });
+    const e3 = new Error('e3', { cause: e2 });
+    const e4 = new Error('e4', { cause: e3 });
+    const e5 = new Error('e5', { cause: e4 });
+
+    const chain = serializeErrorChain(e5, 2);
+    expect(chain).toHaveLength(2);
+    expect(chain[0].message).toBe('e5');
+    expect(chain[1].message).toBe('e4');
+  });
+
+  it('breaks on circular Error.cause references', () => {
+    const a = new Error('a') as Error & { cause?: unknown };
+    const b = new Error('b') as Error & { cause?: unknown };
+    a.cause = b;
+    b.cause = a;
+
+    const chain = serializeErrorChain(a);
+    // Must terminate instead of looping forever. Both errors visited exactly once.
+    expect(chain.length).toBeLessThanOrEqual(2);
+    expect(chain[0].message).toBe('a');
+  });
+
+  it('scrubs numeric IDs from error messages', () => {
+    const err = new Error('company_id 87654321 not found');
+    const chain = serializeErrorChain(err);
+    expect(chain[0].message).toBe('company_id [REDACTED_ID] not found');
+  });
+
+  it('scrubs numeric IDs from stack traces', () => {
+    const err = new Error('context: user=98765432');
+    const chain = serializeErrorChain(err);
+    // Stack traces contain the message string too, so the redaction propagates.
+    expect(chain[0].stack).toContain('[REDACTED_ID]');
+    expect(chain[0].stack).not.toContain('98765432');
+  });
+
+  it('normalizes non-Error throws', () => {
+    const chain = serializeErrorChain('plain string throw');
+    expect(chain).toHaveLength(1);
+    // serialize-error wraps strings into Error-shaped objects.
+    expect(typeof chain[0].name).toBe('string');
+  });
+
+  it('handles null and undefined gracefully', () => {
+    expect(serializeErrorChain(null)).toEqual([]);
+    expect(serializeErrorChain(undefined)).toEqual([]);
+  });
+
+  it('preserves error.code when present', () => {
+    const err = new Error('enoent') as Error & { code?: string };
+    err.code = 'ENOENT';
+    const chain = serializeErrorChain(err);
+    expect(chain[0].code).toBe('ENOENT');
+  });
+});

--- a/src/server/error-serializer.ts
+++ b/src/server/error-serializer.ts
@@ -37,6 +37,16 @@ export function scrubErrorMessage(input: string): string {
 }
 
 /**
+ * Build a single-entry error chain for synthetic errors (validation failures,
+ * routing 404s) that don't have an actual thrown Error object. The `message`
+ * is scrubbed so callers cannot accidentally bypass the privacy protection
+ * that `serializeErrorChain()` provides for real thrown errors.
+ */
+export function makeErrorChain(name: string, message: string): ErrorChainEntry[] {
+  return [{ name, message: scrubErrorMessage(message) }];
+}
+
+/**
  * Walk the `Error.cause` chain of a thrown value and return a flattened
  * array of entries, each containing the bare minimum needed for log-based
  * debugging (name, message, stack, code).

--- a/src/server/error-serializer.ts
+++ b/src/server/error-serializer.ts
@@ -1,0 +1,87 @@
+import { serializeError } from 'serialize-error';
+
+/**
+ * A single entry in a flattened `Error.cause` chain, safe to log.
+ *
+ * Every string field is scrubbed of sensitive identifiers (numeric IDs,
+ * email addresses) before reaching the log stream.
+ */
+export interface ErrorChainEntry {
+  name: string;
+  message: string;
+  stack?: string;
+  code?: string;
+}
+
+/** Safety cap on how deep the cause chain is traversed. */
+const DEFAULT_MAX_CHAIN_DEPTH = 10;
+
+/** Match standalone numeric identifiers (6+ digits): company_id, user_id, timestamps. */
+const NUMERIC_ID_PATTERN = /\b\d{6,}\b/g;
+
+/** Simple email regex — intentionally permissive, prefer over-masking. */
+const EMAIL_PATTERN = /[\w.+-]+@[\w-]+\.[\w.-]+/g;
+
+/**
+ * Mask sensitive identifiers from a free-form error message.
+ *
+ * Masks:
+ * - Numeric IDs with 6 or more digits (company_id, user_id, millisecond
+ *   timestamps). Line numbers and small integers like HTTP status codes
+ *   are intentionally left alone so stack traces stay readable.
+ * - Email addresses.
+ */
+export function scrubErrorMessage(input: string): string {
+  if (typeof input !== 'string' || input.length === 0) return input;
+  return input.replace(EMAIL_PATTERN, '[REDACTED_EMAIL]').replace(NUMERIC_ID_PATTERN, '[REDACTED_ID]');
+}
+
+/**
+ * Walk the `Error.cause` chain of a thrown value and return a flattened
+ * array of entries, each containing the bare minimum needed for log-based
+ * debugging (name, message, stack, code).
+ *
+ * Non-Error throws (e.g., `throw 'oops'`) are normalized via serialize-error
+ * into an Error-shaped object. Circular references and excessive depth are
+ * bounded by `maxDepth` and a WeakSet of visited objects.
+ */
+export function serializeErrorChain(
+  err: unknown,
+  maxDepth: number = DEFAULT_MAX_CHAIN_DEPTH,
+): ErrorChainEntry[] {
+  const chain: ErrorChainEntry[] = [];
+  const seen = new WeakSet<object>();
+  let current: unknown = err;
+  let depth = 0;
+
+  while (current !== undefined && current !== null && depth < maxDepth) {
+    if (typeof current === 'object') {
+      if (seen.has(current as object)) break;
+      seen.add(current as object);
+    }
+
+    // serialize-error safely handles non-Error values, toJSON methods,
+    // circular references, and Buffer-valued properties. maxDepth: 1 keeps
+    // top-level primitives (name, message, stack) but collapses any nested
+    // objects to `{}`, which is exactly what we want for a flat chain entry.
+    const serialized = serializeError(current, { maxDepth: 1 });
+
+    const rawMessage = typeof serialized.message === 'string' ? serialized.message : '';
+    const rawStack = typeof serialized.stack === 'string' ? serialized.stack : undefined;
+
+    chain.push({
+      name: typeof serialized.name === 'string' ? serialized.name : 'Error',
+      message: scrubErrorMessage(rawMessage),
+      stack: rawStack !== undefined ? scrubErrorMessage(rawStack) : undefined,
+      code: typeof serialized.code === 'string' ? serialized.code : undefined,
+    });
+
+    depth += 1;
+    current =
+      typeof current === 'object' && current !== null
+        ? (current as { cause?: unknown }).cause
+        : undefined;
+  }
+
+  return chain;
+}

--- a/src/server/freee-callback.ts
+++ b/src/server/freee-callback.ts
@@ -8,11 +8,11 @@ import {
   FETCH_TIMEOUT_USERINFO_MS,
   FREEE_API_URL,
   FREEE_CALLBACK_PATH,
-  USER_AGENT,
 } from '../constants.js';
 import type { TokenStore } from '../storage/token-store.js';
 import { getLogger } from './logger.js';
 import type { OAuthStateStore } from './oauth-store.js';
+import { getUserAgent } from './user-agent.js';
 
 export interface FreeeCallbackDeps {
   oauthStore: OAuthStateStore;
@@ -38,7 +38,7 @@ async function exchangeFreeeCode(
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
-      'User-Agent': USER_AGENT,
+      'User-Agent': getUserAgent(),
     },
     body: new URLSearchParams({
       grant_type: 'authorization_code',
@@ -73,7 +73,7 @@ async function fetchFreeeUserId(accessToken: string, apiUrl: string): Promise<st
   const response = await fetch(`${apiUrl}/api/1/users/me`, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
-      'User-Agent': USER_AGENT,
+      'User-Agent': getUserAgent(),
     },
     signal: AbortSignal.timeout(FETCH_TIMEOUT_USERINFO_MS),
   });
@@ -99,7 +99,7 @@ async function fetchFirstCompany(
     const response = await fetch(`${apiUrl}/api/1/companies`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
-        'User-Agent': USER_AGENT,
+        'User-Agent': getUserAgent(),
       },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_USERINFO_MS),
     });
@@ -122,7 +122,7 @@ async function fetchFirstCompany(
     const response = await fetch(`${apiUrl}/hr/api/v1/users/me`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
-        'User-Agent': USER_AGENT,
+        'User-Agent': getUserAgent(),
       },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_USERINFO_MS),
     });

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { Request, Response } from 'express';
 import { getConfig, initRemoteConfig, loadRemoteServerConfig } from '../config.js';
@@ -9,21 +8,15 @@ import { closeRedisClient, getRedisClient } from '../storage/redis-client.js';
 import { RedisTokenStore } from '../storage/redis-token-store.js';
 import { createTracingMiddleware } from '../telemetry/middleware.js';
 import { RedisClientStore } from './client-store.js';
+import { serializeErrorChain } from './error-serializer.js';
 import { RedisUnavailableError } from './errors.js';
 import { createFreeeCallbackHandler } from './freee-callback.js';
 import { initLogger } from './logger.js';
 import { FreeeOAuthProvider } from './oauth-provider.js';
 import { OAuthStateStore } from './oauth-store.js';
+import { getCurrentRecorder } from './request-context.js';
 
 const BODY_SIZE_LIMIT = 1_048_576; // 1 MB
-
-function getClientIp(req: Request): string {
-  const xff = req.headers['x-forwarded-for'];
-  if (typeof xff === 'string') {
-    return xff.split(',')[0].trim();
-  }
-  return req.ip || 'unknown';
-}
 
 // Extend Express Request with request ID
 declare module 'express' {
@@ -138,12 +131,8 @@ export async function startHttpServer(options?: {
     next();
   });
 
-  // Request ID + request logging middleware
-  app.use((req: Request, _res: Response, next: () => void) => {
-    req.requestId = randomUUID();
-    logger.debug({ requestId: req.requestId, method: req.method, path: req.path }, 'request');
-    next();
-  });
+  // Note: `req.requestId` and per-request canonical logging are handled by
+  // `createTracingMiddleware` above. No separate request-id middleware needed.
 
   // --- Rate limiting (opt-in) ---
   if (remoteConfig.rateLimitEnabled) {
@@ -199,26 +188,23 @@ export async function startHttpServer(options?: {
   async function handleMcpRequest(req: Request, res: Response): Promise<void> {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
 
-    // Access log with security-relevant fields
-    const sourceIp = getClientIp(req);
+    // Patch the request recorder with user_id / session_id now that bearer
+    // auth has run. These are not known at middleware creation time.
     const authExtra = (req as unknown as Record<string, unknown>).auth as
       | { extra?: Record<string, unknown> }
       | undefined;
     const userId =
       typeof authExtra?.extra?.userId === 'string' ? authExtra.extra.userId : undefined;
-    logger.info(
-      {
-        source_ip: sourceIp,
-        session_id: sessionId,
-        user_id: userId,
-        method: req.method,
-        path: req.path,
-      },
-      'mcp request',
-    );
+    getCurrentRecorder()?.updateContext({ user_id: userId, session_id: sessionId });
 
     // Unknown session ID: return 404 per MCP spec (stateless mode never issues session IDs)
     if (sessionId) {
+      getCurrentRecorder()?.recordError({
+        source: 'mcp_handler',
+        status_code: 404,
+        error_type: 'unknown_session',
+        chain: [{ name: 'SessionNotFound', message: 'Unknown session id supplied' }],
+      });
       res.status(404).json({ error: 'Session not found' });
       return;
     }
@@ -240,25 +226,14 @@ export async function startHttpServer(options?: {
     await transport.handleRequest(req, res);
   }
 
-  function extractRequestContext(req: Request): Record<string, string | undefined> {
-    const authExtra = (req as unknown as Record<string, unknown>).auth as
-      | { extra?: Record<string, unknown> }
-      | undefined;
-    const userId =
-      typeof authExtra?.extra?.userId === 'string' ? authExtra.extra.userId : undefined;
-    return {
-      source_ip: getClientIp(req),
-      session_id: req.headers['mcp-session-id'] as string | undefined,
-      user_id: userId,
-      method: req.method,
-      path: req.path,
-    };
-  }
-
   function mcpHandler(req: Request, res: Response): void {
     handleMcpRequest(req, res).catch((err: unknown) => {
-      const ctx = extractRequestContext(req);
-      logger.error({ err, requestId: req.requestId, ...ctx }, 'MCP request error');
+      getCurrentRecorder()?.recordError({
+        source: 'mcp_handler',
+        status_code: 500,
+        error_type: 'unhandled_exception',
+        chain: serializeErrorChain(err),
+      });
       if (!res.headersSent) {
         res.status(500).json({ error: 'Internal server error' });
       }
@@ -271,8 +246,7 @@ export async function startHttpServer(options?: {
   app.delete('/mcp', bearerAuth, mcpHandler);
 
   // Express error handler (must be after all routes)
-  app.use((err: unknown, req: Request, res: Response, next: (err?: unknown) => void) => {
-    const ctx = extractRequestContext(req);
+  app.use((err: unknown, _req: Request, res: Response, next: (err?: unknown) => void) => {
     if (err instanceof RedisUnavailableError) {
       if (!res.headersSent) {
         res.status(503).json({
@@ -280,7 +254,12 @@ export async function startHttpServer(options?: {
           message: 'Storage backend temporarily unavailable',
         });
       }
-      logger.error({ err, requestId: req.requestId, ...ctx }, 'Redis unavailable');
+      getCurrentRecorder()?.recordError({
+        source: 'redis_unavailable',
+        status_code: 503,
+        error_type: 'redis_unavailable',
+        chain: serializeErrorChain(err),
+      });
       return;
     }
     if (res.headersSent) {
@@ -288,7 +267,12 @@ export async function startHttpServer(options?: {
       return;
     }
     res.status(500).json({ error: 'Internal server error' });
-    logger.error({ err, requestId: req.requestId, ...ctx }, 'Unhandled middleware error');
+    getCurrentRecorder()?.recordError({
+      source: 'middleware',
+      status_code: 500,
+      error_type: 'unhandled_middleware_error',
+      chain: serializeErrorChain(err),
+    });
   });
 
   const server = app.listen(remoteConfig.port, () => {

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -15,6 +15,7 @@ import { initLogger } from './logger.js';
 import { FreeeOAuthProvider } from './oauth-provider.js';
 import { OAuthStateStore } from './oauth-store.js';
 import { getCurrentRecorder } from './request-context.js';
+import { initUserAgentTransportMode } from './user-agent.js';
 
 const BODY_SIZE_LIMIT = 1_048_576; // 1 MB
 
@@ -34,6 +35,7 @@ export async function startHttpServer(options?: {
   initRemoteConfig(remoteConfig);
 
   const logger = initLogger({ level: remoteConfig.logLevel, transportMode: 'remote' });
+  initUserAgentTransportMode('remote');
 
   const redis = getRedisClient(remoteConfig.redisUrl);
 

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -8,7 +8,7 @@ import { closeRedisClient, getRedisClient } from '../storage/redis-client.js';
 import { RedisTokenStore } from '../storage/redis-token-store.js';
 import { createTracingMiddleware } from '../telemetry/middleware.js';
 import { RedisClientStore } from './client-store.js';
-import { serializeErrorChain } from './error-serializer.js';
+import { makeErrorChain, serializeErrorChain } from './error-serializer.js';
 import { RedisUnavailableError } from './errors.js';
 import { createFreeeCallbackHandler } from './freee-callback.js';
 import { initLogger } from './logger.js';
@@ -133,9 +133,6 @@ export async function startHttpServer(options?: {
     next();
   });
 
-  // Note: `req.requestId` and per-request canonical logging are handled by
-  // `createTracingMiddleware` above. No separate request-id middleware needed.
-
   // --- Rate limiting (opt-in) ---
   if (remoteConfig.rateLimitEnabled) {
     await setupRateLimiting(app, redis, logger);
@@ -205,7 +202,7 @@ export async function startHttpServer(options?: {
         source: 'mcp_handler',
         status_code: 404,
         error_type: 'unknown_session',
-        chain: [{ name: 'SessionNotFound', message: 'Unknown session id supplied' }],
+        chain: makeErrorChain('SessionNotFound', 'Unknown session id supplied'),
       });
       res.status(404).json({ error: 'Session not found' });
       return;

--- a/src/server/http-utils.ts
+++ b/src/server/http-utils.ts
@@ -1,0 +1,15 @@
+import type { Request } from 'express';
+
+/**
+ * Extract the client's originating IP address from a request.
+ *
+ * Honors the first value in an `X-Forwarded-For` header (set by the envoy
+ * gateway / ALB in front of freee-mcp); falls back to `req.ip` otherwise.
+ */
+export function getClientIp(req: Request): string {
+  const xff = req.headers['x-forwarded-for'];
+  if (typeof xff === 'string') {
+    return xff.split(',')[0].trim();
+  }
+  return req.ip || 'unknown';
+}

--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -1,6 +1,7 @@
 import { trace } from '@opentelemetry/api';
 import pino from 'pino';
 import { APP_NAME, PACKAGE_VERSION } from '../constants.js';
+import { serializeErrorChain } from './error-serializer.js';
 
 export type Logger = pino.Logger;
 
@@ -40,6 +41,55 @@ function resolveOptions(levelOrOptions?: string | LoggerOptions): LoggerOptions 
   return levelOrOptions ?? {};
 }
 
+/**
+ * Custom pino err serializer built on `serializeErrorChain`.
+ *
+ * Produces a shape compatible with pino-std-serializers (`name`/`message`/`stack`)
+ * so existing log viewers keep working, while also exposing the full cause
+ * chain under `chain` when an error was wrapped via `new Error(msg, { cause })`.
+ *
+ * All string values are scrubbed of numeric IDs and email addresses before
+ * leaving the process.
+ */
+function errSerializer(value: unknown): Record<string, unknown> {
+  const chain = serializeErrorChain(value);
+  const top = chain[0] ?? { name: 'Error', message: '' };
+  return {
+    name: top.name,
+    message: top.message,
+    stack: top.stack,
+    code: top.code,
+    chain: chain.length > 1 ? chain : undefined,
+  };
+}
+
+/**
+ * Defense-in-depth redaction paths.
+ *
+ * The primary privacy defense is the RequestRecorder type system (user-input
+ * fields are not even representable). These redact paths catch the handful of
+ * remaining stray log calls (lifecycle, error handlers) that might otherwise
+ * include secret-bearing fields.
+ */
+const REDACT_PATHS: string[] = [
+  'req.headers.authorization',
+  'req.headers.cookie',
+  '*.password',
+  '*.access_token',
+  '*.refresh_token',
+  '*.token',
+  '*.body',
+  'req.body',
+  '*.args.body',
+  '*.args.query',
+];
+
+const REDACT_OPTIONS: pino.redactOptions = {
+  paths: REDACT_PATHS,
+  censor: '[REDACTED]',
+  remove: false,
+};
+
 export function initLogger(levelOrOptions?: string | LoggerOptions): pino.Logger {
   const options = resolveOptions(levelOrOptions);
   const level = options.level || process.env.LOG_LEVEL || 'info';
@@ -48,6 +98,8 @@ export function initLogger(levelOrOptions?: string | LoggerOptions): pino.Logger
   const baseOptions: pino.LoggerOptions = {
     level,
     mixin: otelMixin,
+    serializers: { err: errSerializer },
+    redact: REDACT_OPTIONS,
     base: {
       service: APP_NAME,
       version: PACKAGE_VERSION,
@@ -66,6 +118,8 @@ export function getLogger(): pino.Logger {
       {
         level: process.env.LOG_LEVEL || 'info',
         mixin: otelMixin,
+        serializers: { err: errSerializer },
+        redact: REDACT_OPTIONS,
         base: {
           service: APP_NAME,
           version: PACKAGE_VERSION,
@@ -76,21 +130,6 @@ export function getLogger(): pino.Logger {
     );
   }
   return _logger;
-}
-
-/**
- * Create a lazily-initialized child logger.
- * The child is created on first call and reused thereafter,
- * avoiding repeated .child() allocations on every invocation.
- */
-export function createChildLogger(bindings: Record<string, unknown>): () => pino.Logger {
-  let child: pino.Logger | null = null;
-  return () => {
-    if (!child) {
-      child = getLogger().child(bindings);
-    }
-    return child;
-  };
 }
 
 /**

--- a/src/server/request-context.test.ts
+++ b/src/server/request-context.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RequestRecorder,
+  getCurrentRecorder,
+  withRequestRecorder,
+} from './request-context.js';
+
+function makeRecorder(overrides: Partial<ConstructorParameters<typeof RequestRecorder>[0]> = {}) {
+  return new RequestRecorder({
+    request_id: 'req-test',
+    source_ip: '127.0.0.1',
+    method: 'POST',
+    path: '/mcp',
+    ...overrides,
+  });
+}
+
+describe('RequestRecorder', () => {
+  describe('recordToolCall / recordApiCall / recordError', () => {
+    it('buffers tool calls and exposes them via buildPayload', () => {
+      const recorder = makeRecorder();
+
+      recorder.recordToolCall({
+        tool: 'freee_api_get',
+        service: 'accounting',
+        api_method: 'GET',
+        api_path_pattern: '/api/:id/deals',
+        query_keys: ['limit', 'offset'],
+        status: 'success',
+        duration_ms: 123,
+      });
+
+      const payload = recorder.buildPayload({ status: 200, duration_ms: 200 });
+      expect(payload.mcp).toMatchObject({
+        tool_call_count: 1,
+        tool_calls: [
+          expect.objectContaining({
+            tool: 'freee_api_get',
+            query_keys: ['limit', 'offset'],
+          }),
+        ],
+      });
+    });
+
+    it('buffers api calls', () => {
+      const recorder = makeRecorder();
+
+      recorder.recordApiCall({
+        method: 'GET',
+        path_pattern: '/api/:id/deals',
+        status_code: 200,
+        duration_ms: 50,
+        company_id: '12345',
+        user_id: 'user-1',
+        error_type: null,
+      });
+
+      const payload = recorder.buildPayload({ status: 200, duration_ms: 100 });
+      expect(payload.api_call_count).toBe(1);
+      expect(payload.api_calls).toEqual([
+        expect.objectContaining({ method: 'GET', status_code: 200, error_type: null }),
+      ]);
+    });
+
+    it('records errors with a timestamp', () => {
+      const recorder = makeRecorder();
+
+      recorder.recordError({
+        source: 'api_client',
+        status_code: 500,
+        error_type: 'http_error',
+        chain: [{ name: 'Error', message: 'boom' }],
+      });
+
+      const payload = recorder.buildPayload({ status: 200, duration_ms: 100 });
+      const errors = payload.errors as Array<{ source: string; timestamp: number; chain: unknown }>;
+      expect(errors).toHaveLength(1);
+      expect(errors[0].source).toBe('api_client');
+      expect(typeof errors[0].timestamp).toBe('number');
+      expect(errors[0].chain).toEqual([{ name: 'Error', message: 'boom' }]);
+    });
+  });
+
+  describe('buildPayload', () => {
+    it('produces the canonical log shape', () => {
+      const recorder = makeRecorder({
+        request_id: 'req-canonical',
+        source_ip: '10.0.0.1',
+        method: 'POST',
+        path: '/mcp',
+      });
+      recorder.updateContext({ user_id: 'user-42', session_id: 'sess-xyz' });
+
+      const payload = recorder.buildPayload({ status: 200, duration_ms: 321 });
+
+      expect(payload).toEqual({
+        request_id: 'req-canonical',
+        source_ip: '10.0.0.1',
+        user_id: 'user-42',
+        session_id: 'sess-xyz',
+        http: {
+          method: 'POST',
+          path: '/mcp',
+          status: 200,
+          duration_ms: 321,
+        },
+        mcp: {
+          tool_calls: [],
+          tool_call_count: 0,
+        },
+        api_calls: [],
+        api_call_count: 0,
+        errors: [],
+      });
+    });
+
+    it('defaults user_id and session_id to null when unset', () => {
+      const recorder = makeRecorder();
+      const payload = recorder.buildPayload({ status: 200, duration_ms: 10 });
+      expect(payload.user_id).toBeNull();
+      expect(payload.session_id).toBeNull();
+    });
+  });
+
+  describe('flushOnce', () => {
+    it('returns true on the first call and false thereafter', () => {
+      const recorder = makeRecorder();
+      expect(recorder.flushOnce()).toBe(true);
+      expect(recorder.flushOnce()).toBe(false);
+      expect(recorder.flushOnce()).toBe(false);
+    });
+  });
+
+  describe('updateContext', () => {
+    it('patches only the allowed fields', () => {
+      const recorder = makeRecorder({
+        request_id: 'req-1',
+        source_ip: '127.0.0.1',
+        method: 'GET',
+        path: '/mcp',
+      });
+
+      recorder.updateContext({ user_id: 'u-1' });
+      const p1 = recorder.buildPayload({ status: 200, duration_ms: 1 });
+      expect(p1.user_id).toBe('u-1');
+      expect(p1.session_id).toBeNull();
+
+      recorder.updateContext({ session_id: 's-1' });
+      const p2 = recorder.buildPayload({ status: 200, duration_ms: 1 });
+      expect(p2.user_id).toBe('u-1');
+      expect(p2.session_id).toBe('s-1');
+
+      // Request metadata from the constructor is preserved.
+      expect(p2.request_id).toBe('req-1');
+      expect((p2.http as { method: string }).method).toBe('GET');
+    });
+  });
+});
+
+describe('AsyncLocalStorage integration', () => {
+  it('returns undefined outside withRequestRecorder', () => {
+    expect(getCurrentRecorder()).toBeUndefined();
+  });
+
+  it('makes the recorder accessible inside withRequestRecorder', () => {
+    const recorder = makeRecorder();
+    withRequestRecorder(recorder, () => {
+      expect(getCurrentRecorder()).toBe(recorder);
+    });
+    expect(getCurrentRecorder()).toBeUndefined();
+  });
+
+  it('isolates recorders across concurrent async contexts', async () => {
+    const rA = makeRecorder({ request_id: 'A', source_ip: '1.1.1.1', method: 'GET', path: '/a' });
+    const rB = makeRecorder({ request_id: 'B', source_ip: '2.2.2.2', method: 'GET', path: '/b' });
+
+    const runA = (): Promise<string> =>
+      withRequestRecorder(rA, async () => {
+        // Yield so that runB interleaves before we read back our context.
+        await new Promise((r) => setTimeout(r, 5));
+        getCurrentRecorder()?.recordToolCall({
+          tool: 'tool_a',
+          status: 'success',
+          duration_ms: 1,
+        });
+        return (
+          (getCurrentRecorder()?.buildPayload({ status: 200, duration_ms: 1 })
+            .request_id as string) ?? 'none'
+        );
+      });
+
+    const runB = (): Promise<string> =>
+      withRequestRecorder(rB, async () => {
+        await new Promise((r) => setTimeout(r, 1));
+        getCurrentRecorder()?.recordToolCall({
+          tool: 'tool_b',
+          status: 'success',
+          duration_ms: 1,
+        });
+        return (
+          (getCurrentRecorder()?.buildPayload({ status: 200, duration_ms: 1 })
+            .request_id as string) ?? 'none'
+        );
+      });
+
+    const [idA, idB] = await Promise.all([runA(), runB()]);
+    expect(idA).toBe('A');
+    expect(idB).toBe('B');
+
+    // Each recorder only ever saw its own tool call — no cross-contamination.
+    const payloadA = rA.buildPayload({ status: 200, duration_ms: 1 });
+    const payloadB = rB.buildPayload({ status: 200, duration_ms: 1 });
+    expect((payloadA.mcp as { tool_calls: Array<{ tool: string }> }).tool_calls).toEqual([
+      expect.objectContaining({ tool: 'tool_a' }),
+    ]);
+    expect((payloadB.mcp as { tool_calls: Array<{ tool: string }> }).tool_calls).toEqual([
+      expect.objectContaining({ tool: 'tool_b' }),
+    ]);
+  });
+});

--- a/src/server/request-context.test.ts
+++ b/src/server/request-context.test.ts
@@ -96,6 +96,7 @@ describe('RequestRecorder', () => {
       expect(payload).toEqual({
         request_id: 'req-canonical',
         source_ip: '10.0.0.1',
+        user_agent: null,
         user_id: 'user-42',
         session_id: 'sess-xyz',
         http: {
@@ -119,6 +120,20 @@ describe('RequestRecorder', () => {
       const payload = recorder.buildPayload({ status: 200, duration_ms: 10 });
       expect(payload.user_id).toBeNull();
       expect(payload.session_id).toBeNull();
+    });
+
+    it('includes user_agent in the payload when set on the context', () => {
+      const recorder = makeRecorder({
+        user_agent: 'ClaudeDesktop/1.2.3 (macOS 15.1)',
+      });
+      const payload = recorder.buildPayload({ status: 200, duration_ms: 1 });
+      expect(payload.user_agent).toBe('ClaudeDesktop/1.2.3 (macOS 15.1)');
+    });
+
+    it('serializes user_agent as null when unset', () => {
+      const recorder = makeRecorder();
+      const payload = recorder.buildPayload({ status: 200, duration_ms: 1 });
+      expect(payload.user_agent).toBeNull();
     });
   });
 

--- a/src/server/request-context.ts
+++ b/src/server/request-context.ts
@@ -64,6 +64,8 @@ export interface ErrorInfo {
 export interface RequestRecorderContext {
   request_id: string;
   source_ip: string;
+  /** Inbound HTTP User-Agent header from the MCP client, normalized and truncated. */
+  user_agent?: string;
   user_id?: string;
   session_id?: string;
   method: string;
@@ -141,6 +143,7 @@ export class RequestRecorder {
     return {
       request_id: this.context.request_id,
       source_ip: this.context.source_ip,
+      user_agent: this.context.user_agent ?? null,
       user_id: this.context.user_id ?? null,
       session_id: this.context.session_id ?? null,
       http: {

--- a/src/server/request-context.ts
+++ b/src/server/request-context.ts
@@ -73,6 +73,32 @@ export interface RequestRecorderContext {
 }
 
 /**
+ * Canonical log line: the complete payload emitted as one JSON log entry
+ * per HTTP request at `res.on('finish')`. Consumers (pino, Datadog) see
+ * exactly this shape.
+ */
+export interface CanonicalLogPayload {
+  request_id: string;
+  source_ip: string;
+  user_agent: string | null;
+  user_id: string | null;
+  session_id: string | null;
+  http: {
+    method: string;
+    path: string;
+    status: number;
+    duration_ms: number;
+  };
+  mcp: {
+    tool_calls: ToolCallInfo[];
+    tool_call_count: number;
+  };
+  api_calls: ApiCallInfo[];
+  api_call_count: number;
+  errors: ErrorInfo[];
+}
+
+/**
  * RequestRecorder is the single place that buffers all per-request observability
  * data for the duration of one HTTP request. At request end the recorder is
  * flushed as a single "canonical log line" JSON log entry.
@@ -86,7 +112,6 @@ export interface RequestRecorderContext {
  *   `res.on('close')` race.
  */
 export class RequestRecorder {
-  private readonly startTimeMs: number;
   private readonly toolCalls: ToolCallInfo[] = [];
   private readonly apiCalls: ApiCallInfo[] = [];
   private readonly errors: ErrorInfo[] = [];
@@ -94,7 +119,6 @@ export class RequestRecorder {
   private flushed = false;
 
   constructor(initial: RequestRecorderContext) {
-    this.startTimeMs = Date.now();
     this.context = initial;
   }
 
@@ -119,11 +143,6 @@ export class RequestRecorder {
     this.errors.push({ ...info, timestamp: Date.now() });
   }
 
-  /** @returns milliseconds elapsed since recorder construction */
-  elapsedMs(): number {
-    return Date.now() - this.startTimeMs;
-  }
-
   /**
    * Return true on the first call, false afterwards. Used by the HTTP
    * middleware to ensure the canonical log line is emitted exactly once
@@ -139,7 +158,7 @@ export class RequestRecorder {
    * Build the canonical log line payload. Does not emit anything — the
    * caller is responsible for passing this object to pino.
    */
-  buildPayload(http: { status: number; duration_ms: number }): Record<string, unknown> {
+  buildPayload(http: { status: number; duration_ms: number }): CanonicalLogPayload {
     return {
       request_id: this.context.request_id,
       source_ip: this.context.source_ip,

--- a/src/server/request-context.ts
+++ b/src/server/request-context.ts
@@ -1,0 +1,184 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { ErrorChainEntry } from './error-serializer.js';
+
+/**
+ * Canonical log line: tool call sub-event.
+ *
+ * Only operational metadata is accepted here. User input (body, query values)
+ * MUST NOT be passed — the type intentionally omits any field that could hold
+ * user-supplied content, so TypeScript rejects privacy regressions at compile time.
+ */
+export interface ToolCallInfo {
+  tool: string;
+  service?: string;
+  api_method?: string;
+  api_path_pattern?: string;
+  /** Names only, never values. Enforced by the type and by recorder callers. */
+  query_keys?: string[];
+  status: 'success' | 'error';
+  duration_ms: number;
+}
+
+export type ApiCallErrorType =
+  | 'timeout'
+  | 'network_error'
+  | 'auth_error'
+  | 'forbidden'
+  | 'http_error'
+  | 'json_parse_error';
+
+/**
+ * Canonical log line: outgoing HTTP API call sub-event.
+ */
+export interface ApiCallInfo {
+  method: string;
+  path_pattern: string;
+  status_code: number | null;
+  duration_ms: number;
+  company_id?: string | null;
+  user_id?: string | null;
+  error_type: ApiCallErrorType | null;
+  /** Upload size (bytes). Not user data; safe to log for debugging file uploads. */
+  file_size_bytes?: number;
+}
+
+export type ErrorSource =
+  | 'api_client'
+  | 'sign_client'
+  | 'file_upload'
+  | 'tool_handler'
+  | 'mcp_handler'
+  | 'middleware'
+  | 'validation'
+  | 'redis_unavailable'
+  | 'auth';
+
+export interface ErrorInfo {
+  source: ErrorSource;
+  status_code?: number;
+  error_type?: string;
+  timestamp: number;
+  chain: ErrorChainEntry[];
+}
+
+export interface RequestRecorderContext {
+  request_id: string;
+  source_ip: string;
+  user_id?: string;
+  session_id?: string;
+  method: string;
+  path: string;
+}
+
+/**
+ * RequestRecorder is the single place that buffers all per-request observability
+ * data for the duration of one HTTP request. At request end the recorder is
+ * flushed as a single "canonical log line" JSON log entry.
+ *
+ * Design notes:
+ * - Stored in an AsyncLocalStorage so every async downstream context (tool
+ *   handlers, fetch calls, etc.) can reach it via `getCurrentRecorder()`.
+ * - All mutation methods accept typed inputs that intentionally exclude user
+ *   input. Callers must construct the input with metadata only.
+ * - `flushOnce()` provides idempotency for the `res.on('finish')` /
+ *   `res.on('close')` race.
+ */
+export class RequestRecorder {
+  private readonly startTimeMs: number;
+  private readonly toolCalls: ToolCallInfo[] = [];
+  private readonly apiCalls: ApiCallInfo[] = [];
+  private readonly errors: ErrorInfo[] = [];
+  private context: RequestRecorderContext;
+  private flushed = false;
+
+  constructor(initial: RequestRecorderContext) {
+    this.startTimeMs = Date.now();
+    this.context = initial;
+  }
+
+  /**
+   * Patch context fields that become known after the recorder was created
+   * (typically `user_id` and `session_id` are only available after the bearer
+   * auth middleware runs).
+   */
+  updateContext(patch: Partial<Pick<RequestRecorderContext, 'user_id' | 'session_id'>>): void {
+    this.context = { ...this.context, ...patch };
+  }
+
+  recordToolCall(info: ToolCallInfo): void {
+    this.toolCalls.push(info);
+  }
+
+  recordApiCall(info: ApiCallInfo): void {
+    this.apiCalls.push(info);
+  }
+
+  recordError(info: Omit<ErrorInfo, 'timestamp'>): void {
+    this.errors.push({ ...info, timestamp: Date.now() });
+  }
+
+  /** @returns milliseconds elapsed since recorder construction */
+  elapsedMs(): number {
+    return Date.now() - this.startTimeMs;
+  }
+
+  /**
+   * Return true on the first call, false afterwards. Used by the HTTP
+   * middleware to ensure the canonical log line is emitted exactly once
+   * even when both `res.on('finish')` and `res.on('close')` fire.
+   */
+  flushOnce(): boolean {
+    if (this.flushed) return false;
+    this.flushed = true;
+    return true;
+  }
+
+  /**
+   * Build the canonical log line payload. Does not emit anything — the
+   * caller is responsible for passing this object to pino.
+   */
+  buildPayload(http: { status: number; duration_ms: number }): Record<string, unknown> {
+    return {
+      request_id: this.context.request_id,
+      source_ip: this.context.source_ip,
+      user_id: this.context.user_id ?? null,
+      session_id: this.context.session_id ?? null,
+      http: {
+        method: this.context.method,
+        path: this.context.path,
+        status: http.status,
+        duration_ms: http.duration_ms,
+      },
+      mcp: {
+        tool_calls: this.toolCalls,
+        tool_call_count: this.toolCalls.length,
+      },
+      api_calls: this.apiCalls,
+      api_call_count: this.apiCalls.length,
+      errors: this.errors,
+    };
+  }
+}
+
+const requestContextStorage = new AsyncLocalStorage<RequestRecorder>();
+
+/**
+ * Returns the RequestRecorder associated with the current async context,
+ * or `undefined` if called outside any request (CLI mode, server startup,
+ * background tasks).
+ *
+ * Callers must treat this as optional and use the `?.` operator:
+ *   getCurrentRecorder()?.recordApiCall({...})
+ */
+export function getCurrentRecorder(): RequestRecorder | undefined {
+  return requestContextStorage.getStore();
+}
+
+/**
+ * Run `fn` with `recorder` installed as the current request recorder.
+ * All downstream async operations will see the recorder via
+ * `getCurrentRecorder()` for the lifetime of the returned promise.
+ */
+export function withRequestRecorder<T>(recorder: RequestRecorder, fn: () => T): T {
+  return requestContextStorage.run(recorder, fn);
+}

--- a/src/server/user-agent.test.ts
+++ b/src/server/user-agent.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getUserAgent, initUserAgentTransportMode } from './user-agent.js';
+
+/**
+ * The module uses a single mutable global, so each test case restores the
+ * default `stdio` mode afterwards to avoid leaking state between tests.
+ */
+afterEach(() => {
+  initUserAgentTransportMode('stdio');
+});
+
+describe('getUserAgent', () => {
+  it('defaults to stdio mode before any explicit initUserAgentTransportMode call', () => {
+    // The module default is 'stdio' — no setup required.
+    const ua = getUserAgent();
+    expect(ua).toContain('MCP Server');
+    expect(ua).toContain('; stdio;');
+    expect(ua).not.toContain('; remote;');
+  });
+
+  it('switches to the remote segment after initUserAgentTransportMode("remote")', () => {
+    initUserAgentTransportMode('remote');
+    const ua = getUserAgent();
+    expect(ua).toContain('; remote;');
+    expect(ua).not.toContain('; stdio;');
+  });
+
+  it('switches back to stdio after initUserAgentTransportMode("stdio")', () => {
+    initUserAgentTransportMode('remote');
+    initUserAgentTransportMode('stdio');
+    expect(getUserAgent()).toContain('; stdio;');
+  });
+
+  it('emits an RFC 7231 compliant product + comment format', () => {
+    // Product: freee-mcp/<version>
+    // Comment: (MCP Server; <mode>; +<url>)
+    const pattern =
+      /^freee-mcp\/[\w.\-+]+ \(MCP Server; (?:stdio|remote); \+https:\/\/github\.com\/freee\/freee-mcp\)$/;
+    expect(getUserAgent()).toMatch(pattern);
+
+    initUserAgentTransportMode('remote');
+    expect(getUserAgent()).toMatch(pattern);
+  });
+
+  it('always starts with the freee-mcp product token', () => {
+    // Other tests across the codebase rely on this prefix via /^freee-mcp\// —
+    // if we ever break it the matrix of api-client / sign / auth tests would
+    // all fail, so assert it directly here as a single cheap regression guard.
+    expect(getUserAgent()).toMatch(/^freee-mcp\//);
+    initUserAgentTransportMode('remote');
+    expect(getUserAgent()).toMatch(/^freee-mcp\//);
+  });
+});

--- a/src/server/user-agent.ts
+++ b/src/server/user-agent.ts
@@ -1,0 +1,56 @@
+import { PACKAGE_VERSION } from '../constants.js';
+
+/**
+ * Transport mode that freee-mcp is currently running as.
+ *
+ * - `stdio`: CLI mode, invoked over stdin/stdout by an MCP client process
+ * - `remote`: HTTP mode, serving `/mcp` behind Express (mcp.freee.co.jp)
+ */
+export type TransportMode = 'stdio' | 'remote';
+
+/**
+ * Internal mutable state. Node.js is single-threaded, so reading and writing
+ * a module-level variable is safe. We default to `stdio` because CLI usage
+ * does not need to explicitly initialize anything — only the remote entry
+ * point has to switch it via `initUserAgentTransportMode('remote')`.
+ */
+let currentMode: TransportMode = 'stdio';
+
+/**
+ * Initialize the transport label embedded in the outbound `User-Agent` header.
+ *
+ * Intended to be called exactly once at process startup from the relevant
+ * entry point, mirroring the `initLogger` pattern used elsewhere in the
+ * codebase:
+ *
+ * - `src/server/http-server.ts` for the remote entry (must set `'remote'`)
+ * - `src/index.ts` and `src/sign/index.ts` for stdio entries (can be omitted
+ *   because `'stdio'` is the module default, but calling it explicitly makes
+ *   the transport mode self-documenting at the entry point)
+ *
+ * The setting is global. Calling it again at runtime would silently
+ * repartition every subsequent outbound request into a different bucket,
+ * making Datadog analytics inconsistent — the `init`-prefixed name is a
+ * signal to the reader that late reassignment is outside the intended
+ * contract.
+ */
+export function initUserAgentTransportMode(mode: TransportMode): void {
+  currentMode = mode;
+}
+
+/**
+ * Build the User-Agent header string used for every outbound freee API call.
+ *
+ * Format follows RFC 7231 §5.5.3 (product with comment):
+ *
+ *   freee-mcp/<version> (MCP Server; <mode>; +<url>)
+ *
+ * The `<mode>` segment lets freee-side log analysis distinguish calls made by
+ * the local CLI from calls made by the deployed remote server, so patterns
+ * that only show up in one transport can be isolated.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3
+ */
+export function getUserAgent(): string {
+  return `freee-mcp/${PACKAGE_VERSION} (MCP Server; ${currentMode}; +https://github.com/freee/freee-mcp)`;
+}

--- a/src/sign/client.ts
+++ b/src/sign/client.ts
@@ -1,9 +1,10 @@
 // freee-mcp パッケージとして配布されるため、User-Agent は freee 本体と共通
-import { FETCH_TIMEOUT_API_MS, USER_AGENT } from '../constants.js';
+import { FETCH_TIMEOUT_API_MS } from '../constants.js';
 import { serializeErrorChain } from '../server/error-serializer.js';
 import { sanitizePath } from '../server/logger.js';
 import type { ApiCallErrorType } from '../server/request-context.js';
 import { getCurrentRecorder } from '../server/request-context.js';
+import { getUserAgent } from '../server/user-agent.js';
 import { formatResponseErrorInfo } from '../utils/error.js';
 import { SIGN_API_URL } from './config.js';
 import { getValidSignAccessToken } from './tokens.js';
@@ -45,7 +46,7 @@ export async function makeSignApiRequest(
       headers: {
         Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
-        'User-Agent': USER_AGENT,
+        'User-Agent': getUserAgent(),
       },
       body: body ? JSON.stringify(body) : undefined,
       signal: AbortSignal.timeout(FETCH_TIMEOUT_API_MS),

--- a/src/sign/client.ts
+++ b/src/sign/client.ts
@@ -1,5 +1,9 @@
 // freee-mcp パッケージとして配布されるため、User-Agent は freee 本体と共通
 import { FETCH_TIMEOUT_API_MS, USER_AGENT } from '../constants.js';
+import { serializeErrorChain } from '../server/error-serializer.js';
+import { sanitizePath } from '../server/logger.js';
+import type { ApiCallErrorType } from '../server/request-context.js';
+import { getCurrentRecorder } from '../server/request-context.js';
 import { formatResponseErrorInfo } from '../utils/error.js';
 import { SIGN_API_URL } from './config.js';
 import { getValidSignAccessToken } from './tokens.js';
@@ -10,6 +14,10 @@ export async function makeSignApiRequest(
   params?: Record<string, unknown>,
   body?: Record<string, unknown>,
 ): Promise<unknown> {
+  const recorder = getCurrentRecorder();
+  const startTime = Date.now();
+  const safePath = sanitizePath(apiPath);
+
   const accessToken = await getValidSignAccessToken();
 
   if (!accessToken) {
@@ -30,35 +38,88 @@ export async function makeSignApiRequest(
     }
   }
 
-  const response = await fetch(url.toString(), {
-    method,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-      'User-Agent': USER_AGENT,
-    },
-    body: body ? JSON.stringify(body) : undefined,
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_API_MS),
-  });
+  let response: Response;
+  try {
+    response = await fetch(url.toString(), {
+      method,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        'User-Agent': USER_AGENT,
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_API_MS),
+    });
+  } catch (fetchError) {
+    const errorType: ApiCallErrorType =
+      fetchError instanceof Error && fetchError.name === 'TimeoutError' ? 'timeout' : 'network_error';
+    recorder?.recordApiCall({
+      method,
+      path_pattern: safePath,
+      status_code: null,
+      duration_ms: Date.now() - startTime,
+      error_type: errorType,
+    });
+    recorder?.recordError({
+      source: 'sign_client',
+      error_type: errorType,
+      chain: serializeErrorChain(fetchError),
+    });
+    throw fetchError;
+  }
+
+  const recordFailure = (statusCode: number, errorType: ApiCallErrorType, err: Error): never => {
+    recorder?.recordApiCall({
+      method,
+      path_pattern: safePath,
+      status_code: statusCode,
+      duration_ms: Date.now() - startTime,
+      error_type: errorType,
+    });
+    recorder?.recordError({
+      source: 'sign_client',
+      status_code: statusCode,
+      error_type: errorType,
+      chain: serializeErrorChain(err),
+    });
+    throw err;
+  };
 
   if (response.status === 401) {
     const errorInfo = await formatResponseErrorInfo(response);
-    throw new Error(
-      '認証エラーが発生しました。sign_authenticate ツールを使用して再認証を行ってください。\n' +
-        `エラー詳細: ${response.status} ${errorInfo}`,
+    recordFailure(
+      401,
+      'auth_error',
+      new Error(
+        '認証エラーが発生しました。sign_authenticate ツールを使用して再認証を行ってください。\n' +
+          `エラー詳細: ${response.status} ${errorInfo}`,
+      ),
     );
   }
 
   if (response.status === 429) {
     const retryAfter = response.headers.get('RateLimit-Reset') || response.headers.get('Retry-After');
     const retryMsg = retryAfter ? `${retryAfter}秒後に再試行してください。` : '数分待ってから再試行してください。';
-    throw new Error(`レートリミットに達しました (429)。${retryMsg}`);
+    recordFailure(429, 'http_error', new Error(`レートリミットに達しました (429)。${retryMsg}`));
   }
 
   if (!response.ok) {
     const errorInfo = await formatResponseErrorInfo(response);
-    throw new Error(`Sign API request failed: ${response.status} ${errorInfo}`);
+    recordFailure(
+      response.status,
+      'http_error',
+      new Error(`Sign API request failed: ${response.status} ${errorInfo}`),
+    );
   }
+
+  // Success path: record the api call once with a null error_type
+  recorder?.recordApiCall({
+    method,
+    path_pattern: safePath,
+    status_code: response.status,
+    duration_ms: Date.now() - startTime,
+    error_type: null,
+  });
 
   if (response.status === 204) {
     return null;

--- a/src/sign/client.ts
+++ b/src/sign/client.ts
@@ -112,29 +112,58 @@ export async function makeSignApiRequest(
     );
   }
 
-  // Success path: record the api call once with a null error_type
-  recorder?.recordApiCall({
-    method,
-    path_pattern: safePath,
-    status_code: response.status,
-    duration_ms: Date.now() - startTime,
-    error_type: null,
-  });
-
   if (response.status === 204) {
+    recorder?.recordApiCall({
+      method,
+      path_pattern: safePath,
+      status_code: response.status,
+      duration_ms: Date.now() - startTime,
+      error_type: null,
+    });
     return null;
   }
 
   const text = await response.text();
   if (!text) {
+    recorder?.recordApiCall({
+      method,
+      path_pattern: safePath,
+      status_code: response.status,
+      duration_ms: Date.now() - startTime,
+      error_type: null,
+    });
     return null;
   }
 
   try {
-    return JSON.parse(text);
+    const parsed = JSON.parse(text);
+    // Record success only after JSON.parse succeeds to avoid a misleading
+    // "successful" api_call entry alongside a json_parse_error in the log.
+    recorder?.recordApiCall({
+      method,
+      path_pattern: safePath,
+      status_code: response.status,
+      duration_ms: Date.now() - startTime,
+      error_type: null,
+    });
+    return parsed;
   } catch {
-    throw new Error(
+    const parseError = new Error(
       `Failed to parse Sign API response as JSON. Status: ${response.status}, Body preview: ${text.slice(0, 200)}`,
     );
+    recorder?.recordApiCall({
+      method,
+      path_pattern: safePath,
+      status_code: response.status,
+      duration_ms: Date.now() - startTime,
+      error_type: 'json_parse_error',
+    });
+    recorder?.recordError({
+      source: 'sign_client',
+      status_code: response.status,
+      error_type: 'json_parse_error',
+      chain: serializeErrorChain(parseError),
+    });
+    throw parseError;
   }
 }

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -1,7 +1,10 @@
+import { initUserAgentTransportMode } from '../server/user-agent.js';
 import { signConfigure } from './cli/index.js';
 import { createAndStartSignServer } from './handlers.js';
 
 const main = async (): Promise<void> => {
+  initUserAgentTransportMode('stdio');
+
   const args = process.argv.slice(2);
   const subcommand = args.find((arg) => !arg.startsWith('--'));
 

--- a/src/sign/oauth.test.ts
+++ b/src/sign/oauth.test.ts
@@ -108,7 +108,7 @@ describe('sign/oauth', () => {
   });
 
   describe('リクエストヘッダー', () => {
-    it('User-Agent ヘッダーが USER_AGENT 定数と一致する', async () => {
+    it('User-Agent ヘッダーが freee-mcp プレフィックスで始まる', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: () =>

--- a/src/sign/oauth.ts
+++ b/src/sign/oauth.ts
@@ -5,7 +5,7 @@ import {
   getSignCredentials,
 } from './config.js';
 import { OAuthTokenResponseSchema, saveSignTokens, type TokenData } from './tokens.js';
-import { USER_AGENT } from '../constants.js';
+import { getUserAgent } from '../server/user-agent.js';
 import { formatResponseErrorInfo } from '../utils/error.js';
 import { createTokenData } from '../auth/token-utils.js';
 
@@ -31,7 +31,7 @@ export async function exchangeSignCodeForTokens(
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
-      'User-Agent': USER_AGENT,
+      'User-Agent': getUserAgent(),
     },
     body: new URLSearchParams({
       grant_type: 'authorization_code',

--- a/src/telemetry/middleware.test.ts
+++ b/src/telemetry/middleware.test.ts
@@ -15,17 +15,21 @@ function makeRequest(
   port: number,
   path: string,
   method = 'GET',
+  headers?: Record<string, string>,
 ): Promise<{ statusCode: number; body: string }> {
   return new Promise((resolve, reject) => {
-    const req = http.request({ hostname: '127.0.0.1', port, path, method }, (res) => {
-      let body = '';
-      res.on('data', (chunk) => {
-        body += chunk;
-      });
-      res.on('end', () => {
-        resolve({ statusCode: res.statusCode ?? 0, body });
-      });
-    });
+    const req = http.request(
+      { hostname: '127.0.0.1', port, path, method, headers },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          resolve({ statusCode: res.statusCode ?? 0, body });
+        });
+      },
+    );
     req.on('error', reject);
     req.end();
   });
@@ -387,5 +391,180 @@ describe('createTracingMiddleware - canonical log line', () => {
     expect(payload.api_calls).toEqual([
       expect.objectContaining({ method: 'GET', status_code: 200 }),
     ]);
+  });
+
+  it('captures the inbound User-Agent header verbatim in the canonical log', async () => {
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp', 'GET', {
+      'user-agent': 'ClaudeDesktop/1.2.3 (macOS 15.1)',
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(logInfo).toHaveBeenCalledTimes(1);
+    const [payload] = logInfo.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.user_agent).toBe('ClaudeDesktop/1.2.3 (macOS 15.1)');
+  });
+
+  it('sets user_agent to null when the client sends no User-Agent header', async () => {
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    // Node's http module always sends a default User-Agent unless we actively
+    // overwrite it with an empty string. Empty is the closest thing to "no
+    // UA" a real client can produce.
+    await makeRequest(port, '/mcp', 'GET', { 'user-agent': '' });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logInfo.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.user_agent).toBeNull();
+  });
+
+  it('truncates oversized user-agents to 256 characters', async () => {
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    const huge = `BadClient/${'x'.repeat(400)}`;
+    await makeRequest(port, '/mcp', 'GET', { 'user-agent': huge });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logInfo.mock.calls[0] as [Record<string, unknown>];
+    const ua = payload.user_agent as string;
+    expect(ua.length).toBe(256);
+    expect(ua.startsWith('BadClient/')).toBe(true);
+  });
+
+  it('scrubs numeric IDs and emails from the user-agent', async () => {
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp', 'GET', {
+      'user-agent': 'CustomBot/1.0 (uid=98765432 contact=ops@example.com)',
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logInfo.mock.calls[0] as [Record<string, unknown>];
+    const ua = payload.user_agent as string;
+    expect(ua).toContain('[REDACTED_ID]');
+    expect(ua).toContain('[REDACTED_EMAIL]');
+    expect(ua).not.toContain('98765432');
+    expect(ua).not.toContain('ops@example.com');
+  });
+
+  it('caps length AFTER scrubbing so ID/email expansion cannot exceed 256', async () => {
+    // Regression test for the truncate-then-scrub ordering bug.
+    //
+    // Input is exactly 256 chars and contains a 6-digit number preceded by
+    // whitespace (so `\b\d{6,}\b` can match — without the space, `A123456`
+    // has no word boundary between A and 1). After scrubbing, the 6-digit
+    // ID `123456` is replaced with `[REDACTED_ID]` (13 chars), inflating
+    // the result from 256 → 263. If the code truncated before scrubbing
+    // the output would violate the 256-char cap; scrub-then-truncate must
+    // clamp it back to 256.
+    const base = 'A'.repeat(249);
+    const input = `${base} 123456`; // 249 + 7 = 256 chars
+    expect(input.length).toBe(256);
+
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp', 'GET', { 'user-agent': input });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logInfo.mock.calls[0] as [Record<string, unknown>];
+    const ua = payload.user_agent as string;
+    // The critical invariant: no matter what the scrub does, the final
+    // string MUST fit within the cap.
+    expect(ua.length).toBeLessThanOrEqual(256);
+    // Original ID must not leak.
+    expect(ua).not.toContain('123456');
+    // The scrubbed prefix should be present (possibly cut at the cap
+    // boundary, so check the leading token rather than the full marker).
+    expect(ua).toContain('[REDAC');
+    expect(ua.startsWith(base)).toBe(true);
+  });
+});
+
+/**
+ * Direct unit tests for `normalizeUserAgent`.
+ *
+ * These complement the HTTP-level tests above by exercising edge cases that
+ * Node's `http.request` can't produce in practice (undefined header,
+ * `string[]` header, input at the exact 256-char boundary). Running these as
+ * pure function calls avoids the ~40 ms/per-case socket overhead of booting
+ * an Express server.
+ */
+describe('normalizeUserAgent', () => {
+  it('returns undefined for an undefined input (absent header case)', async () => {
+    const { normalizeUserAgent } = await import('./middleware.js');
+    expect(normalizeUserAgent(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', async () => {
+    const { normalizeUserAgent } = await import('./middleware.js');
+    expect(normalizeUserAgent('')).toBeUndefined();
+  });
+
+  it('returns undefined for a `string[]` value (defensive guard)', async () => {
+    // Node's IncomingHttpHeaders types `user-agent` as `string | undefined`,
+    // so a `string[]` should never reach this helper in practice. The `unknown`
+    // parameter + `typeof` guard exists purely as defense-in-depth against a
+    // future typing regression or middleware that forwards raw multi-value
+    // headers. This test locks that guard in place.
+    const { normalizeUserAgent } = await import('./middleware.js');
+    expect(normalizeUserAgent(['ClaudeDesktop/1.0', 'AnotherClient/2.0'])).toBeUndefined();
+  });
+
+  it('passes through a normal user-agent unchanged', async () => {
+    const { normalizeUserAgent } = await import('./middleware.js');
+    expect(normalizeUserAgent('ClaudeDesktop/1.2.3 (macOS 15.1)')).toBe(
+      'ClaudeDesktop/1.2.3 (macOS 15.1)',
+    );
+  });
+
+  it('preserves realistic Chrome/Safari UAs whose build numbers are <6 digits', async () => {
+    // Regression test for CodeRabbit finding M1 — confirm that real-world UAs
+    // with 4-digit build numbers (the most common pattern) are NOT mangled by
+    // the 6+-digit NUMERIC_ID_PATTERN scrub. If this test fails, the scrub has
+    // become too aggressive and Datadog client-segment analytics will silently
+    // degrade.
+    const { normalizeUserAgent } = await import('./middleware.js');
+    const chrome =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 ' +
+      '(KHTML, like Gecko) Chrome/120.0.6099.129 Safari/605.1.15';
+    expect(normalizeUserAgent(chrome)).toBe(chrome);
+  });
+
+  it('redacts a 6+ digit build number if a client UA happens to embed one', async () => {
+    // This documents the known tradeoff — UAs with 6+-digit build numbers
+    // WILL be scrubbed. The defense-in-depth policy takes priority over
+    // analytics precision for this edge case. See CLAUDE.md for an example
+    // so future on-call engineers aren't confused by a `[REDACTED_ID]` in UA.
+    const { normalizeUserAgent } = await import('./middleware.js');
+    expect(normalizeUserAgent('Chrome/120.0.987654.1')).toBe('Chrome/120.0.[REDACTED_ID].1');
+  });
+
+  it('boundary: input of exactly 256 chars with no scrub passes through', async () => {
+    const { normalizeUserAgent } = await import('./middleware.js');
+    const exactly256 = 'A'.repeat(256);
+    expect(normalizeUserAgent(exactly256)).toBe(exactly256);
+  });
+
+  it('boundary: input of 257 chars gets truncated to 256', async () => {
+    const { normalizeUserAgent } = await import('./middleware.js');
+    const result = normalizeUserAgent('A'.repeat(257));
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(256);
   });
 });

--- a/src/telemetry/middleware.test.ts
+++ b/src/telemetry/middleware.test.ts
@@ -214,3 +214,178 @@ describe('createTracingMiddleware', () => {
     });
   });
 });
+
+describe('createTracingMiddleware - canonical log line', () => {
+  let server: http.Server;
+  let port: number;
+
+  afterEach(async () => {
+    if (server?.listening) {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  async function setupAppWithLoggerSpy(
+    routeHandler: (req: express.Request, res: express.Response) => void,
+    routePath = '/mcp',
+  ): Promise<{ logInfo: ReturnType<typeof vi.fn>; app: express.Express }> {
+    const logInfo = vi.fn();
+    vi.doMock('../server/logger.js', () => ({
+      getLogger: (): { info: ReturnType<typeof vi.fn> } => ({ info: logInfo }),
+    }));
+
+    const { createTracingMiddleware } = await import('./middleware.js');
+    const { getCurrentRecorder } = await import('../server/request-context.js');
+
+    const app = express();
+    app.use(createTracingMiddleware());
+    app.all(routePath, (req, res) => {
+      // Expose recorder access to the route so it can record tool/api calls.
+      (req as unknown as { recorder: unknown }).recorder = getCurrentRecorder();
+      routeHandler(req, res);
+    });
+    return { logInfo, app };
+  }
+
+  function listen(app: express.Express): Promise<{ srv: http.Server; port: number }> {
+    return new Promise((resolve) => {
+      const srv = app.listen(0, () => {
+        const addr = srv.address();
+        resolve({ srv, port: typeof addr === 'object' && addr ? addr.port : 0 });
+      });
+    });
+  }
+
+  it('emits exactly one canonical log line per request with the full payload shape', async () => {
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    const result = await makeRequest(port, '/mcp');
+    expect(result.statusCode).toBe(200);
+
+    // Give res.on('finish') a tick to flush synchronously before assertions.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(logInfo).toHaveBeenCalledTimes(1);
+    const [payload, message] = logInfo.mock.calls[0];
+    expect(message).toBe('mcp request completed');
+
+    expect(payload).toMatchObject({
+      request_id: expect.any(String),
+      source_ip: expect.any(String),
+      user_id: null,
+      session_id: null,
+      http: {
+        method: 'GET',
+        path: '/mcp',
+        status: 200,
+        duration_ms: expect.any(Number),
+      },
+      mcp: { tool_calls: [], tool_call_count: 0 },
+      api_calls: [],
+      api_call_count: 0,
+      errors: [],
+    });
+  });
+
+  it('reflects 500 status in http.status', async () => {
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(500).json({ error: 'boom' });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(logInfo).toHaveBeenCalledTimes(1);
+    const [payload] = logInfo.mock.calls[0];
+    expect((payload as { http: { status: number } }).http.status).toBe(500);
+  });
+
+  it('reflects 400 status in http.status (addresses the missing-400-logs bug)', async () => {
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(400).json({ error: 'invalid request' });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(logInfo).toHaveBeenCalledTimes(1);
+    const [payload] = logInfo.mock.calls[0];
+    expect((payload as { http: { status: number } }).http.status).toBe(400);
+  });
+
+  it('flushes only once even if both finish and close events fire', async () => {
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp');
+    await new Promise((r) => setTimeout(r, 20));
+
+    // flushOnce() in the middleware guarantees at most one emit.
+    expect(logInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips /health entirely — no canonical log emitted', async () => {
+    const { logInfo, app } = await setupAppWithLoggerSpy(
+      (_req, res) => {
+        res.status(200).json({ status: 'ok' });
+      },
+      '/health',
+    );
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/health');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(logInfo).not.toHaveBeenCalled();
+  });
+
+  it('includes recorded tool_calls and api_calls from downstream handlers', async () => {
+    type Recorder = import('../server/request-context.js').RequestRecorder;
+    const { logInfo, app } = await setupAppWithLoggerSpy(async (req, res) => {
+      // Simulate a tool handler recording activity on the in-context recorder.
+      const recorder = (req as unknown as { recorder?: Recorder }).recorder;
+      recorder?.recordToolCall({
+        tool: 'freee_api_get',
+        service: 'accounting',
+        api_method: 'GET',
+        api_path_pattern: '/api/:id/deals',
+        query_keys: ['limit'],
+        status: 'success',
+        duration_ms: 5,
+      });
+      recorder?.recordApiCall({
+        method: 'GET',
+        path_pattern: '/api/:id/deals',
+        status_code: 200,
+        duration_ms: 3,
+        company_id: '12345',
+        user_id: 'user-1',
+        error_type: null,
+      });
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(logInfo).toHaveBeenCalledTimes(1);
+    const [payload] = logInfo.mock.calls[0] as [Record<string, unknown>];
+    expect((payload.mcp as { tool_call_count: number }).tool_call_count).toBe(1);
+    expect(payload.api_call_count).toBe(1);
+    expect(payload.api_calls).toEqual([
+      expect.objectContaining({ method: 'GET', status_code: 200 }),
+    ]);
+  });
+});

--- a/src/telemetry/middleware.ts
+++ b/src/telemetry/middleware.ts
@@ -1,51 +1,111 @@
+import { randomUUID } from 'node:crypto';
+import { SpanKind, SpanStatusCode, context, trace, type Span } from '@opentelemetry/api';
 import type { NextFunction, Request, Response } from 'express';
-import { SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
+import { getClientIp } from '../server/http-utils.js';
+import { getLogger } from '../server/logger.js';
+import { RequestRecorder, withRequestRecorder } from '../server/request-context.js';
 import { isOtelEnabled } from './init.js';
 import { getHttpRequestDuration, getHttpRequestErrorCount } from './metrics.js';
 
 /**
- * Express middleware that creates a server span for each incoming request.
- * Returns a no-op pass-through when OTel is disabled.
+ * Express middleware responsible for per-request observability.
+ *
+ * For every non-health HTTP request this middleware:
+ *
+ * 1. Assigns a `request_id` (generating one if upstream didn't) and creates a
+ *    `RequestRecorder` installed in AsyncLocalStorage. Downstream code can
+ *    reach it via `getCurrentRecorder()`.
+ *
+ * 2. When OTel is enabled, opens a server span that is propagated through the
+ *    same async context so that tool handlers / fetch calls become children
+ *    of this span.
+ *
+ * 3. At request end (`res.on('finish')` or `res.on('close')`, whichever fires
+ *    first), emits a single "canonical log line" — one pino `info` entry
+ *    containing all metadata collected during the request (http status,
+ *    duration, tool calls, api calls, errors) — and closes the OTel span.
+ *
+ * The canonical log is emitted regardless of OTel state; observability
+ * remains functional even if OTel export is misconfigured.
  */
-export function createTracingMiddleware(): (req: Request, res: Response, next: NextFunction) => void {
+export function createTracingMiddleware(): (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => void {
   return (req: Request, res: Response, next: NextFunction): void => {
-    if (!isOtelEnabled()) {
-      next();
-      return;
-    }
-
-    // Skip health check endpoint to avoid noisy traces
+    // Skip health checks entirely — no recorder, no span, no canonical log.
     if (req.path === '/health') {
       next();
       return;
     }
 
-    const tracer = trace.getTracer('freee-mcp');
-    tracer.startActiveSpan(
-      `HTTP ${req.method} ${req.path}`,
-      {
+    // Assign a request_id at the earliest possible point. If another
+    // middleware already set one we respect it.
+    if (!req.requestId) {
+      req.requestId = randomUUID();
+    }
+
+    const recorder = new RequestRecorder({
+      request_id: req.requestId,
+      source_ip: getClientIp(req),
+      method: req.method,
+      path: req.path,
+    });
+
+    const startTime = performance.now();
+    let otelSpan: Span | undefined;
+
+    if (isOtelEnabled()) {
+      const tracer = trace.getTracer('freee-mcp');
+      otelSpan = tracer.startSpan(`HTTP ${req.method} ${req.path}`, {
         kind: SpanKind.SERVER,
         attributes: {
           'http.request.method': req.method,
           'url.path': req.path,
         },
-      },
-      (span) => {
-        const startTime = performance.now();
-        res.on('finish', () => {
-          const durationS = (performance.now() - startTime) / 1000;
-          const attrs = { method: req.method, path: req.path, status: String(res.statusCode) };
+      });
+    }
 
-          span.setAttribute('http.response.status_code', res.statusCode);
-          getHttpRequestDuration().record(durationS, attrs);
-          if (res.statusCode >= 500) {
-            span.setStatus({ code: SpanStatusCode.ERROR, message: `HTTP ${res.statusCode}` });
-            getHttpRequestErrorCount().add(1, attrs);
-          }
-          span.end();
-        });
+    const flush = (): void => {
+      if (!recorder.flushOnce()) return;
+
+      const durationMs = Math.round(performance.now() - startTime);
+      const status = res.statusCode;
+
+      const payload = recorder.buildPayload({ status, duration_ms: durationMs });
+      getLogger().info(payload, 'mcp request completed');
+
+      if (otelSpan) {
+        const attrs = { method: req.method, path: req.path, status: String(status) };
+        otelSpan.setAttribute('http.response.status_code', status);
+        getHttpRequestDuration().record(durationMs / 1000, attrs);
+        if (status >= 500) {
+          otelSpan.setStatus({ code: SpanStatusCode.ERROR, message: `HTTP ${status}` });
+          getHttpRequestErrorCount().add(1, attrs);
+        }
+        otelSpan.end();
+      }
+    };
+
+    // Attach flush to both events. flushOnce() inside ensures it runs at most
+    // once regardless of which fires first (normal completion vs. client
+    // disconnect during SSE streaming).
+    res.on('finish', flush);
+    res.on('close', flush);
+
+    const runDownstream = (): void => {
+      withRequestRecorder(recorder, () => {
         next();
-      },
-    );
+      });
+    };
+
+    if (otelSpan) {
+      // Propagate the active span through the same async context as the
+      // recorder so pino's otelMixin picks up trace_id/span_id correctly.
+      context.with(trace.setSpan(context.active(), otelSpan), runDownstream);
+    } else {
+      runDownstream();
+    }
   };
 }

--- a/src/telemetry/middleware.ts
+++ b/src/telemetry/middleware.ts
@@ -1,11 +1,56 @@
 import { randomUUID } from 'node:crypto';
 import { SpanKind, SpanStatusCode, context, trace, type Span } from '@opentelemetry/api';
 import type { NextFunction, Request, Response } from 'express';
+import { scrubErrorMessage } from '../server/error-serializer.js';
 import { getClientIp } from '../server/http-utils.js';
 import { getLogger } from '../server/logger.js';
 import { RequestRecorder, withRequestRecorder } from '../server/request-context.js';
 import { isOtelEnabled } from './init.js';
 import { getHttpRequestDuration, getHttpRequestErrorCount } from './metrics.js';
+
+/**
+ * Hard cap on the inbound User-Agent string length before it is logged.
+ *
+ * A well-behaved MCP client sends a UA well under 100 chars, but a malicious
+ * or buggy client could send arbitrary-length headers and blow up the log
+ * stream size. 256 is generous enough for every real user-agent we expect
+ * to see (browser/OS/version combinations rarely exceed 200).
+ */
+const MAX_USER_AGENT_LENGTH = 256;
+
+/**
+ * Normalize and scrub the inbound `User-Agent` header before storing it in
+ * the canonical log line.
+ *
+ * Steps:
+ * 1. Reject non-string values (`req.headers['user-agent']` is typed as
+ *    `string | string[] | undefined`; only scalars are accepted).
+ * 2. Treat empty strings as "missing".
+ * 3. Run the value through `scrubErrorMessage` so any 6+ digit ID or email
+ *    that a custom client might have stuffed into its UA gets masked. This
+ *    is defense-in-depth — real user-agents rarely contain such data.
+ * 4. Truncate to `MAX_USER_AGENT_LENGTH` AFTER scrubbing.
+ *
+ * The scrub-then-truncate order is critical for correctness: scrub
+ * replacements (`[REDACTED_ID]` 13 chars, `[REDACTED_EMAIL]` 16 chars) are
+ * longer than the 6-char minimum they replace, so scrubbing CAN grow the
+ * string. Truncating first would let a 256-char input with a 6-digit ID
+ * expand to 263 chars after scrub, silently violating the documented cap.
+ *
+ * DoS note: running scrub on the raw (pre-truncation) value is safe because
+ * (a) `scrubErrorMessage` uses two character-class regexes with no nested
+ * quantifiers — both run in O(n) with a small constant — and (b) Node's
+ * HTTP parser already bounds the total headers block to ~16KB by default
+ * (`--max-http-header-size`), so a single header can never be pathologically
+ * long in practice.
+ */
+export function normalizeUserAgent(raw: unknown): string | undefined {
+  if (typeof raw !== 'string' || raw.length === 0) return undefined;
+  const scrubbed = scrubErrorMessage(raw);
+  return scrubbed.length > MAX_USER_AGENT_LENGTH
+    ? scrubbed.slice(0, MAX_USER_AGENT_LENGTH)
+    : scrubbed;
+}
 
 /**
  * Express middleware responsible for per-request observability.
@@ -49,6 +94,7 @@ export function createTracingMiddleware(): (
     const recorder = new RequestRecorder({
       request_id: req.requestId,
       source_ip: getClientIp(req),
+      user_agent: normalizeUserAgent(req.headers['user-agent']),
       method: req.method,
       path: req.path,
     });


### PR DESCRIPTION
## 概要

- Replaces ~20 scattered per-event log calls (`API request completed`, `Tool call completed`, etc.) with a single structured JSON log entry emitted once per HTTP request via `res.on('finish')`
- Introduces `RequestRecorder` backed by `AsyncLocalStorage` so every async downstream context (tool handlers, fetch calls, error handlers) can append data to the same request-scoped collector without prop-drilling
- Adds `serializeErrorChain` to flatten `Error.cause` chains into `errors[].chain[]` with stack traces and ID/email scrubbing
- Privacy enforced at the type level: `ToolCallInfo` has no field that can hold user-supplied values (query values, body); `pino.redact` and `scrubErrorMessage` provide defense-in-depth
- 400-class errors (previously swallowed inside the MCP SDK transport) are now automatically captured via `res.statusCode` in the `finish` listener

### Canonical log line schema

```json
{
  "msg": "mcp request completed",
  "request_id": "b8f3a...",
  "trace_id": "d74e42ff...",
  "source_ip": "160.79.x.x",
  "user_id": "3187986",
  "http": { "method": "POST", "path": "/mcp", "status": 200, "duration_ms": 1842 },
  "mcp": {
    "tool_calls": [{ "tool": "freee_api_get", "service": "accounting", "api_method": "GET",
                     "api_path_pattern": "/api/:id/deals", "query_keys": ["limit"], "status": "success", "duration_ms": 1820 }],
    "tool_call_count": 1
  },
  "api_calls": [{ "method": "GET", "path_pattern": "/api/:id/deals", "status_code": 200, "duration_ms": 1805, "error_type": null }],
  "api_call_count": 1,
  "errors": []
}
```

### Two status_code layers

`http.status` is the final status the MCP server returned to the client (200 even when a tool error is wrapped as MCP content). `api_calls[].status_code` is what the upstream freee API returned. Both are needed for correct Datadog queries.

### Useful Datadog queries after staging/production deployment

- `@http.status:500` — true MCP server errors
- `@api_calls.error_type:timeout` — upstream API timeouts (correlate with envoy alarm)
- `@http.status:200 @errors:*` — requests that look successful but had internal API failures
- `@request_id:<uuid>` — all data for a single request in one line

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 issues
- [x] `bun run test:run` — 537/537 passing (+40 new tests across 47 suites)
- [x] `bun run build` — success

### Local verification — happy path

- Start the remote server: `bun run src/entry-remote.ts`
- Send a tool call to `/mcp` (e.g., `freee_api_get` with `service=accounting, path=/api/1/users/me`) via curl or MCP inspector
- Verify stderr emits exactly one `"msg":"mcp request completed"` JSON line per request
- Expand the JSON and confirm `http`, `mcp.tool_calls`, `api_calls`, and `errors` fields are all present
- Confirm `request_id` and `trace_id` appear in the same line (OTel span linkage)

### Local verification — error paths

- Call a nonexistent path (`/api/1/nonexistent`) and check `errors[0].chain` contains a stack trace
- Force a 400 response (malformed JSON-RPC) and verify `http.status: 400` is captured — this was previously invisible in logs
- Simulate a freee API 500: confirm `http.status: 200` + `api_calls[0].status_code: 500` + `errors[0].source: api_client`

### Privacy regression check (critical)

- POST a request with `body: { secret: "secret-value-xyz" }` and query `{ partner_name: "SECRET_COMPANY" }`
- `grep secret-value-xyz` on the emitted canonical log — must return nothing
- `grep SECRET_COMPANY` on the emitted canonical log — must return nothing
- Check `mcp.tool_calls[0].query_keys` contains `["partner_name"]` (key name only, never the value)

### Staging verification (after deployment)

- Datadog log search: `service:freee-mcp msg:"mcp request completed"`
- Expand a single log entry and verify `mcp.tool_calls[0].tool`, `api_calls[0].status_code`, `http.duration_ms` are all populated
- Click the Trace tab and confirm `trace_id` links to the OTel APM span
- Inspect two concurrent requests from the same time window and verify they have different `request_id` values (ALS isolation check)
- Trigger 400/500 intentionally and confirm they appear in canonical logs (regression check for the previously missing 400 logs)

### Production monitoring (after merge)

- Register Datadog facets: `@http.status`, `@mcp.tool_calls.tool`, `@api_calls.error_type`
- Monitor for 1 hour: total log volume should decrease (individual event logs removed); canonical log count should match request count
- Correlate `@api_calls.error_type:timeout` with existing envoy `upstream_rq_timeout` alerts to diagnose the original timeout incident root cause

## 変更種別

- [ ] 新機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント
- [ ] その他