### PR TITLE
feat(remote): align canonical log level with HTTP status for Datadog status mapping

### DIFF
--- a/.changeset/canonical-log-level-stack.md
+++ b/.changeset/canonical-log-level-stack.md
@@ -1,0 +1,11 @@
+---
+"freee-mcp": minor
+---
+
+Remote モードの canonical log line を Datadog の status マッピングと整合するよう改善。
+
+- HTTP status に応じて pino の log level を `info` / `warn` / `error` に分岐 (5xx → error, 4xx → warn, それ以外 → info)。401/403/404/422 もすべて warn に集約。
+- `formatters.level` で level を文字列ラベル (`"info"` / `"warn"` / `"error"`) として出力するよう変更。Datadog の Status Remapper が追加 pipeline 設定なしで `service:freee-mcp* status:error` クエリを解釈できるようになる。
+- canonical log の `msg` フィールドを HTTP status に応じた動的文字列 (`mcp request ok` / `mcp request client_error` / `mcp request server_error`) に変更。Datadog UI 上での目視判別が容易になる。
+- `makeErrorChain` を `new Error` + `Error.captureStackTrace` ベースに再実装。validation / routing 由来の synthetic error にも stack trace が付与され、Datadog から呼び出し位置を直接追跡可能。プライバシー scrub は従来通り適用。
+- pino otelMixin に `trace_sampled` フィールドを追加。アクティブな span がない場合も `trace_sampled: false` として明示的に出力するため、Datadog 上で「sampler が sampled と判定したログのみ」を facet で抽出できる(エクスポーター段階の drop は含まない)。

--- a/src/server/error-serializer.test.ts
+++ b/src/server/error-serializer.test.ts
@@ -137,27 +137,14 @@ describe('makeErrorChain', () => {
   });
 
   it('produces a populated stack so synthetic errors are debuggable', () => {
-    // Pre-fix this entry was a literal `{name, message}` with no `stack` —
-    // operators staring at a 400 in Datadog had nothing to grep for. The
-    // new implementation routes through `serializeErrorChain` which fills
-    // `stack` from a real Error object.
     const chain = makeErrorChain('RoutingError', 'unknown session id');
     expect(typeof chain[0].stack).toBe('string');
     expect((chain[0].stack as string).length).toBeGreaterThan(0);
   });
 
-  // Bun and Node both expose `Error.captureStackTrace`. The runtime guard
-  // here mirrors the production code so this assertion only runs where
-  // captureStackTrace exists; on hypothetical non-V8 runtimes the helper
-  // frame may legitimately remain in the stack and the production code
-  // documents that as an accepted fallback.
   it.skipIf(typeof Error.captureStackTrace !== 'function')(
     'elides its own helper frame from the stack via captureStackTrace',
     () => {
-      // The `Error.captureStackTrace(err, makeErrorChain)` second argument
-      // tells V8/Bun to drop everything from `makeErrorChain` upwards. The
-      // resulting top frame must therefore be the *caller* of makeErrorChain
-      // (in this test: the test fn), never makeErrorChain itself.
       function callerFrame(): ReturnType<typeof makeErrorChain> {
         return makeErrorChain('SyntheticError', 'demo');
       }
@@ -168,9 +155,6 @@ describe('makeErrorChain', () => {
   );
 
   it('still scrubs sensitive identifiers from message and stack', () => {
-    // Regression guard: the rewrite must not bypass the privacy protection
-    // serializeErrorChain applies. Numeric IDs (6+ digits) and emails are
-    // both masked.
     const chain = makeErrorChain('PrivacyTest', 'company_id 87654321 contact ops@example.com');
     expect(chain[0].message).toContain('[REDACTED_ID]');
     expect(chain[0].message).toContain('[REDACTED_EMAIL]');

--- a/src/server/error-serializer.test.ts
+++ b/src/server/error-serializer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { scrubErrorMessage, serializeErrorChain } from './error-serializer.js';
+import { makeErrorChain, scrubErrorMessage, serializeErrorChain } from './error-serializer.js';
 
 describe('scrubErrorMessage', () => {
   it('masks 6+ digit numeric IDs', () => {
@@ -125,5 +125,56 @@ describe('serializeErrorChain', () => {
     err.code = 'ENOENT';
     const chain = serializeErrorChain(err);
     expect(chain[0].code).toBe('ENOENT');
+  });
+});
+
+describe('makeErrorChain', () => {
+  it('preserves the supplied name and message', () => {
+    const chain = makeErrorChain('ValidationError', 'path /foo not found in schema');
+    expect(chain).toHaveLength(1);
+    expect(chain[0].name).toBe('ValidationError');
+    expect(chain[0].message).toBe('path /foo not found in schema');
+  });
+
+  it('produces a populated stack so synthetic errors are debuggable', () => {
+    // Pre-fix this entry was a literal `{name, message}` with no `stack` —
+    // operators staring at a 400 in Datadog had nothing to grep for. The
+    // new implementation routes through `serializeErrorChain` which fills
+    // `stack` from a real Error object.
+    const chain = makeErrorChain('RoutingError', 'unknown session id');
+    expect(typeof chain[0].stack).toBe('string');
+    expect((chain[0].stack as string).length).toBeGreaterThan(0);
+  });
+
+  // Bun and Node both expose `Error.captureStackTrace`. The runtime guard
+  // here mirrors the production code so this assertion only runs where
+  // captureStackTrace exists; on hypothetical non-V8 runtimes the helper
+  // frame may legitimately remain in the stack and the production code
+  // documents that as an accepted fallback.
+  it.skipIf(typeof Error.captureStackTrace !== 'function')(
+    'elides its own helper frame from the stack via captureStackTrace',
+    () => {
+      // The `Error.captureStackTrace(err, makeErrorChain)` second argument
+      // tells V8/Bun to drop everything from `makeErrorChain` upwards. The
+      // resulting top frame must therefore be the *caller* of makeErrorChain
+      // (in this test: the test fn), never makeErrorChain itself.
+      function callerFrame(): ReturnType<typeof makeErrorChain> {
+        return makeErrorChain('SyntheticError', 'demo');
+      }
+      const chain = callerFrame();
+      const stack = chain[0].stack ?? '';
+      expect(stack).not.toMatch(/at makeErrorChain/);
+    },
+  );
+
+  it('still scrubs sensitive identifiers from message and stack', () => {
+    // Regression guard: the rewrite must not bypass the privacy protection
+    // serializeErrorChain applies. Numeric IDs (6+ digits) and emails are
+    // both masked.
+    const chain = makeErrorChain('PrivacyTest', 'company_id 87654321 contact ops@example.com');
+    expect(chain[0].message).toContain('[REDACTED_ID]');
+    expect(chain[0].message).toContain('[REDACTED_EMAIL]');
+    expect(chain[0].message).not.toContain('87654321');
+    expect(chain[0].message).not.toContain('ops@example.com');
   });
 });

--- a/src/server/error-serializer.ts
+++ b/src/server/error-serializer.ts
@@ -38,12 +38,31 @@ export function scrubErrorMessage(input: string): string {
 
 /**
  * Build a single-entry error chain for synthetic errors (validation failures,
- * routing 404s) that don't have an actual thrown Error object. The `message`
- * is scrubbed so callers cannot accidentally bypass the privacy protection
- * that `serializeErrorChain()` provides for real thrown errors.
+ * routing 404s) that don't have an actual thrown Error object.
+ *
+ * Instantiates a real `Error` so the `stack` property reflects the call site.
+ * `captureStackTrace(err, makeErrorChain)` elides this helper from the stack
+ * frames, so the top frame becomes the caller (e.g., the validation branch in
+ * client-mode.ts). Routing the result through `serializeErrorChain` keeps the
+ * scrub + shape identical to real thrown errors.
+ *
+ * Intentionally hard-coded to `maxDepth: 1` — synthetic errors are
+ * single-event by definition, with no `Error.cause` chain to walk. If a
+ * caller ever needs cause-chain support, they should construct the wrapped
+ * `Error` themselves and pass it to `serializeErrorChain` directly rather
+ * than reusing this helper.
  */
 export function makeErrorChain(name: string, message: string): ErrorChainEntry[] {
-  return [{ name, message: scrubErrorMessage(message) }];
+  const err = new Error(message);
+  err.name = name;
+  // V8-only API; Bun/JSC also expose it but the guard keeps this portable.
+  // On runtimes without it, the built-in `new Error().stack` is used as-is
+  // (may include this helper frame at the top — still strictly better than
+  // the previous no-stack behavior).
+  if (typeof Error.captureStackTrace === 'function') {
+    Error.captureStackTrace(err, makeErrorChain);
+  }
+  return serializeErrorChain(err, 1);
 }
 
 /**

--- a/src/server/error-serializer.ts
+++ b/src/server/error-serializer.ts
@@ -38,27 +38,13 @@ export function scrubErrorMessage(input: string): string {
 
 /**
  * Build a single-entry error chain for synthetic errors (validation failures,
- * routing 404s) that don't have an actual thrown Error object.
- *
- * Instantiates a real `Error` so the `stack` property reflects the call site.
- * `captureStackTrace(err, makeErrorChain)` elides this helper from the stack
- * frames, so the top frame becomes the caller (e.g., the validation branch in
- * client-mode.ts). Routing the result through `serializeErrorChain` keeps the
- * scrub + shape identical to real thrown errors.
- *
- * Intentionally hard-coded to `maxDepth: 1` — synthetic errors are
- * single-event by definition, with no `Error.cause` chain to walk. If a
- * caller ever needs cause-chain support, they should construct the wrapped
- * `Error` themselves and pass it to `serializeErrorChain` directly rather
- * than reusing this helper.
+ * routing 404s) that don't have an actual thrown Error object. Routes through
+ * `serializeErrorChain` so the result gets the same scrub + shape as a real
+ * thrown error, and a stack rooted at the caller (this helper frame elided).
  */
 export function makeErrorChain(name: string, message: string): ErrorChainEntry[] {
   const err = new Error(message);
   err.name = name;
-  // V8-only API; Bun/JSC also expose it but the guard keeps this portable.
-  // On runtimes without it, the built-in `new Error().stack` is used as-is
-  // (may include this helper frame at the top — still strictly better than
-  // the previous no-stack behavior).
   if (typeof Error.captureStackTrace === 'function') {
     Error.captureStackTrace(err, makeErrorChain);
   }

--- a/src/server/logger.test.ts
+++ b/src/server/logger.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Writable } from 'node:stream';
+import pino from 'pino';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('logger', () => {
   afterEach(() => {
@@ -39,6 +41,86 @@ describe('logger', () => {
     const logger = getLogger();
     expect(logger).toBeDefined();
     expect(logger.level).toBe('info');
+  });
+});
+
+/**
+ * Verify the pino output shape end-to-end by intercepting `pino.destination`
+ * with a captured-in-memory Writable. We test the actual emitted JSON
+ * because that is the contract Datadog ingests, not internal helpers.
+ */
+describe('logger pino output', () => {
+  let lines: string[];
+  let destSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    lines = [];
+    const stream = new Writable({
+      write(chunk, _enc, cb) {
+        lines.push(chunk.toString());
+        cb();
+      },
+    });
+    // pino.destination(2) returns a SonicBoom; substituting a Writable
+    // works because pino accepts any Node stream as its destination.
+    destSpy = vi
+      .spyOn(pino, 'destination')
+      .mockReturnValue(stream as unknown as ReturnType<typeof pino.destination>);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    destSpy.mockRestore();
+  });
+
+  it('emits level as string label, not numeric (Datadog Status Remapper compat)', async () => {
+    const { initLogger } = await import('./logger.js');
+    const logger = initLogger();
+    logger.info({ x: 1 }, 'hello');
+
+    expect(lines.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(lines[lines.length - 1]);
+    expect(parsed.level).toBe('info');
+    expect(typeof parsed.level).toBe('string');
+  });
+
+  it('emits warn and error as their string labels', async () => {
+    const { initLogger } = await import('./logger.js');
+    const logger = initLogger();
+    logger.warn('w');
+    logger.error('e');
+
+    const parsed = lines.map((l) => JSON.parse(l));
+    expect(parsed.find((p) => p.msg === 'w')?.level).toBe('warn');
+    expect(parsed.find((p) => p.msg === 'e')?.level).toBe('error');
+  });
+
+  it('emits trace_sampled:false when no active OpenTelemetry span is set', async () => {
+    // Without an active span, otelMixin must still publish trace_sampled
+    // (as `false`) so Datadog facets work uniformly across requests with
+    // and without traces. Absence of the field would force consumers to
+    // distinguish "missing" from "false" everywhere.
+    const { initLogger } = await import('./logger.js');
+    const logger = initLogger();
+    logger.info('hi');
+
+    const parsed = JSON.parse(lines[lines.length - 1]);
+    expect(parsed.trace_sampled).toBe(false);
+    expect(parsed.trace_id).toBeUndefined();
+    expect(parsed.span_id).toBeUndefined();
+  });
+
+  it('serialises freee-mcp service base fields alongside the level', async () => {
+    // Smoke test: verify base fields (service, version, transport_mode)
+    // still flow through with the new formatter wiring in place.
+    const { initLogger } = await import('./logger.js');
+    const logger = initLogger({ level: 'info', transportMode: 'remote' });
+    logger.info('boot');
+
+    const parsed = JSON.parse(lines[lines.length - 1]);
+    expect(parsed.service).toBeDefined();
+    expect(parsed.transport_mode).toBe('remote');
+    expect(parsed.level).toBe('info');
   });
 });
 

--- a/src/server/logger.test.ts
+++ b/src/server/logger.test.ts
@@ -44,11 +44,6 @@ describe('logger', () => {
   });
 });
 
-/**
- * Verify the pino output shape end-to-end by intercepting `pino.destination`
- * with a captured-in-memory Writable. We test the actual emitted JSON
- * because that is the contract Datadog ingests, not internal helpers.
- */
 describe('logger pino output', () => {
   let lines: string[];
   let destSpy: ReturnType<typeof vi.spyOn>;
@@ -61,8 +56,6 @@ describe('logger pino output', () => {
         cb();
       },
     });
-    // pino.destination(2) returns a SonicBoom; substituting a Writable
-    // works because pino accepts any Node stream as its destination.
     destSpy = vi
       .spyOn(pino, 'destination')
       .mockReturnValue(stream as unknown as ReturnType<typeof pino.destination>);
@@ -96,10 +89,8 @@ describe('logger pino output', () => {
   });
 
   it('emits trace_sampled:false when no active OpenTelemetry span is set', async () => {
-    // Without an active span, otelMixin must still publish trace_sampled
-    // (as `false`) so Datadog facets work uniformly across requests with
-    // and without traces. Absence of the field would force consumers to
-    // distinguish "missing" from "false" everywhere.
+    // Always present (even as false) so Datadog facets don't have to
+    // distinguish "missing" from "false".
     const { initLogger } = await import('./logger.js');
     const logger = initLogger();
     logger.info('hi');
@@ -111,8 +102,6 @@ describe('logger pino output', () => {
   });
 
   it('serialises freee-mcp service base fields alongside the level', async () => {
-    // Smoke test: verify base fields (service, version, transport_mode)
-    // still flow through with the new formatter wiring in place.
     const { initLogger } = await import('./logger.js');
     const logger = initLogger({ level: 'info', transportMode: 'remote' });
     logger.info('boot');

--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -1,4 +1,4 @@
-import { trace } from '@opentelemetry/api';
+import { TraceFlags, trace } from '@opentelemetry/api';
 import pino from 'pino';
 import { APP_NAME, PACKAGE_VERSION } from '../constants.js';
 import { serializeErrorChain } from './error-serializer.js';
@@ -21,16 +21,23 @@ function getStderrDest(): pino.DestinationStream {
 }
 
 /**
- * Inject trace_id / span_id from the active OpenTelemetry span.
- * Returns an empty object when no span is active (OTel disabled).
+ * Inject trace_id / span_id / trace_sampled from the active OpenTelemetry span.
+ *
+ * When no span is active (OTel disabled, or code path outside a traced
+ * context) the function still returns `trace_sampled: false` so Datadog
+ * queries can select "logs whose trace was actually exported" without
+ * joining on trace_id presence.
  */
-function otelMixin(): Record<string, string> {
+function otelMixin(): Record<string, unknown> {
   const span = trace.getActiveSpan();
-  if (!span) return {};
+  if (!span) {
+    return { trace_sampled: false };
+  }
   const ctx = span.spanContext();
   return {
     trace_id: ctx.traceId,
     span_id: ctx.spanId,
+    trace_sampled: (ctx.traceFlags & TraceFlags.SAMPLED) === TraceFlags.SAMPLED,
   };
 }
 
@@ -90,14 +97,33 @@ const REDACT_OPTIONS: pino.redactOptions = {
   remove: false,
 };
 
-export function initLogger(levelOrOptions?: string | LoggerOptions): pino.Logger {
-  const options = resolveOptions(levelOrOptions);
-  const level = options.level || process.env.LOG_LEVEL || 'info';
-  const transportMode = options.transportMode ?? 'stdio';
+/**
+ * Emit `level` as a lowercase string ('info' | 'warn' | 'error') instead of
+ * pino's default numeric form (30 | 40 | 50).
+ *
+ * Rationale: Datadog's default Status Remapper recognises string levels out
+ * of the box, so `service:freee-mcp* status:error` queries work without
+ * enabling the pino integration pipeline on the collector side. Pino's
+ * internal level filtering (LOG_LEVEL threshold, child loggers) still
+ * operates on the numeric value — formatters only affect output
+ * serialization.
+ */
+const LEVEL_FORMATTER: NonNullable<pino.LoggerOptions['formatters']>['level'] = (label) => ({
+  level: label,
+});
 
-  const baseOptions: pino.LoggerOptions = {
+/**
+ * Single source of truth for pino options. Both eager (`initLogger`) and
+ * lazy (`getLogger`) construction paths funnel through here so that adding
+ * a new field — e.g. another formatter or redact path — only touches one
+ * place. Drift between the two paths previously had to be caught by code
+ * review.
+ */
+function buildBaseOptions(level: string, transportMode: 'stdio' | 'remote'): pino.LoggerOptions {
+  return {
     level,
     mixin: otelMixin,
+    formatters: { level: LEVEL_FORMATTER },
     serializers: { err: errSerializer },
     redact: REDACT_OPTIONS,
     base: {
@@ -106,8 +132,14 @@ export function initLogger(levelOrOptions?: string | LoggerOptions): pino.Logger
       transport_mode: transportMode,
     },
   };
+}
 
-  _logger = pino(baseOptions, getStderrDest());
+export function initLogger(levelOrOptions?: string | LoggerOptions): pino.Logger {
+  const options = resolveOptions(levelOrOptions);
+  const level = options.level || process.env.LOG_LEVEL || 'info';
+  const transportMode = options.transportMode ?? 'stdio';
+
+  _logger = pino(buildBaseOptions(level, transportMode), getStderrDest());
 
   return _logger;
 }
@@ -115,17 +147,7 @@ export function initLogger(levelOrOptions?: string | LoggerOptions): pino.Logger
 export function getLogger(): pino.Logger {
   if (!_logger) {
     _logger = pino(
-      {
-        level: process.env.LOG_LEVEL || 'info',
-        mixin: otelMixin,
-        serializers: { err: errSerializer },
-        redact: REDACT_OPTIONS,
-        base: {
-          service: APP_NAME,
-          version: PACKAGE_VERSION,
-          transport_mode: 'stdio',
-        },
-      },
+      buildBaseOptions(process.env.LOG_LEVEL || 'info', 'stdio'),
       getStderrDest(),
     );
   }

--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -98,27 +98,14 @@ const REDACT_OPTIONS: pino.redactOptions = {
 };
 
 /**
- * Emit `level` as a lowercase string ('info' | 'warn' | 'error') instead of
- * pino's default numeric form (30 | 40 | 50).
- *
- * Rationale: Datadog's default Status Remapper recognises string levels out
- * of the box, so `service:freee-mcp* status:error` queries work without
- * enabling the pino integration pipeline on the collector side. Pino's
- * internal level filtering (LOG_LEVEL threshold, child loggers) still
- * operates on the numeric value — formatters only affect output
- * serialization.
+ * Emit `level` as a lowercase string label so Datadog's default Status
+ * Remapper works without custom pipeline config. Pino's threshold filtering
+ * still uses the numeric level internally.
  */
 const LEVEL_FORMATTER: NonNullable<pino.LoggerOptions['formatters']>['level'] = (label) => ({
   level: label,
 });
 
-/**
- * Single source of truth for pino options. Both eager (`initLogger`) and
- * lazy (`getLogger`) construction paths funnel through here so that adding
- * a new field — e.g. another formatter or redact path — only touches one
- * place. Drift between the two paths previously had to be caught by code
- * review.
- */
 function buildBaseOptions(level: string, transportMode: 'stdio' | 'remote'): pino.LoggerOptions {
   return {
     level,

--- a/src/telemetry/middleware.test.ts
+++ b/src/telemetry/middleware.test.ts
@@ -242,9 +242,6 @@ describe('createTracingMiddleware - canonical log line', () => {
     logError: ReturnType<typeof vi.fn>;
     app: express.Express;
   }> {
-    // Middleware dispatches `getLogger()[level](payload, msg)` based on HTTP
-    // status (see `levelFor`). Spy on all three levels so individual tests
-    // can assert which one actually fired.
     const logInfo = vi.fn();
     const logWarn = vi.fn();
     const logError = vi.fn();
@@ -313,10 +310,6 @@ describe('createTracingMiddleware - canonical log line', () => {
   });
 
   it('emits canonical log at error level for 5xx with server_error message', async () => {
-    // `levelFor(500)` dispatches the canonical log line through
-    // `logger.error()` (numeric pino level 50 → Datadog `status:error`),
-    // not `logger.info()`. This assertion locks that mapping in place so a
-    // regression would immediately break the Datadog error dashboard.
     const { logInfo, logWarn, logError, app } = await setupAppWithLoggerSpy((_req, res) => {
       res.status(500).json({ error: 'boom' });
     });
@@ -334,8 +327,6 @@ describe('createTracingMiddleware - canonical log line', () => {
   });
 
   it('emits canonical log at warn level for 4xx with client_error message', async () => {
-    // 4xx (400/401/403/404/422) all map to `warn` per ECS/Datadog
-    // convention — server is healthy, client misused it.
     const { logInfo, logWarn, logError, app } = await setupAppWithLoggerSpy((_req, res) => {
       res.status(400).json({ error: 'invalid request' });
     });
@@ -352,10 +343,7 @@ describe('createTracingMiddleware - canonical log line', () => {
     expect((payload as { http: { status: number } }).http.status).toBe(400);
   });
 
-  it('also maps 404 to warn (regression: previously emitted as info)', async () => {
-    // 404 is especially important because both upstream freee API "not
-    // found" responses and our own synthetic routing errors look identical
-    // in the canonical log. Both must show up on a `status:warn` filter.
+  it('maps 404 to warn (covers both upstream and synthetic routing not-found)', async () => {
     const { logInfo, logWarn, logError, app } = await setupAppWithLoggerSpy((_req, res) => {
       res.status(404).json({ error: 'not found' });
     });
@@ -612,13 +600,6 @@ describe('normalizeUserAgent', () => {
   });
 });
 
-/**
- * Unit-level tests for the HTTP-status → pino-level and msg helpers. The
- * end-to-end tests above already cover the happy path through Express;
- * these exercise the boundary values and every 4xx code we care about in a
- * single-line call each so a broken mapping fails loudly without requiring
- * a real server.
- */
 describe('levelFor', () => {
   it('maps 2xx and 3xx to info', async () => {
     const { levelFor } = await import('./middleware.js');

--- a/src/telemetry/middleware.test.ts
+++ b/src/telemetry/middleware.test.ts
@@ -236,10 +236,24 @@ describe('createTracingMiddleware - canonical log line', () => {
   async function setupAppWithLoggerSpy(
     routeHandler: (req: express.Request, res: express.Response) => void,
     routePath = '/mcp',
-  ): Promise<{ logInfo: ReturnType<typeof vi.fn>; app: express.Express }> {
+  ): Promise<{
+    logInfo: ReturnType<typeof vi.fn>;
+    logWarn: ReturnType<typeof vi.fn>;
+    logError: ReturnType<typeof vi.fn>;
+    app: express.Express;
+  }> {
+    // Middleware dispatches `getLogger()[level](payload, msg)` based on HTTP
+    // status (see `levelFor`). Spy on all three levels so individual tests
+    // can assert which one actually fired.
     const logInfo = vi.fn();
+    const logWarn = vi.fn();
+    const logError = vi.fn();
     vi.doMock('../server/logger.js', () => ({
-      getLogger: (): { info: ReturnType<typeof vi.fn> } => ({ info: logInfo }),
+      getLogger: (): {
+        info: ReturnType<typeof vi.fn>;
+        warn: ReturnType<typeof vi.fn>;
+        error: ReturnType<typeof vi.fn>;
+      } => ({ info: logInfo, warn: logWarn, error: logError }),
     }));
 
     const { createTracingMiddleware } = await import('./middleware.js');
@@ -252,7 +266,7 @@ describe('createTracingMiddleware - canonical log line', () => {
       (req as unknown as { recorder: unknown }).recorder = getCurrentRecorder();
       routeHandler(req, res);
     });
-    return { logInfo, app };
+    return { logInfo, logWarn, logError, app };
   }
 
   function listen(app: express.Express): Promise<{ srv: http.Server; port: number }> {
@@ -278,7 +292,7 @@ describe('createTracingMiddleware - canonical log line', () => {
 
     expect(logInfo).toHaveBeenCalledTimes(1);
     const [payload, message] = logInfo.mock.calls[0];
-    expect(message).toBe('mcp request completed');
+    expect(message).toBe('mcp request ok');
 
     expect(payload).toMatchObject({
       request_id: expect.any(String),
@@ -298,8 +312,12 @@ describe('createTracingMiddleware - canonical log line', () => {
     });
   });
 
-  it('reflects 500 status in http.status', async () => {
-    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+  it('emits canonical log at error level for 5xx with server_error message', async () => {
+    // `levelFor(500)` dispatches the canonical log line through
+    // `logger.error()` (numeric pino level 50 → Datadog `status:error`),
+    // not `logger.info()`. This assertion locks that mapping in place so a
+    // regression would immediately break the Datadog error dashboard.
+    const { logInfo, logWarn, logError, app } = await setupAppWithLoggerSpy((_req, res) => {
       res.status(500).json({ error: 'boom' });
     });
     ({ srv: server, port } = await listen(app));
@@ -307,13 +325,18 @@ describe('createTracingMiddleware - canonical log line', () => {
     await makeRequest(port, '/mcp');
     await new Promise((r) => setTimeout(r, 10));
 
-    expect(logInfo).toHaveBeenCalledTimes(1);
-    const [payload] = logInfo.mock.calls[0];
+    expect(logInfo).not.toHaveBeenCalled();
+    expect(logWarn).not.toHaveBeenCalled();
+    expect(logError).toHaveBeenCalledTimes(1);
+    const [payload, message] = logError.mock.calls[0];
+    expect(message).toBe('mcp request server_error');
     expect((payload as { http: { status: number } }).http.status).toBe(500);
   });
 
-  it('reflects 400 status in http.status (addresses the missing-400-logs bug)', async () => {
-    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+  it('emits canonical log at warn level for 4xx with client_error message', async () => {
+    // 4xx (400/401/403/404/422) all map to `warn` per ECS/Datadog
+    // convention — server is healthy, client misused it.
+    const { logInfo, logWarn, logError, app } = await setupAppWithLoggerSpy((_req, res) => {
       res.status(400).json({ error: 'invalid request' });
     });
     ({ srv: server, port } = await listen(app));
@@ -321,9 +344,29 @@ describe('createTracingMiddleware - canonical log line', () => {
     await makeRequest(port, '/mcp');
     await new Promise((r) => setTimeout(r, 10));
 
-    expect(logInfo).toHaveBeenCalledTimes(1);
-    const [payload] = logInfo.mock.calls[0];
+    expect(logInfo).not.toHaveBeenCalled();
+    expect(logError).not.toHaveBeenCalled();
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    const [payload, message] = logWarn.mock.calls[0];
+    expect(message).toBe('mcp request client_error');
     expect((payload as { http: { status: number } }).http.status).toBe(400);
+  });
+
+  it('also maps 404 to warn (regression: previously emitted as info)', async () => {
+    // 404 is especially important because both upstream freee API "not
+    // found" responses and our own synthetic routing errors look identical
+    // in the canonical log. Both must show up on a `status:warn` filter.
+    const { logInfo, logWarn, logError, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(404).json({ error: 'not found' });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(logInfo).not.toHaveBeenCalled();
+    expect(logError).not.toHaveBeenCalled();
+    expect(logWarn).toHaveBeenCalledTimes(1);
   });
 
   it('flushes only once even if both finish and close events fire', async () => {
@@ -566,5 +609,75 @@ describe('normalizeUserAgent', () => {
     const result = normalizeUserAgent('A'.repeat(257));
     expect(result).toBeDefined();
     expect(result).toHaveLength(256);
+  });
+});
+
+/**
+ * Unit-level tests for the HTTP-status → pino-level and msg helpers. The
+ * end-to-end tests above already cover the happy path through Express;
+ * these exercise the boundary values and every 4xx code we care about in a
+ * single-line call each so a broken mapping fails loudly without requiring
+ * a real server.
+ */
+describe('levelFor', () => {
+  it('maps 2xx and 3xx to info', async () => {
+    const { levelFor } = await import('./middleware.js');
+    expect(levelFor(200)).toBe('info');
+    expect(levelFor(201)).toBe('info');
+    expect(levelFor(204)).toBe('info');
+    expect(levelFor(301)).toBe('info');
+    expect(levelFor(302)).toBe('info');
+  });
+
+  it('maps all 4xx codes to warn (including auth/notfound)', async () => {
+    const { levelFor } = await import('./middleware.js');
+    expect(levelFor(400)).toBe('warn');
+    expect(levelFor(401)).toBe('warn');
+    expect(levelFor(403)).toBe('warn');
+    expect(levelFor(404)).toBe('warn');
+    expect(levelFor(422)).toBe('warn');
+    expect(levelFor(429)).toBe('warn');
+    expect(levelFor(499)).toBe('warn');
+  });
+
+  it('maps 5xx to error', async () => {
+    const { levelFor } = await import('./middleware.js');
+    expect(levelFor(500)).toBe('error');
+    expect(levelFor(502)).toBe('error');
+    expect(levelFor(503)).toBe('error');
+    expect(levelFor(599)).toBe('error');
+  });
+
+  it('boundary: 399 is info, 400 is warn', async () => {
+    const { levelFor } = await import('./middleware.js');
+    expect(levelFor(399)).toBe('info');
+    expect(levelFor(400)).toBe('warn');
+  });
+
+  it('boundary: 499 is warn, 500 is error', async () => {
+    const { levelFor } = await import('./middleware.js');
+    expect(levelFor(499)).toBe('warn');
+    expect(levelFor(500)).toBe('error');
+  });
+});
+
+describe('messageFor', () => {
+  it('returns "mcp request ok" for 2xx/3xx', async () => {
+    const { messageFor } = await import('./middleware.js');
+    expect(messageFor(200)).toBe('mcp request ok');
+    expect(messageFor(302)).toBe('mcp request ok');
+  });
+
+  it('returns "mcp request client_error" for 4xx', async () => {
+    const { messageFor } = await import('./middleware.js');
+    expect(messageFor(400)).toBe('mcp request client_error');
+    expect(messageFor(404)).toBe('mcp request client_error');
+    expect(messageFor(422)).toBe('mcp request client_error');
+  });
+
+  it('returns "mcp request server_error" for 5xx', async () => {
+    const { messageFor } = await import('./middleware.js');
+    expect(messageFor(500)).toBe('mcp request server_error');
+    expect(messageFor(503)).toBe('mcp request server_error');
   });
 });

--- a/src/telemetry/middleware.ts
+++ b/src/telemetry/middleware.ts
@@ -21,16 +21,8 @@ const MAX_USER_AGENT_LENGTH = 256;
 export type CanonicalLogLevel = 'info' | 'warn' | 'error';
 
 /**
- * Map an HTTP response status code to the pino log level used for the
- * canonical log line of that request.
- *
- * - 5xx → `error` so Datadog's default Status Remapper raises severity and
- *   on-call alerts can fire on `status:error`.
- * - 4xx → `warn` including 401/403/404/422. All client errors become
- *   warnings per ECS / Datadog convention — the server is healthy but the
- *   caller misused it, which is still an observability signal worth
- *   tracking in dashboards.
- * - Everything else → `info`.
+ * 4xx (incl. 401/403/404/422) → `warn`, 5xx → `error`. Per ECS/Datadog
+ * convention: client misuse is a warning, server fault is an error.
  */
 export function levelFor(status: number): CanonicalLogLevel {
   if (status >= 500) return 'error';
@@ -38,19 +30,10 @@ export function levelFor(status: number): CanonicalLogLevel {
   return 'info';
 }
 
-const MSG_OK = 'mcp request ok';
-const MSG_CLIENT_ERROR = 'mcp request client_error';
-const MSG_SERVER_ERROR = 'mcp request server_error';
-
-/**
- * Return the `msg` string attached to the canonical log line for a given
- * HTTP status. A tiny number of distinct values keeps Datadog facet
- * cardinality low while still letting engineers eyeball logs at a glance.
- */
 export function messageFor(status: number): string {
-  if (status >= 500) return MSG_SERVER_ERROR;
-  if (status >= 400) return MSG_CLIENT_ERROR;
-  return MSG_OK;
+  if (status >= 500) return 'mcp request server_error';
+  if (status >= 400) return 'mcp request client_error';
+  return 'mcp request ok';
 }
 
 /**
@@ -156,12 +139,9 @@ export function createTracingMiddleware(): (
 
       const payload = recorder.buildPayload({ status, duration_ms: durationMs });
       const message = messageFor(status);
-      // Explicit dispatch (rather than `getLogger()[level](...)`) keeps the
-      // call sites consistent with the rest of the codebase and avoids
-      // bracket-access against pino's `BaseLogger` interface, which has no
-      // index signature.
+      const level = levelFor(status);
       const logger = getLogger();
-      switch (levelFor(status)) {
+      switch (level) {
         case 'error':
           logger.error(payload, message);
           break;
@@ -177,7 +157,7 @@ export function createTracingMiddleware(): (
         const attrs = { method: req.method, path: req.path, status: String(status) };
         otelSpan.setAttribute('http.response.status_code', status);
         getHttpRequestDuration().record(durationMs / 1000, attrs);
-        if (status >= 500) {
+        if (level === 'error') {
           otelSpan.setStatus({ code: SpanStatusCode.ERROR, message: `HTTP ${status}` });
           getHttpRequestErrorCount().add(1, attrs);
         }

--- a/src/telemetry/middleware.ts
+++ b/src/telemetry/middleware.ts
@@ -18,6 +18,41 @@ import { getHttpRequestDuration, getHttpRequestErrorCount } from './metrics.js';
  */
 const MAX_USER_AGENT_LENGTH = 256;
 
+export type CanonicalLogLevel = 'info' | 'warn' | 'error';
+
+/**
+ * Map an HTTP response status code to the pino log level used for the
+ * canonical log line of that request.
+ *
+ * - 5xx → `error` so Datadog's default Status Remapper raises severity and
+ *   on-call alerts can fire on `status:error`.
+ * - 4xx → `warn` including 401/403/404/422. All client errors become
+ *   warnings per ECS / Datadog convention — the server is healthy but the
+ *   caller misused it, which is still an observability signal worth
+ *   tracking in dashboards.
+ * - Everything else → `info`.
+ */
+export function levelFor(status: number): CanonicalLogLevel {
+  if (status >= 500) return 'error';
+  if (status >= 400) return 'warn';
+  return 'info';
+}
+
+const MSG_OK = 'mcp request ok';
+const MSG_CLIENT_ERROR = 'mcp request client_error';
+const MSG_SERVER_ERROR = 'mcp request server_error';
+
+/**
+ * Return the `msg` string attached to the canonical log line for a given
+ * HTTP status. A tiny number of distinct values keeps Datadog facet
+ * cardinality low while still letting engineers eyeball logs at a glance.
+ */
+export function messageFor(status: number): string {
+  if (status >= 500) return MSG_SERVER_ERROR;
+  if (status >= 400) return MSG_CLIENT_ERROR;
+  return MSG_OK;
+}
+
 /**
  * Normalize and scrub the inbound `User-Agent` header before storing it in
  * the canonical log line.
@@ -120,7 +155,23 @@ export function createTracingMiddleware(): (
       const status = res.statusCode;
 
       const payload = recorder.buildPayload({ status, duration_ms: durationMs });
-      getLogger().info(payload, 'mcp request completed');
+      const message = messageFor(status);
+      // Explicit dispatch (rather than `getLogger()[level](...)`) keeps the
+      // call sites consistent with the rest of the codebase and avoids
+      // bracket-access against pino's `BaseLogger` interface, which has no
+      // index signature.
+      const logger = getLogger();
+      switch (levelFor(status)) {
+        case 'error':
+          logger.error(payload, message);
+          break;
+        case 'warn':
+          logger.warn(payload, message);
+          break;
+        default:
+          logger.info(payload, message);
+          break;
+      }
 
       if (otelSpan) {
         const attrs = { method: req.method, path: req.path, status: String(status) };


### PR DESCRIPTION
## 概要

Improve the freee-mcp remote-mode canonical log line so it integrates cleanly with Datadog's default Status Remapper and stack-trace facets.

- HTTP status → pino level dispatch: 5xx → `error`, 4xx → `warn` (covers 401/403/404/422), otherwise `info`. Datadog severity filters (`status:error`, `status:warn`) now light up automatically.
- Pino `formatters.level` emits the level as a string label (`"info"` / `"warn"` / `"error"`) instead of the numeric form (30/40/50). Datadog's default Status Remapper recognises string labels without any pipeline configuration on the collector.
- `msg` field is now status-driven: `mcp request ok` / `mcp request client_error` / `mcp request server_error`. Low-cardinality, eyeball-friendly in Datadog Live Tail.
- `makeErrorChain` now constructs a real `Error` and uses `Error.captureStackTrace(err, makeErrorChain)` so synthetic errors (validation, routing) carry a stack trace pointing at the call site. Upstream freee-API HTTP error responses are intentionally unchanged — they are not freee-mcp-internal errors and continue to be recorded structurally on `api_calls[]`.
- pino `otelMixin` always publishes `trace_sampled: boolean` (falling back to `false` when no span is active) so Datadog facets can filter "logs whose trace was tagged as sampled" uniformly.
- Internal: `buildBaseOptions(level, transportMode)` factored out so `initLogger` and `getLogger` no longer duplicate the pino options object.

Privacy note: the new synthetic stack traces flow through the existing `serializeErrorChain` → `scrubErrorMessage` pipeline (numeric IDs ≥6 digits + emails are masked). Stack frames may still include local file paths from the build environment — operators should be aware before exporting logs externally.

## Datadog query examples (now possible)

- `service:freee-mcp* status:error` — server errors only
- `service:freee-mcp* status:warn @http.status:4*` — client errors only
- `@trace_sampled:true status:error` — server errors with a sampled trace
- `@msg:"mcp request server_error"` — narrow to the canonical 5xx events

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test:run` (574 tests, including new coverage for `levelFor` / `messageFor`, `makeErrorChain` stack capture, pino level string output, `trace_sampled` mixin)
- [x] `bun run build`
- [ ] After merge: smoke-check Datadog `service:freee-mcp* status:error` filter against staging traffic

This is part 1 of 2. The follow-up PR (`feat/canonical-log-shape-sampler`, stacked on this branch) refactors the canonical log payload shape (`api.calls`, `api.call_count`) and introduces a tool/method-aware OTel sampler.

<!-- 変更内容を簡潔に記述 -->

## 変更種別

- [ ] 新機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント
- [ ] その他