### PR TITLE
fix(remote): synthesize fallback errors[] entry for unrecorded 4xx/5xx

### DIFF
--- a/.changeset/canonical-log-unrecorded-fallback.md
+++ b/.changeset/canonical-log-unrecorded-fallback.md
@@ -1,0 +1,14 @@
+---
+"freee-mcp": patch
+---
+
+Canonical log の `errors[]` が 4xx/5xx 応答で常に空になる hole を修正。
+`res.status().json()` で応答を直接送出して Express エラーハンドラを bypass
+する third-party middleware のケースで `errors[]` が空のまま emit されて
+いた問題を、`flush()` の universal fallback で補完。`source: "response"`,
+`error_type: "unrecorded"` の placeholder ErrorInfo を合成し、Datadog
+operator が `status:error` で filter した後でも最低限のドリルダウン情報を
+得られるようにした。
+
+明示的な `recordError` が呼ばれているケースでは fallback は no-op となる
+ため、既存の挙動には影響しない。

--- a/.changeset/canonical-log-unrecorded-fallback.md
+++ b/.changeset/canonical-log-unrecorded-fallback.md
@@ -10,5 +10,13 @@ Canonical log の `errors[]` が 4xx/5xx 応答で常に空になる hole を修
 operator が `status:error` で filter した後でも最低限のドリルダウン情報を
 得られるようにした。
 
+Fallback の `chain[0].message` には `HTTP <status> <method> <path>` を
+埋め込み、Datadog の scrubbing を通過する状態で route の特定が可能に
+なるようにした。
+
+body-size limit middleware (`http-server.ts`) は我々のコードなので
+fallback 経由ではなく explicit `recordError({source: "middleware",
+error_type: "payload_too_large"})` を直接呼ぶように更新。
+
 明示的な `recordError` が呼ばれているケースでは fallback は no-op となる
 ため、既存の挙動には影響しない。

--- a/src/openapi/client-mode.test.ts
+++ b/src/openapi/client-mode.test.ts
@@ -1,15 +1,8 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-/**
- * Privacy regression tests for the generated freee_api_* tools.
- *
- * The single most important guarantee of the RequestRecorder design is that
- * user-supplied query values and request bodies NEVER leave the process via
- * the canonical log line. The type system already excludes those fields from
- * `ToolCallInfo`, but a reviewer could still accidentally pass them; these
- * runtime tests catch that regression.
- */
+// Privacy regression tests: query values and request bodies must never appear
+// in the canonical log payload emitted by RequestRecorder.
 
 type CapturedHandler = (
   args: Record<string, unknown>,
@@ -94,7 +87,6 @@ describe('generateClientModeTool - privacy', () => {
     const payload = recorder.buildPayload({ status: 200, duration_ms: 10 });
     const payloadJson = JSON.stringify(payload);
 
-    // Tool-layer recording must not contain query values.
     expect(payloadJson).not.toContain('2024-01-01');
     expect(payloadJson).not.toContain('Acme Corp');
     expect(payloadJson).not.toContain('SECRET');
@@ -133,8 +125,6 @@ describe('generateClientModeTool - privacy', () => {
 
     const payloadJson = JSON.stringify(recorder.buildPayload({ status: 200, duration_ms: 10 }));
 
-    // No body field in ToolCallInfo means body is not even representable; assert the
-    // actual values are absent so a future refactor that adds `args.body` fails loudly.
     expect(payloadJson).not.toContain('99999999');
     expect(payloadJson).not.toContain('confidential');
     expect(payloadJson).not.toContain('ceo@example.com');

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -127,6 +127,15 @@ export async function startHttpServer(options?: {
   app.use((req: Request, res: Response, next: () => void) => {
     const contentLength = req.headers['content-length'];
     if (contentLength && Number.parseInt(contentLength, 10) > BODY_SIZE_LIMIT) {
+      getCurrentRecorder()?.recordError({
+        source: 'middleware',
+        status_code: 413,
+        error_type: 'payload_too_large',
+        chain: makeErrorChain(
+          'PayloadTooLargeError',
+          'Content-Length exceeds configured body size limit',
+        ),
+      });
       res.status(413).json({ error: 'Payload too large' });
       return;
     }

--- a/src/server/request-context.test.ts
+++ b/src/server/request-context.test.ts
@@ -172,6 +172,18 @@ describe('RequestRecorder', () => {
       expect(payload.errors[0]?.chain[0]?.message).toContain('HTTP 500');
     });
 
+    it('embeds method and path into the synthesized message for Datadog drilldown', () => {
+      const recorder = makeRecorder({ method: 'GET', path: '/authorize' });
+
+      recorder.synthesizeFallbackErrorIfMissing(400);
+
+      const payload = recorder.buildPayload({ status: 400, duration_ms: 1 });
+      const message = payload.errors[0]?.chain[0]?.message ?? '';
+      expect(message).toContain('GET');
+      expect(message).toContain('/authorize');
+      expect(message).toContain('HTTP 400');
+    });
+
     it('is a no-op when an explicit recordError was already called', () => {
       const recorder = makeRecorder();
       recorder.recordError({

--- a/src/server/request-context.test.ts
+++ b/src/server/request-context.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   RequestRecorder,
+  UNRECORDED_ERROR_NAME,
+  UNRECORDED_ERROR_TYPE,
   getCurrentRecorder,
   withRequestRecorder,
 } from './request-context.js';
@@ -150,6 +152,61 @@ describe('RequestRecorder', () => {
       expect(recorder.flushOnce()).toBe(true);
       expect(recorder.flushOnce()).toBe(false);
       expect(recorder.flushOnce()).toBe(false);
+    });
+  });
+
+  describe('synthesizeFallbackErrorIfMissing', () => {
+    it('synthesizes a placeholder ErrorInfo when errors[] is empty', () => {
+      const recorder = makeRecorder();
+
+      recorder.synthesizeFallbackErrorIfMissing(500);
+
+      const payload = recorder.buildPayload({ status: 500, duration_ms: 1 });
+      expect(payload.errors).toHaveLength(1);
+      expect(payload.errors[0]).toMatchObject({
+        source: 'response',
+        status_code: 500,
+        error_type: UNRECORDED_ERROR_TYPE,
+      });
+      expect(payload.errors[0]?.chain[0]?.name).toBe(UNRECORDED_ERROR_NAME);
+      expect(payload.errors[0]?.chain[0]?.message).toContain('HTTP 500');
+    });
+
+    it('is a no-op when an explicit recordError was already called', () => {
+      const recorder = makeRecorder();
+      recorder.recordError({
+        source: 'redis_unavailable',
+        status_code: 503,
+        error_type: 'redis_unavailable',
+        chain: [{ name: 'RedisUnavailableError', message: 'down' }],
+      });
+
+      recorder.synthesizeFallbackErrorIfMissing(503);
+
+      const payload = recorder.buildPayload({ status: 503, duration_ms: 1 });
+      expect(payload.errors).toHaveLength(1);
+      expect(payload.errors[0]?.source).toBe('redis_unavailable');
+    });
+
+    it('embeds the actual status code into the synthesized message', () => {
+      const recorder = makeRecorder();
+      recorder.synthesizeFallbackErrorIfMissing(401);
+
+      const payload = recorder.buildPayload({ status: 401, duration_ms: 1 });
+      expect(payload.errors[0]?.status_code).toBe(401);
+      expect(payload.errors[0]?.chain[0]?.message).toContain('HTTP 401');
+    });
+
+    it('is idempotent — calling twice produces exactly one synthesized entry', () => {
+      // The middleware's flushOnce() guarantees one call per request, but
+      // this method is public — lock the contract so a future bypass of
+      // the errors.length guard cannot silently double-append.
+      const recorder = makeRecorder();
+      recorder.synthesizeFallbackErrorIfMissing(500);
+      recorder.synthesizeFallbackErrorIfMissing(500);
+
+      const payload = recorder.buildPayload({ status: 500, duration_ms: 1 });
+      expect(payload.errors).toHaveLength(1);
     });
   });
 

--- a/src/server/request-context.ts
+++ b/src/server/request-context.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import type { ErrorChainEntry } from './error-serializer.js';
+import { makeErrorChain, type ErrorChainEntry } from './error-serializer.js';
 
 /**
  * Canonical log line: tool call sub-event.
@@ -59,7 +59,18 @@ export type ErrorSource =
   | 'middleware'
   | 'validation'
   | 'redis_unavailable'
-  | 'auth';
+  | 'auth'
+  | 'response';
+
+/**
+ * Marker values for the fallback ErrorInfo synthesized by
+ * `RequestRecorder.synthesizeFallbackErrorIfMissing`. Exported so dashboards,
+ * alerting code, and tests can reference the same symbol — Datadog operators
+ * filter on `@errors.error_type:unrecorded` to find canonical logs that hit
+ * the universal safety net (i.e. some middleware bypassed `recordError`).
+ */
+export const UNRECORDED_ERROR_TYPE = 'unrecorded' as const;
+export const UNRECORDED_ERROR_NAME = 'UnrecordedError' as const;
 
 export interface ErrorInfo {
   source: ErrorSource;
@@ -163,6 +174,37 @@ export class RequestRecorder {
 
   recordError(info: Omit<ErrorInfo, 'timestamp'>): void {
     this.errors.push({ ...info, timestamp: Date.now() });
+  }
+
+  /**
+   * Synthesize a placeholder ErrorInfo when no explicit `recordError` was
+   * called for a 4xx/5xx response. Universal safety net for any middleware
+   * that responds without going through Express's error handler (and so
+   * never gives our handler a chance to call `recordError`).
+   *
+   * No-op if `errors[]` is already non-empty — explicit recording wins,
+   * preserving the more specific source/error_type that handlers know about.
+   *
+   * Why this exists: the canonical log promise is "1 line = full debug
+   * context". Without this, a Datadog operator who filters `status:error`
+   * sees the row but cannot drill down to know what went wrong.
+   *
+   * `status_code` here is the MCP server's outbound HTTP status (i.e.
+   * `res.statusCode`), distinct from `api_calls[].status_code` which
+   * records freee API responses to us. Datadog facets that overload these
+   * across both directions need to disambiguate via `errors[].source`.
+   */
+  synthesizeFallbackErrorIfMissing(status: number): void {
+    if (this.errors.length > 0) return;
+    this.recordError({
+      source: 'response',
+      status_code: status,
+      error_type: UNRECORDED_ERROR_TYPE,
+      chain: makeErrorChain(
+        UNRECORDED_ERROR_NAME,
+        `HTTP ${status} response emitted without explicit recordError`,
+      ),
+    });
   }
 
   /**

--- a/src/server/request-context.ts
+++ b/src/server/request-context.ts
@@ -172,7 +172,7 @@ export class RequestRecorder {
       error_type: UNRECORDED_ERROR_TYPE,
       chain: makeErrorChain(
         UNRECORDED_ERROR_NAME,
-        `HTTP ${status} response emitted without explicit recordError`,
+        `HTTP ${status} ${this.context.method} ${this.context.path} response emitted without explicit recordError`,
       ),
     });
   }

--- a/src/server/request-context.ts
+++ b/src/server/request-context.ts
@@ -62,13 +62,8 @@ export type ErrorSource =
   | 'auth'
   | 'response';
 
-/**
- * Marker values for the fallback ErrorInfo synthesized by
- * `RequestRecorder.synthesizeFallbackErrorIfMissing`. Exported so dashboards,
- * alerting code, and tests can reference the same symbol — Datadog operators
- * filter on `@errors.error_type:unrecorded` to find canonical logs that hit
- * the universal safety net (i.e. some middleware bypassed `recordError`).
- */
+// Datadog facet: @errors.error_type:unrecorded identifies requests where a
+// middleware bypassed recordError and the fallback safety net fired instead.
 export const UNRECORDED_ERROR_TYPE = 'unrecorded' as const;
 export const UNRECORDED_ERROR_NAME = 'UnrecordedError' as const;
 
@@ -132,17 +127,9 @@ export interface CanonicalLogPayload {
 }
 
 /**
- * RequestRecorder is the single place that buffers all per-request observability
- * data for the duration of one HTTP request. At request end the recorder is
- * flushed as a single "canonical log line" JSON log entry.
- *
- * Design notes:
- * - Stored in an AsyncLocalStorage so every async downstream context (tool
- *   handlers, fetch calls, etc.) can reach it via `getCurrentRecorder()`.
- * - All mutation methods accept typed inputs that intentionally exclude user
- *   input. Callers must construct the input with metadata only.
- * - `flushOnce()` provides idempotency for the `res.on('finish')` /
- *   `res.on('close')` race.
+ * Buffers per-request observability data and flushes it as a single canonical
+ * log line at request end. Stored in AsyncLocalStorage so downstream async
+ * contexts can reach it via `getCurrentRecorder()`.
  */
 export class RequestRecorder {
   private readonly toolCalls: ToolCallInfo[] = [];
@@ -155,11 +142,7 @@ export class RequestRecorder {
     this.context = initial;
   }
 
-  /**
-   * Patch context fields that become known after the recorder was created
-   * (typically `user_id` and `session_id` are only available after the bearer
-   * auth middleware runs).
-   */
+  /** Patch fields available only after bearer auth runs (user_id, session_id). */
   updateContext(patch: Partial<Pick<RequestRecorderContext, 'user_id' | 'session_id'>>): void {
     this.context = { ...this.context, ...patch };
   }
@@ -177,22 +160,9 @@ export class RequestRecorder {
   }
 
   /**
-   * Synthesize a placeholder ErrorInfo when no explicit `recordError` was
-   * called for a 4xx/5xx response. Universal safety net for any middleware
-   * that responds without going through Express's error handler (and so
-   * never gives our handler a chance to call `recordError`).
-   *
-   * No-op if `errors[]` is already non-empty — explicit recording wins,
-   * preserving the more specific source/error_type that handlers know about.
-   *
-   * Why this exists: the canonical log promise is "1 line = full debug
-   * context". Without this, a Datadog operator who filters `status:error`
-   * sees the row but cannot drill down to know what went wrong.
-   *
-   * `status_code` here is the MCP server's outbound HTTP status (i.e.
-   * `res.statusCode`), distinct from `api_calls[].status_code` which
-   * records freee API responses to us. Datadog facets that overload these
-   * across both directions need to disambiguate via `errors[].source`.
+   * Safety net for middleware (e.g. MCP SDK bearerAuth) that calls
+   * `res.status().json()` directly, bypassing the Express error handler and
+   * leaving `errors[]` empty. No-op when `errors[]` is already non-empty.
    */
   synthesizeFallbackErrorIfMissing(status: number): void {
     if (this.errors.length > 0) return;
@@ -207,21 +177,14 @@ export class RequestRecorder {
     });
   }
 
-  /**
-   * Return true on the first call, false afterwards. Used by the HTTP
-   * middleware to ensure the canonical log line is emitted exactly once
-   * even when both `res.on('finish')` and `res.on('close')` fire.
-   */
+  /** Returns true on the first call, false afterwards — guards the finish/close race. */
   flushOnce(): boolean {
     if (this.flushed) return false;
     this.flushed = true;
     return true;
   }
 
-  /**
-   * Build the canonical log line payload. Does not emit anything — the
-   * caller is responsible for passing this object to pino.
-   */
+  /** Builds the canonical log payload; caller passes it to pino. */
   buildPayload(http: { status: number; duration_ms: number }): CanonicalLogPayload {
     return {
       request_id: this.context.request_id,
@@ -250,14 +213,7 @@ export class RequestRecorder {
 
 const requestContextStorage = new AsyncLocalStorage<RequestRecorder>();
 
-/**
- * Returns the RequestRecorder associated with the current async context,
- * or `undefined` if called outside any request (CLI mode, server startup,
- * background tasks).
- *
- * Callers must treat this as optional and use the `?.` operator:
- *   getCurrentRecorder()?.recordApiCall({...})
- */
+/** Returns the recorder for the current async context, or `undefined` outside a request. */
 export function getCurrentRecorder(): RequestRecorder | undefined {
   return requestContextStorage.getStore();
 }
@@ -265,11 +221,9 @@ export function getCurrentRecorder(): RequestRecorder | undefined {
 /**
  * Derive `query_keys` for `ApiCallInfo` from a params object.
  *
- * PRIVACY: key names only, never values. Names are stable per endpoint
- * (`limit`, `type`, etc.), so they are safe to facet on in Datadog.
- * Returns `undefined` when no recorder is installed (CLI mode) or when
- * the params object has no keys, so Datadog doesn't index an empty-array
- * facet.
+ * PRIVACY: key names only, never values. Returns `undefined` when no recorder
+ * is installed (CLI mode) or when params has no keys, so Datadog doesn't
+ * index an empty-array facet.
  */
 export function deriveQueryKeys(
   recorder: RequestRecorder | undefined,
@@ -280,11 +234,7 @@ export function deriveQueryKeys(
   return keys.length > 0 ? keys : undefined;
 }
 
-/**
- * Run `fn` with `recorder` installed as the current request recorder.
- * All downstream async operations will see the recorder via
- * `getCurrentRecorder()` for the lifetime of the returned promise.
- */
+/** Runs `fn` with `recorder` as the current request recorder in AsyncLocalStorage. */
 export function withRequestRecorder<T>(recorder: RequestRecorder, fn: () => T): T {
   return requestContextStorage.run(recorder, fn);
 }

--- a/src/telemetry/middleware.test.ts
+++ b/src/telemetry/middleware.test.ts
@@ -356,6 +356,96 @@ describe('createTracingMiddleware - canonical log line', () => {
     expect(logWarn).toHaveBeenCalledTimes(1);
   });
 
+  it('synthesizes a fallback errors[0] for 5xx when no recordError was called', async () => {
+    const { UNRECORDED_ERROR_TYPE } = await import('../server/request-context.js');
+    const { logError, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(500).json({ error: 'opaque' });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logError.mock.calls[0] as [Record<string, unknown>];
+    const errors = payload.errors as Array<Record<string, unknown>>;
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      source: 'response',
+      status_code: 500,
+      error_type: UNRECORDED_ERROR_TYPE,
+    });
+  });
+
+  it('synthesizes a fallback errors[0] for 4xx as well, not only 5xx', async () => {
+    const { UNRECORDED_ERROR_TYPE } = await import('../server/request-context.js');
+    const { logWarn, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(401).json({ error: 'unauthorized' });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logWarn.mock.calls[0] as [Record<string, unknown>];
+    const errors = payload.errors as Array<Record<string, unknown>>;
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      source: 'response',
+      status_code: 401,
+      error_type: UNRECORDED_ERROR_TYPE,
+    });
+  });
+
+  it('does NOT synthesize a fallback when an explicit recordError was already called', async () => {
+    type Recorder = import('../server/request-context.js').RequestRecorder;
+    const { logError, app } = await setupAppWithLoggerSpy((req, res) => {
+      const recorder = (req as unknown as { recorder?: Recorder }).recorder;
+      recorder?.recordError({
+        source: 'redis_unavailable',
+        status_code: 503,
+        error_type: 'redis_unavailable',
+        chain: [{ name: 'RedisUnavailableError', message: 'down' }],
+      });
+      res.status(503).json({ error: 'service_unavailable' });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logError.mock.calls[0] as [Record<string, unknown>];
+    const errors = payload.errors as Array<Record<string, unknown>>;
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.source).toBe('redis_unavailable');
+  });
+
+  it('does NOT synthesize a fallback for 2xx responses', async () => {
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logInfo.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.errors).toEqual([]);
+  });
+
+  it('does NOT synthesize a fallback for 3xx redirects', async () => {
+    // Locks the gate at status >= 400 so OAuth redirects never get flagged.
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(302).set('Location', '/somewhere').end();
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logInfo.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.errors).toEqual([]);
+  });
+
   it('flushes only once even if both finish and close events fire', async () => {
     const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
       res.status(200).json({ ok: true });

--- a/src/telemetry/middleware.ts
+++ b/src/telemetry/middleware.ts
@@ -137,6 +137,12 @@ export function createTracingMiddleware(): (
       const durationMs = Math.round(performance.now() - startTime);
       const status = res.statusCode;
 
+      // Safety net for the canonical-log "1 line = full debug context"
+      // promise. See RequestRecorder.synthesizeFallbackErrorIfMissing.
+      if (status >= 400) {
+        recorder.synthesizeFallbackErrorIfMissing(status);
+      }
+
       const payload = recorder.buildPayload({ status, duration_ms: durationMs });
       const message = messageFor(status);
       const level = levelFor(status);


### PR DESCRIPTION
## 概要

Express エラーハンドラを bypass する third-party middleware（例: MCP SDK bearerAuth）が `res.status().json()` で直接 4xx/5xx を送出した場合に、canonical log の `errors[]` が空のまま emit される問題を修正する。

主な変更:

- `RequestRecorder.synthesizeFallbackErrorIfMissing(status)` を新設: `errors[]` が空かつ status >= 400 の場合に `source: "response"`, `error_type: "unrecorded"` の placeholder ErrorInfo を合成
- `UNRECORDED_ERROR_TYPE` / `UNRECORDED_ERROR_NAME` 定数をエクスポート: Datadog operator のフィルタ (`@errors.error_type:unrecorded`) とテストが同一シンボルを参照できる
- `createTracingMiddleware` の `flushOnce()` 内で `status >= 400` 時に上記メソッドを呼び出す
- 明示的な `recordError` が呼ばれた場合は fallback は no-op になるため、既存の挙動に影響なし
- 7 件のテストを追加（合成・no-op・2xx/3xx スキップ・冪等性）

## 変更種別

- [ ] 新機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他

## 動作確認方法

```bash
bun run test:run -- src/server/request-context.test.ts
bun run test:run -- src/telemetry/middleware.test.ts
```

`errors[]` が空でなく `error_type: "unrecorded"` の entry が入っていることを確認。Datadog では `@errors.error_type:unrecorded` でフィルタすることで、`recordError` を呼ばずに 4xx/5xx を送出した middleware のリクエストを特定できる。