### PR TITLE
add sign remote mcp

### DIFF
--- a/.changeset/sign-remote-mcp.md
+++ b/.changeset/sign-remote-mcp.md
@@ -1,0 +1,14 @@
+---
+"freee-mcp": minor
+---
+
+Sign Remote MCP サーバーを追加
+
+freee サイン用の Remote MCP サーバー（`freee-sign-remote-mcp`）を追加。freee 本体と同一構成で OAuth 2.1 Authorization Server + Streamable HTTP transport + Redis トークンストア + canonical log line + OTel tracing をサポート。
+
+- 新規エントリポイント `bin/freee-sign-remote-mcp.js`（ポート 3002）
+- ninja-sign.com との OAuth 2.0 code exchange + MCP クライアント向け OAuth 2.1 AS の二層認証
+- Redis 分離: freee 本体は DB 0 / Sign は DB 1、キー prefix `freee-sign-mcp:*` で名前空間分離
+- rate-limit キーも `rl:sign:*` prefix で freee 本体のカウンタと衝突しないよう分離
+- トークン交換失敗時のエラー本文は先頭 200 文字に truncate して PII 漏洩を防止
+- Docker Compose に `freee-sign-mcp` サービス追加、`Dockerfile.sign` でビルド分離

--- a/.changeset/sign-remote-mcp.md
+++ b/.changeset/sign-remote-mcp.md
@@ -10,18 +10,26 @@ freee サイン用の Remote MCP サーバー（`freee-sign-remote-mcp`）を追
 - ninja-sign.com との OAuth 2.0 code exchange + MCP クライアント向け OAuth 2.1 AS の二層認証
 - Docker Compose に `freee-sign-mcp` サービス追加、`Dockerfile.sign` でビルド分離
 
-## freee 本体との分離
+## 共有 Valkey での分離
 
-共有インフラを Sign と freee 本体が使う構成のため、片方が他方に波及しないよう以下で分離:
+本番で Sign と freee 本体が共有する Valkey インスタンスの名前空間を以下で分離:
 
 - Redis の DB (freee 本体 DB 0 / Sign DB 1) とキー prefix (`freee-sign-mcp:*`) で名前空間分離
 - rate-limit キーに `rl:sign:*` prefix を付与し freee 本体とカウンタ合算を防止
-- Redis の `maxmemory-policy` を `noeviction` に変更し、全 DB 合算の LRU eviction で freee 本体の refresh token / DCR client が巻き添え削除される事態を防止
-- OTel Collector に `memory_limiter` / `batch` processor を追加し、Sign のバーストで freee 本体 trace がサイレント drop する事態を防止
+
+本番 Valkey は parameter group で `maxmemory-policy` 未設定のため Valkey デフォルト (`noeviction`) で稼働しており、cross-DB eviction は発生しない想定。
+
+## ローカル開発環境の調整
+
+`compose.yaml` / `otel-collector-config.yaml` を本番挙動と整合させる:
+
+- Redis の `maxmemory-policy` を `noeviction` に変更し、本番 Valkey と同じ挙動でローカル検証できるようにする
+- OTel Collector に `memory_limiter` / `batch` processor を追加し、compose で Sign + freee が単一 collector を共有する開発環境の trace 欠落を防止（本番は Datadog Agent が Node 単位で OTLP を受ける構成のため該当しない）
 
 ## セキュリティ
 
 - `sign_api_*` ツールの path を `/v1/` 始まりに制限し、絶対 URL 経由で Bearer トークンが外部ホストへ流出する SSRF 経路を遮断
+- path traversal (`..` / `%2e%2e`) を Zod と URL 組み立て後の pathname 再検証で拒否し、ninja-sign.com 内の `/v1/` 外エンドポイントへの到達を防止
 - Remote モードで認証コンテキストが取れない場合に local filesystem のトークンへ fallback する経路を禁止し、impersonation を防止
 - ninja-sign.com との通信エラー本文を先頭 200 文字に truncate して PII 漏洩を防止
 - `/v1/users/me` レスポンスを Zod schema で検証し、id の型不正による Redis キー衝突を防止

--- a/.changeset/sign-remote-mcp.md
+++ b/.changeset/sign-remote-mcp.md
@@ -8,7 +8,20 @@ freee サイン用の Remote MCP サーバー（`freee-sign-remote-mcp`）を追
 
 - 新規エントリポイント `bin/freee-sign-remote-mcp.js`（ポート 3002）
 - ninja-sign.com との OAuth 2.0 code exchange + MCP クライアント向け OAuth 2.1 AS の二層認証
-- Redis 分離: freee 本体は DB 0 / Sign は DB 1、キー prefix `freee-sign-mcp:*` で名前空間分離
-- rate-limit キーも `rl:sign:*` prefix で freee 本体のカウンタと衝突しないよう分離
-- トークン交換失敗時のエラー本文は先頭 200 文字に truncate して PII 漏洩を防止
 - Docker Compose に `freee-sign-mcp` サービス追加、`Dockerfile.sign` でビルド分離
+
+## freee 本体との分離
+
+共有インフラを Sign と freee 本体が使う構成のため、片方が他方に波及しないよう以下で分離:
+
+- Redis の DB (freee 本体 DB 0 / Sign DB 1) とキー prefix (`freee-sign-mcp:*`) で名前空間分離
+- rate-limit キーに `rl:sign:*` prefix を付与し freee 本体とカウンタ合算を防止
+- Redis の `maxmemory-policy` を `noeviction` に変更し、全 DB 合算の LRU eviction で freee 本体の refresh token / DCR client が巻き添え削除される事態を防止
+- OTel Collector に `memory_limiter` / `batch` processor を追加し、Sign のバーストで freee 本体 trace がサイレント drop する事態を防止
+
+## セキュリティ
+
+- `sign_api_*` ツールの path を `/v1/` 始まりに制限し、絶対 URL 経由で Bearer トークンが外部ホストへ流出する SSRF 経路を遮断
+- Remote モードで認証コンテキストが取れない場合に local filesystem のトークンへ fallback する経路を禁止し、impersonation を防止
+- ninja-sign.com との通信エラー本文を先頭 200 文字に truncate して PII 漏洩を防止
+- `/v1/users/me` レスポンスを Zod schema で検証し、id の型不正による Redis キー衝突を防止

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@ node_modules
 dist
 bin/freee-mcp.js
 bin/freee-remote-mcp.js
+bin/freee-sign-remote-mcp.js
 coverage
 obs
 *.md

--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,7 @@ out
 **/bin/freee-mcp.js
 **/bin/freee-remote-mcp.js
 **/bin/freee-sign-mcp.js
+**/bin/freee-sign-remote-mcp.js
 
 # Local Docker build helpers
 Dockerfile.local

--- a/Dockerfile.sign
+++ b/Dockerfile.sign
@@ -1,0 +1,20 @@
+FROM oven/bun:1.3-alpine AS builder
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --ignore-scripts
+COPY . .
+RUN bun run build
+
+FROM oven/bun:1.3-alpine
+RUN addgroup -g 65532 -S nonroot && adduser -u 65532 -S nonroot -G nonroot
+WORKDIR /app
+COPY --from=builder /app/bin ./bin
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/openapi/minimal ./openapi/minimal
+USER 65532:65532
+EXPOSE 3002
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \
+  CMD wget -q --spider http://localhost:3002/health || exit 1
+CMD ["bun", "run", "bin/freee-sign-remote-mcp.js"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
-# image_assembly_line が target: . で呼び出すためデフォルトターゲット名を維持
-.PHONY: . build\:sign
+.PHONY: build\:main build\:sign
 
-.:
+build\:main:
 	docker build -t $(IMAGE_NAME):$(VERSION_TAG) -f Dockerfile .
 
 build\:sign:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: .
+# image_assembly_line が target: . で呼び出すためデフォルトターゲット名を維持
+.PHONY: . build\:sign
 
 .:
 	docker build -t $(IMAGE_NAME):$(VERSION_TAG) -f Dockerfile .
+
+build\:sign:
+	docker build -t $(IMAGE_NAME):$(VERSION_TAG) -f Dockerfile.sign .

--- a/build.ts
+++ b/build.ts
@@ -6,6 +6,7 @@ const entries = [
   { entrypoint: 'src/index.ts', output: './bin/freee-mcp.js' },
   { entrypoint: 'src/entry-remote.ts', output: './bin/freee-remote-mcp.js' },
   { entrypoint: 'src/sign/index.ts', output: './bin/freee-sign-mcp.js' },
+  { entrypoint: 'src/sign/entry-remote.ts', output: './bin/freee-sign-remote-mcp.js' },
 ];
 
 for (const { entrypoint, output } of entries) {

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,6 +21,27 @@ services:
           cpus: "2"
     restart: unless-stopped
 
+  freee-sign-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile.sign
+    ports:
+      - "3002:3002"
+    env_file: .env
+    environment:
+      OTEL_ENABLED: "true"
+      OTEL_SERVICE_NAME: freee-sign-mcp
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+    depends_on:
+      redis:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "2"
+    restart: unless-stopped
+
   redis:
     image: redis:7-alpine
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -50,7 +50,10 @@ services:
       - "6379:6379"
     volumes:
       - redis-data:/data
-    command: redis-server --maxmemory 256mb --maxmemory-policy allkeys-lru
+    # allkeys-lru は全 DB 合算で evict するため、Sign (DB 1) のバーストが freee 本体 (DB 0) の
+    # refresh token / DCR client を巻き添え eviction する。本番障害を避けるため noeviction で
+    # OOM を書き込みエラーとして顕在化し、fail-fast で検知する運用にする
+    command: redis-server --maxmemory 256mb --maxmemory-policy noeviction
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s

--- a/compose.yaml
+++ b/compose.yaml
@@ -29,6 +29,8 @@ services:
       - "3002:3002"
     env_file: .env
     environment:
+      # 共有 Redis を freee 本体 (DB 0) と論理分離するため DB 1 を明示
+      SIGN_REDIS_URL: redis://redis:6379/1
       OTEL_ENABLED: "true"
       OTEL_SERVICE_NAME: freee-sign-mcp
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318

--- a/openapi/minimal/sign.json
+++ b/openapi/minimal/sign.json
@@ -538,6 +538,12 @@
         "hasJsonBody": true
       }
     },
+    "/v1/users/me": {
+      "get": {
+        "summary": "認証中のユーザー情報の取得",
+        "description": "現在認証しているユーザーの情報を取得する。\n\nOAuth 2.0認証でのみ利用可能です。APIクライアント（アクセストークン認証）では利用できません。"
+      }
+    },
     "/v1/users/{user_id}/activenesses": {
       "delete": {
         "summary": "ユーザーの退会",

--- a/openapi/sign-api-schema.json
+++ b/openapi/sign-api-schema.json
@@ -3799,6 +3799,48 @@
         }
       }
     },
+    "/v1/users/me": {
+      "get": {
+        "summary": "認証中のユーザー情報の取得",
+        "description": "現在認証しているユーザーの情報を取得する。\n\nOAuth 2.0認証でのみ利用可能です。APIクライアント（アクセストークン認証）では利用できません。",
+        "operationId": "get-v1-users-me",
+        "tags": [
+          "ユーザー"
+        ],
+        "responses": {
+          "200": {
+            "description": "取得成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "なんらかのエラーが発生した場合",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/users/{user_id}/activenesses": {
       "parameters": [
         {

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -4,11 +4,26 @@ receivers:
       http:
         endpoint: 0.0.0.0:4318
 
+processors:
+  # Sign (freee-sign-mcp) と freee 本体 (freee-mcp) が同一 collector を共有するため、
+  # 片方のバーストで他方の span/metric がサイレント drop しないよう memory_limiter と
+  # batch を挟む。check_interval=5s / limit=200MiB は collector 自体のメモリ 256MiB 想定
+  memory_limiter:
+    check_interval: 5s
+    limit_mib: 200
+    spike_limit_mib: 50
+  batch:
+    send_batch_size: 512
+    timeout: 5s
+
 exporters:
   otlp/jaeger:
     endpoint: jaeger:4317
     tls:
       insecure: true
+    sending_queue:
+      enabled: true
+      queue_size: 1000
   prometheus:
     endpoint: 0.0.0.0:8889
 
@@ -16,7 +31,9 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
+      processors: [memory_limiter, batch]
       exporters: [otlp/jaeger]
     metrics:
       receivers: [otlp]
+      processors: [memory_limiter, batch]
       exporters: [prometheus]

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "bin": {
     "freee-mcp": "./bin/freee-mcp.js",
     "freee-remote-mcp": "./bin/freee-remote-mcp.js",
-    "freee-sign-mcp": "./bin/freee-sign-mcp.js"
+    "freee-sign-mcp": "./bin/freee-sign-mcp.js",
+    "freee-sign-remote-mcp": "./bin/freee-sign-remote-mcp.js"
   },
   "scripts": {
-    "clean": "rm -rf dist bin/freee-mcp.js bin/freee-remote-mcp.js bin/freee-sign-mcp.js",
+    "clean": "rm -rf dist bin/freee-mcp.js bin/freee-remote-mcp.js bin/freee-sign-mcp.js bin/freee-sign-remote-mcp.js",
     "build": "bun run build.ts",
     "prepare": "bun run build",
     "start": "bun run src/index.ts",

--- a/skills/freee-api-skill/sign-references/sign-users.md
+++ b/skills/freee-api-skill/sign-references/sign-users.md
@@ -138,6 +138,32 @@
   - lastname (任意): string - 姓 例: `フリー`
   - affiliation (任意): string - 部署・役職 例: `法務部`
 
+### GET /v1/users/me
+
+操作: 認証中のユーザー情報の取得
+
+説明: 現在認証しているユーザーの情報を取得する。 OAuth 2.0認証でのみ利用可能です。APIクライアント（アクセストークン認証）では利用できません。
+
+### レスポンス (200)
+
+取得成功
+
+- id (必須): object - ユーザーID
+- team_id (任意): object - チームID。本登録していないユーザーはチームに所属していない。
+- status (必須): string - ユーザーのステータス
+* receiving_only - 文書を受領した未登録ユーザー
+* active - 登録済ユーザー
+* unconfirmed - 登録途中ユーザー
+* canceled - 退会済ユーザー (選択肢: receiving_only, active, unconfirmed, canceled)
+- email (任意): string(email) - メールアドレス
+
+メールアドレスの登録がない場合は無し。
+- sms_telephone_number (任意): string - SMS用の電話番号
+
+E.164形式。登録されていない場合は無し。
+ex. +8190xxxxxxxx
+- full_name (任意): string - フルネーム。本登録していないユーザーは無い。
+
 ### DELETE /v1/users/{user_id}/activenesses
 
 操作: ユーザーの退会

--- a/src/server/client-store.ts
+++ b/src/server/client-store.ts
@@ -13,6 +13,7 @@ const CLIENT_TTL_SECONDS = 365 * 24 * 60 * 60; // 1 year
 export interface ClientStoreOptions {
   redis: Redis;
   cimdFetcher?: CIMDFetcher;
+  prefix?: string;
 }
 
 function isCimdUrl(clientId: string): boolean {
@@ -22,10 +23,12 @@ function isCimdUrl(clientId: string): boolean {
 export class RedisClientStore implements OAuthRegisteredClientsStore {
   private readonly redis: Redis;
   private readonly cimdFetcher: CIMDFetcher;
+  private readonly prefix: string;
 
   constructor(options: ClientStoreOptions) {
     this.redis = options.redis;
     this.cimdFetcher = options.cimdFetcher ?? new HttpCIMDFetcher();
+    this.prefix = options.prefix ?? OAUTH_KEY_PREFIX;
   }
 
   async getClient(clientId: string): Promise<OAuthClientInformationFull | undefined> {
@@ -38,7 +41,7 @@ export class RedisClientStore implements OAuthRegisteredClientsStore {
   async registerClient(client: OAuthClientInformationFull): Promise<OAuthClientInformationFull> {
     await withRedis('registerClient', () =>
       this.redis.set(
-        `${OAUTH_KEY_PREFIX}:client:${client.client_id}`,
+        `${this.prefix}:client:${client.client_id}`,
         JSON.stringify(client),
         'EX',
         CLIENT_TTL_SECONDS,
@@ -51,7 +54,7 @@ export class RedisClientStore implements OAuthRegisteredClientsStore {
     clientIdUrl: string,
   ): Promise<OAuthClientInformationFull | undefined> {
     const hash = hashCimdUrl(clientIdUrl);
-    const cacheKey = `${OAUTH_KEY_PREFIX}:cimd:${hash}`;
+    const cacheKey = `${this.prefix}:cimd:${hash}`;
 
     const cached = await withRedis('getCimdClient:cache-read', () => this.redis.get(cacheKey));
 
@@ -80,7 +83,7 @@ export class RedisClientStore implements OAuthRegisteredClientsStore {
   }
 
   private async getDcrClient(clientId: string): Promise<OAuthClientInformationFull | undefined> {
-    const key = `${OAUTH_KEY_PREFIX}:client:${clientId}`;
+    const key = `${this.prefix}:client:${clientId}`;
     const raw = await withRedis('getDcrClient:read', () => this.redis.get(key));
     if (!raw) return undefined;
 

--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -8,6 +8,7 @@ export type Logger = pino.Logger;
 export interface LoggerOptions {
   level?: string;
   transportMode?: 'stdio' | 'remote';
+  serviceName?: string;
 }
 
 let _logger: pino.Logger | null = null;
@@ -106,7 +107,11 @@ const LEVEL_FORMATTER: NonNullable<pino.LoggerOptions['formatters']>['level'] = 
   level: label,
 });
 
-function buildBaseOptions(level: string, transportMode: 'stdio' | 'remote'): pino.LoggerOptions {
+function buildBaseOptions(
+  level: string,
+  transportMode: 'stdio' | 'remote',
+  serviceName?: string,
+): pino.LoggerOptions {
   return {
     level,
     mixin: otelMixin,
@@ -114,7 +119,7 @@ function buildBaseOptions(level: string, transportMode: 'stdio' | 'remote'): pin
     serializers: { err: errSerializer },
     redact: REDACT_OPTIONS,
     base: {
-      service: APP_NAME,
+      service: serviceName ?? APP_NAME,
       version: PACKAGE_VERSION,
       transport_mode: transportMode,
     },
@@ -126,17 +131,14 @@ export function initLogger(levelOrOptions?: string | LoggerOptions): pino.Logger
   const level = options.level || process.env.LOG_LEVEL || 'info';
   const transportMode = options.transportMode ?? 'stdio';
 
-  _logger = pino(buildBaseOptions(level, transportMode), getStderrDest());
+  _logger = pino(buildBaseOptions(level, transportMode, options.serviceName), getStderrDest());
 
   return _logger;
 }
 
 export function getLogger(): pino.Logger {
   if (!_logger) {
-    _logger = pino(
-      buildBaseOptions(process.env.LOG_LEVEL || 'info', 'stdio'),
-      getStderrDest(),
-    );
+    _logger = pino(buildBaseOptions(process.env.LOG_LEVEL || 'info', 'stdio'), getStderrDest());
   }
   return _logger;
 }

--- a/src/server/oauth-store.ts
+++ b/src/server/oauth-store.ts
@@ -41,14 +41,17 @@ function tryParseJson<T>(raw: string, label: string): T | null {
 }
 
 export class OAuthStateStore {
-  constructor(private readonly redis: Redis) {}
+  constructor(
+    private readonly redis: Redis,
+    private readonly prefix: string = OAUTH_KEY_PREFIX,
+  ) {}
 
   // --- Sessions ---
 
   async saveSession(id: string, data: OAuthSessionData): Promise<void> {
     await withRedis('saveSession', () =>
       this.redis.set(
-        `${OAUTH_KEY_PREFIX}:session:${id}`,
+        `${this.prefix}:session:${id}`,
         JSON.stringify(data),
         'EX',
         SESSION_TTL_SECONDS,
@@ -58,7 +61,7 @@ export class OAuthStateStore {
 
   async consumeSession(id: string): Promise<OAuthSessionData | null> {
     const raw = await withRedis('consumeSession', () =>
-      this.redis.getdel(`${OAUTH_KEY_PREFIX}:session:${id}`),
+      this.redis.getdel(`${this.prefix}:session:${id}`),
     );
     if (!raw) return null;
     return tryParseJson<OAuthSessionData>(raw, 'session');
@@ -69,7 +72,7 @@ export class OAuthStateStore {
   async saveAuthCode(code: string, data: AuthCodeData): Promise<void> {
     await withRedis('saveAuthCode', () =>
       this.redis.set(
-        `${OAUTH_KEY_PREFIX}:code:${code}`,
+        `${this.prefix}:code:${code}`,
         JSON.stringify(data),
         'EX',
         AUTH_CODE_TTL_SECONDS,
@@ -78,16 +81,14 @@ export class OAuthStateStore {
   }
 
   async getAuthCode(code: string): Promise<AuthCodeData | null> {
-    const raw = await withRedis('getAuthCode', () =>
-      this.redis.get(`${OAUTH_KEY_PREFIX}:code:${code}`),
-    );
+    const raw = await withRedis('getAuthCode', () => this.redis.get(`${this.prefix}:code:${code}`));
     if (!raw) return null;
     return tryParseJson<AuthCodeData>(raw, 'authCode');
   }
 
   async consumeAuthCode(code: string): Promise<AuthCodeData | null> {
     const raw = await withRedis('consumeAuthCode', () =>
-      this.redis.getdel(`${OAUTH_KEY_PREFIX}:code:${code}`),
+      this.redis.getdel(`${this.prefix}:code:${code}`),
     );
     if (!raw) return null;
     return tryParseJson<AuthCodeData>(raw, 'authCode');
@@ -98,7 +99,7 @@ export class OAuthStateStore {
   async saveRefreshToken(token: string, data: RefreshTokenData): Promise<void> {
     await withRedis('saveRefreshToken', () =>
       this.redis.set(
-        `${OAUTH_KEY_PREFIX}:refresh:${token}`,
+        `${this.prefix}:refresh:${token}`,
         JSON.stringify(data),
         'EX',
         REFRESH_TOKEN_TTL_SECONDS,
@@ -108,7 +109,7 @@ export class OAuthStateStore {
 
   async getRefreshToken(token: string): Promise<RefreshTokenData | null> {
     const raw = await withRedis('getRefreshToken', () =>
-      this.redis.get(`${OAUTH_KEY_PREFIX}:refresh:${token}`),
+      this.redis.get(`${this.prefix}:refresh:${token}`),
     );
     if (!raw) return null;
     return tryParseJson<RefreshTokenData>(raw, 'refreshToken');
@@ -116,15 +117,13 @@ export class OAuthStateStore {
 
   async consumeRefreshToken(token: string): Promise<RefreshTokenData | null> {
     const raw = await withRedis('consumeRefreshToken', () =>
-      this.redis.getdel(`${OAUTH_KEY_PREFIX}:refresh:${token}`),
+      this.redis.getdel(`${this.prefix}:refresh:${token}`),
     );
     if (!raw) return null;
     return tryParseJson<RefreshTokenData>(raw, 'refreshToken');
   }
 
   async revokeRefreshToken(token: string): Promise<void> {
-    await withRedis('revokeRefreshToken', () =>
-      this.redis.del(`${OAUTH_KEY_PREFIX}:refresh:${token}`),
-    );
+    await withRedis('revokeRefreshToken', () => this.redis.del(`${this.prefix}:refresh:${token}`));
   }
 }

--- a/src/sign/client.test.ts
+++ b/src/sign/client.test.ts
@@ -154,6 +154,21 @@ describe('sign/client', () => {
       );
     });
 
+    it('path traversal (`..` / `%2e%2e`) は /v1/ 外への遷移を許すため拒否される', async () => {
+      const { getValidSignAccessToken } = await import('./tokens.js');
+      vi.mocked(getValidSignAccessToken).mockResolvedValue('test-token');
+
+      await expect(
+        makeSignApiRequest('GET', '/v1/../../../admin/secret'),
+      ).rejects.toThrow('/v1/ namespace 外への遷移は許可されていません');
+      await expect(makeSignApiRequest('GET', '/v1/documents/../../admin')).rejects.toThrow(
+        '/v1/ namespace 外への遷移は許可されていません',
+      );
+      await expect(makeSignApiRequest('GET', '/v1/%2e%2e/admin')).rejects.toThrow(
+        '/v1/ namespace 外への遷移は許可されていません',
+      );
+    });
+
     it('空配列レスポンスが正常に処理される', async () => {
       const { getValidSignAccessToken } = await import('./tokens.js');
       vi.mocked(getValidSignAccessToken).mockResolvedValue('test-token');

--- a/src/sign/client.test.ts
+++ b/src/sign/client.test.ts
@@ -139,25 +139,19 @@ describe('sign/client', () => {
   });
 
   describe('エッジケース', () => {
-    it('API path 先頭スラッシュ有無が正規化される', async () => {
+    it('絶対 URL path は Bearer トークンを外部ホストへ流出させないため拒否される', async () => {
       const { getValidSignAccessToken } = await import('./tokens.js');
       vi.mocked(getValidSignAccessToken).mockResolvedValue('test-token');
 
-      mockFetch.mockResolvedValue({
-        ok: true,
-        status: 200,
-        headers: new Headers({ 'content-type': 'application/json' }),
-        text: () => Promise.resolve('{}'),
-      });
-
-      await makeSignApiRequest('GET', 'v1/documents');
-      const url1 = mockFetch.mock.calls[0][0] as string;
-
-      mockFetch.mockClear();
-      await makeSignApiRequest('GET', '/v1/documents');
-      const url2 = mockFetch.mock.calls[0][0] as string;
-
-      expect(url1).toBe(url2);
+      await expect(
+        makeSignApiRequest('GET', 'https://attacker.example.com/leak'),
+      ).rejects.toThrow('Invalid Sign API path');
+      await expect(makeSignApiRequest('GET', '//attacker.example.com/leak')).rejects.toThrow(
+        'Invalid Sign API path',
+      );
+      await expect(makeSignApiRequest('GET', 'v1/documents')).rejects.toThrow(
+        'Invalid Sign API path',
+      );
     });
 
     it('空配列レスポンスが正常に処理される', async () => {

--- a/src/sign/client.test.ts
+++ b/src/sign/client.test.ts
@@ -106,9 +106,7 @@ describe('sign/client', () => {
       const { getValidSignAccessToken } = await import('./tokens.js');
       vi.mocked(getValidSignAccessToken).mockResolvedValue(null);
 
-      await expect(makeSignApiRequest('GET', '/v1/documents')).rejects.toThrow(
-        'sign_authenticate',
-      );
+      await expect(makeSignApiRequest('GET', '/v1/documents')).rejects.toThrow('sign_authenticate');
     });
 
     it('401 → 再認証誘導', async () => {
@@ -121,9 +119,7 @@ describe('sign/client', () => {
         json: () => Promise.resolve({ error: 'unauthorized' }),
       });
 
-      await expect(makeSignApiRequest('GET', '/v1/documents')).rejects.toThrow(
-        'sign_authenticate',
-      );
+      await expect(makeSignApiRequest('GET', '/v1/documents')).rejects.toThrow('sign_authenticate');
     });
 
     it('400 → エラー詳細が含まれる', async () => {
@@ -196,11 +192,73 @@ describe('sign/client', () => {
     });
   });
 
+  describe('tokenContext', () => {
+    it('tokenContext 未指定時は getValidSignAccessToken が呼ばれる', async () => {
+      const { getValidSignAccessToken } = await import('./tokens.js');
+      vi.mocked(getValidSignAccessToken).mockResolvedValue('file-token');
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve(JSON.stringify({ ok: true })),
+      });
+
+      await makeSignApiRequest('GET', '/v1/documents');
+
+      expect(getValidSignAccessToken).toHaveBeenCalled();
+      expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe('Bearer file-token');
+    });
+
+    it('tokenContext 指定時は tokenStore.getValidAccessToken が呼ばれる', async () => {
+      const { getValidSignAccessToken } = await import('./tokens.js');
+      vi.mocked(getValidSignAccessToken).mockResolvedValue(null);
+
+      const mockTokenStore = {
+        getValidAccessToken: vi.fn().mockResolvedValue('redis-token'),
+        loadTokens: vi.fn(),
+        saveTokens: vi.fn(),
+        clearTokens: vi.fn(),
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: () => Promise.resolve(JSON.stringify({ ok: true })),
+      });
+
+      await makeSignApiRequest('GET', '/v1/documents', undefined, undefined, {
+        userId: 'user-1',
+        tokenStore: mockTokenStore,
+      });
+
+      expect(getValidSignAccessToken).not.toHaveBeenCalled();
+      expect(mockTokenStore.getValidAccessToken).toHaveBeenCalledWith('user-1');
+      expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe('Bearer redis-token');
+    });
+
+    it('tokenContext 指定時で tokenStore が null を返す → 認証エラー', async () => {
+      const mockTokenStore = {
+        getValidAccessToken: vi.fn().mockResolvedValue(null),
+        loadTokens: vi.fn(),
+        saveTokens: vi.fn(),
+        clearTokens: vi.fn(),
+      };
+
+      await expect(
+        makeSignApiRequest('GET', '/v1/documents', undefined, undefined, {
+          userId: 'user-1',
+          tokenStore: mockTokenStore,
+        }),
+      ).rejects.toThrow('認証が必要です');
+    });
+  });
+
   describe('canonical log の query_keys 連携', () => {
     it('クエリキー名のみが api.calls[].query_keys に記録され、値は流出しない', async () => {
-      // Sign client のプライバシーガード:
       // makeSignApiRequest 経由でも api.calls[].query_keys にキー名のみが
-      // 入り、値は絶対にペイロードへ漏れないことを保証する。
+      // 入り、値はペイロードに漏れないことを保証する
       const { getValidSignAccessToken } = await import('./tokens.js');
       vi.mocked(getValidSignAccessToken).mockResolvedValue('test-token');
 
@@ -211,9 +269,7 @@ describe('sign/client', () => {
         text: () => Promise.resolve('[]'),
       });
 
-      const { RequestRecorder, withRequestRecorder } = await import(
-        '../server/request-context.js'
-      );
+      const { RequestRecorder, withRequestRecorder } = await import('../server/request-context.js');
       const recorder = new RequestRecorder({
         request_id: 'req-sign-success',
         source_ip: '127.0.0.1',
@@ -234,7 +290,6 @@ describe('sign/client', () => {
         error_type: null,
         query_keys: ['page', 'per'],
       });
-      // Query values must never leak into the payload.
       const serialized = JSON.stringify(apiCalls[0]);
       expect(serialized).not.toContain('page=1');
       expect(serialized).not.toContain('per=10');
@@ -242,7 +297,7 @@ describe('sign/client', () => {
       expect(serialized).not.toMatch(/"10"/);
     });
 
-    it('params が {} のときは query_keys を記録しない (空配列を index しない)', async () => {
+    it('params が {} のときは query_keys を記録しない', async () => {
       const { getValidSignAccessToken } = await import('./tokens.js');
       vi.mocked(getValidSignAccessToken).mockResolvedValue('test-token');
 
@@ -253,9 +308,7 @@ describe('sign/client', () => {
         text: () => Promise.resolve('{}'),
       });
 
-      const { RequestRecorder, withRequestRecorder } = await import(
-        '../server/request-context.js'
-      );
+      const { RequestRecorder, withRequestRecorder } = await import('../server/request-context.js');
       const recorder = new RequestRecorder({
         request_id: 'req-sign-empty-params',
         source_ip: '127.0.0.1',
@@ -263,9 +316,7 @@ describe('sign/client', () => {
         path: '/mcp',
       });
 
-      await withRequestRecorder(recorder, () =>
-        makeSignApiRequest('GET', '/v1/documents', {}),
-      );
+      await withRequestRecorder(recorder, () => makeSignApiRequest('GET', '/v1/documents', {}));
 
       const payload = recorder.buildPayload({ status: 200, duration_ms: 1 });
       const apiCalls = payload.api.calls as Array<Record<string, unknown>>;

--- a/src/sign/client.ts
+++ b/src/sign/client.ts
@@ -47,6 +47,12 @@ export async function makeSignApiRequest(
   const normalizedPath = apiPath.slice(1);
   const url = new URL(normalizedPath, normalizedBase);
 
+  // Zod schema で弾かれる想定だが、`..` / `%2e%2e` が URL normalize 後に /v1/ 外へ逸脱していないか
+  // 最終 pathname で再検証する (ninja-sign.com 内の管理エンドポイント到達を阻止する二重防御)
+  if (!url.pathname.startsWith('/v1/')) {
+    throw new Error('Invalid Sign API path: /v1/ namespace 外への遷移は許可されていません');
+  }
+
   if (params) {
     for (const [key, value] of Object.entries(params)) {
       if (value !== undefined) {

--- a/src/sign/client.ts
+++ b/src/sign/client.ts
@@ -27,16 +27,24 @@ export async function makeSignApiRequest(
   const safePath = sanitizePath(apiPath);
   const queryKeys = deriveQueryKeys(recorder, params);
 
+  // tools.ts の schema regex に加え、defense-in-depth で client 層でも絶対 URL / protocol-relative を拒否
+  if (!apiPath.startsWith('/') || apiPath.startsWith('//')) {
+    throw new Error('Invalid Sign API path: /v1/ で始まる相対パスを指定してください');
+  }
+
   const accessToken = tokenContext
     ? await tokenContext.tokenStore.getValidAccessToken(tokenContext.userId)
     : await getValidSignAccessToken();
 
   if (!accessToken) {
-    throw new Error('認証が必要です。sign_authenticate ツールを使用して認証を行ってください。');
+    const hint = tokenContext
+      ? 'MCP クライアントを再接続して認証してください。'
+      : 'sign_authenticate ツールを使用して認証を行ってください。';
+    throw new Error(`認証が必要です。${hint}`);
   }
 
   const normalizedBase = SIGN_API_URL.endsWith('/') ? SIGN_API_URL : `${SIGN_API_URL}/`;
-  const normalizedPath = apiPath.startsWith('/') ? apiPath.slice(1) : apiPath;
+  const normalizedPath = apiPath.slice(1);
   const url = new URL(normalizedPath, normalizedBase);
 
   if (params) {
@@ -100,13 +108,13 @@ export async function makeSignApiRequest(
 
   if (response.status === 401) {
     const errorInfo = await formatResponseErrorInfo(response);
+    const hint = tokenContext
+      ? 'MCP クライアントを再接続して認証してください。'
+      : 'sign_authenticate ツールを使用して再認証を行ってください。';
     recordFailure(
       401,
       'auth_error',
-      new Error(
-        '認証エラーが発生しました。sign_authenticate ツールを使用して再認証を行ってください。\n' +
-          `エラー詳細: ${response.status} ${errorInfo}`,
-      ),
+      new Error(`認証エラーが発生しました。${hint}\nエラー詳細: ${response.status} ${errorInfo}`),
     );
   }
 

--- a/src/sign/client.ts
+++ b/src/sign/client.ts
@@ -7,25 +7,32 @@ import { deriveQueryKeys, getCurrentRecorder } from '../server/request-context.j
 import { getUserAgent } from '../server/user-agent.js';
 import { formatResponseErrorInfo } from '../utils/error.js';
 import { SIGN_API_URL } from './config.js';
+import type { SignTokenStore } from './server/sign-redis-token-store.js';
 import { getValidSignAccessToken } from './tokens.js';
+
+export interface SignTokenContext {
+  userId: string;
+  tokenStore: SignTokenStore;
+}
 
 export async function makeSignApiRequest(
   method: string,
   apiPath: string,
   params?: Record<string, unknown>,
   body?: Record<string, unknown>,
+  tokenContext?: SignTokenContext,
 ): Promise<unknown> {
   const recorder = getCurrentRecorder();
   const startTime = Date.now();
   const safePath = sanitizePath(apiPath);
   const queryKeys = deriveQueryKeys(recorder, params);
 
-  const accessToken = await getValidSignAccessToken();
+  const accessToken = tokenContext
+    ? await tokenContext.tokenStore.getValidAccessToken(tokenContext.userId)
+    : await getValidSignAccessToken();
 
   if (!accessToken) {
-    throw new Error(
-      '認証が必要です。sign_authenticate ツールを使用して認証を行ってください。',
-    );
+    throw new Error('認証が必要です。sign_authenticate ツールを使用して認証を行ってください。');
   }
 
   const normalizedBase = SIGN_API_URL.endsWith('/') ? SIGN_API_URL : `${SIGN_API_URL}/`;
@@ -54,7 +61,9 @@ export async function makeSignApiRequest(
     });
   } catch (fetchError) {
     const errorType: ApiCallErrorType =
-      fetchError instanceof Error && fetchError.name === 'TimeoutError' ? 'timeout' : 'network_error';
+      fetchError instanceof Error && fetchError.name === 'TimeoutError'
+        ? 'timeout'
+        : 'network_error';
     recorder?.recordApiCall({
       method,
       path_pattern: safePath,
@@ -102,8 +111,11 @@ export async function makeSignApiRequest(
   }
 
   if (response.status === 429) {
-    const retryAfter = response.headers.get('RateLimit-Reset') || response.headers.get('Retry-After');
-    const retryMsg = retryAfter ? `${retryAfter}秒後に再試行してください。` : '数分待ってから再試行してください。';
+    const retryAfter =
+      response.headers.get('RateLimit-Reset') || response.headers.get('Retry-After');
+    const retryMsg = retryAfter
+      ? `${retryAfter}秒後に再試行してください。`
+      : '数分待ってから再試行してください。';
     recordFailure(429, 'http_error', new Error(`レートリミットに達しました (429)。${retryMsg}`));
   }
 

--- a/src/sign/config.test.ts
+++ b/src/sign/config.test.ts
@@ -150,7 +150,7 @@ describe('loadSignRemoteServerConfig', () => {
       signAuthorizationEndpoint: 'https://ninja-sign.com/oauth/authorize',
       signTokenEndpoint: 'https://ninja-sign.com/oauth/token',
       signScope: 'all',
-      redisUrl: 'redis://localhost:6379',
+      redisUrl: 'redis://localhost:6379/1',
       corsAllowedOrigins: undefined,
       rateLimitEnabled: false,
       logLevel: 'info',

--- a/src/sign/config.test.ts
+++ b/src/sign/config.test.ts
@@ -2,10 +2,10 @@ import fs from 'node:fs/promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupTestTempDir } from '../test-utils/temp-dir.js';
 import {
-  type SignConfig,
   getSignCredentials,
   loadSignConfig,
   resetSignConfigCache,
+  type SignConfig,
 } from './config.js';
 
 const { setup: setupTempDir, cleanup: cleanupTempDir } = setupTestTempDir('sign-config-test-');
@@ -93,9 +93,7 @@ describe('sign/config', () => {
     });
 
     it('client_id 未設定 → configure 誘導エラー', async () => {
-      mockFs.readFile.mockResolvedValue(
-        JSON.stringify({}),
-      );
+      mockFs.readFile.mockResolvedValue(JSON.stringify({}));
 
       await expect(getSignCredentials()).rejects.toThrow('freee-sign-mcp configure');
     });
@@ -121,5 +119,70 @@ describe('sign/config', () => {
       // mockFs.readFile が呼ばれていない = loadFullConfig (freee) に依存していない
       expect(mockFs.readFile).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('loadSignRemoteServerConfig', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.SIGN_ISSUER_URL = 'https://sign-mcp.example.com';
+    process.env.SIGN_JWT_SECRET = 'a-sign-test-secret-that-is-at-least-32-characters-long';
+    process.env.FREEE_SIGN_CLIENT_ID = 'sign-client-id';
+    process.env.FREEE_SIGN_CLIENT_SECRET = 'sign-client-secret';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('全環境変数が設定されている場合は正常に Config が返る', async () => {
+    const { loadSignRemoteServerConfig } = await import('./config.js');
+    const config = loadSignRemoteServerConfig();
+
+    expect(config).toEqual({
+      port: 3002,
+      issuerUrl: 'https://sign-mcp.example.com',
+      jwtSecret: 'a-sign-test-secret-that-is-at-least-32-characters-long',
+      signClientId: 'sign-client-id',
+      signClientSecret: 'sign-client-secret',
+      signAuthorizationEndpoint: 'https://ninja-sign.com/oauth/authorize',
+      signTokenEndpoint: 'https://ninja-sign.com/oauth/token',
+      signScope: 'all',
+      redisUrl: 'redis://localhost:6379',
+      corsAllowedOrigins: undefined,
+      rateLimitEnabled: false,
+      logLevel: 'info',
+    });
+  });
+
+  it('SIGN_ISSUER_URL 未設定 → エラー', async () => {
+    delete process.env.SIGN_ISSUER_URL;
+    const { loadSignRemoteServerConfig } = await import('./config.js');
+
+    expect(() => loadSignRemoteServerConfig()).toThrow('SIGN_ISSUER_URL');
+  });
+
+  it('SIGN_JWT_SECRET 未設定 → エラー', async () => {
+    delete process.env.SIGN_JWT_SECRET;
+    const { loadSignRemoteServerConfig } = await import('./config.js');
+
+    expect(() => loadSignRemoteServerConfig()).toThrow('SIGN_JWT_SECRET');
+  });
+
+  it('SIGN_JWT_SECRET が 32 文字未満 → エラー', async () => {
+    process.env.SIGN_JWT_SECRET = 'short';
+    const { loadSignRemoteServerConfig } = await import('./config.js');
+
+    expect(() => loadSignRemoteServerConfig()).toThrow('at least 32 characters');
+  });
+
+  it('FREEE_SIGN_CLIENT_ID / SECRET 未設定 → エラー', async () => {
+    delete process.env.FREEE_SIGN_CLIENT_ID;
+    delete process.env.FREEE_SIGN_CLIENT_SECRET;
+    const { loadSignRemoteServerConfig } = await import('./config.js');
+
+    expect(() => loadSignRemoteServerConfig()).toThrow('FREEE_SIGN_CLIENT_ID');
   });
 });

--- a/src/sign/config.ts
+++ b/src/sign/config.ts
@@ -188,7 +188,8 @@ export function loadSignRemoteServerConfig(): SignRemoteServerConfig {
       process.env.SIGN_AUTHORIZATION_ENDPOINT || SIGN_AUTHORIZATION_ENDPOINT,
     signTokenEndpoint: process.env.SIGN_TOKEN_ENDPOINT || SIGN_TOKEN_ENDPOINT,
     signScope: process.env.SIGN_SCOPE || SIGN_OAUTH_SCOPE,
-    // freee 本体 (DB 0) と allkeys-lru で evict しあうのを防ぐため Sign は DB 1 を既定にする
+    // 名前空間管理のため Sign は DB 1 を既定にする (キー衝突と運用時の目視分離が目的)。
+    // DB 分離は maxmemory の eviction を防がない点に注意（server 側設定で対処）
     redisUrl: process.env.SIGN_REDIS_URL || 'redis://localhost:6379/1',
     corsAllowedOrigins: process.env.SIGN_CORS_ALLOWED_ORIGINS,
     rateLimitEnabled: process.env.SIGN_RATE_LIMIT_ENABLED === 'true',

--- a/src/sign/config.ts
+++ b/src/sign/config.ts
@@ -1,13 +1,15 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { z } from 'zod';
+import { parsePort } from '../config.js';
 import { CONFIG_FILE_PERMISSION, getConfigDir } from '../constants.js';
 
 /** サイン専用のデフォルトコールバックポート（freee 本体の 54321 と競合しないようにする） */
 export const SIGN_DEFAULT_CALLBACK_PORT = 54322;
 
 // Sign OAuth endpoints
-export const SIGN_API_URL = process.env.FREEE_SIGN_API_URL?.replace(/\/+$/, '') || 'https://ninja-sign.com';
+export const SIGN_API_URL =
+  process.env.FREEE_SIGN_API_URL?.replace(/\/+$/, '') || 'https://ninja-sign.com';
 export const SIGN_AUTHORIZATION_ENDPOINT = `${SIGN_API_URL}/oauth/authorize`;
 export const SIGN_TOKEN_ENDPOINT = `${SIGN_API_URL}/oauth/token`;
 export const SIGN_OAUTH_SCOPE = 'all';
@@ -116,9 +118,7 @@ export async function getSignCredentials(): Promise<{
   }
 
   if (envClientId || envClientSecret) {
-    throw new Error(
-      'FREEE_SIGN_CLIENT_ID と FREEE_SIGN_CLIENT_SECRET は両方設定してください。',
-    );
+    throw new Error('FREEE_SIGN_CLIENT_ID と FREEE_SIGN_CLIENT_SECRET は両方設定してください。');
   }
 
   const config = await loadSignConfig();
@@ -136,3 +136,61 @@ export async function getSignCredentials(): Promise<{
   };
 }
 
+export const SIGN_CALLBACK_PATH = '/oauth/sign-callback';
+
+export interface SignRemoteServerConfig {
+  port: number;
+  issuerUrl: string;
+  jwtSecret: string;
+  signClientId: string;
+  signClientSecret: string;
+  signAuthorizationEndpoint: string;
+  signTokenEndpoint: string;
+  signScope: string;
+  redisUrl: string;
+  corsAllowedOrigins?: string;
+  rateLimitEnabled: boolean;
+  logLevel: string;
+}
+
+export function loadSignRemoteServerConfig(): SignRemoteServerConfig {
+  const issuerUrl = process.env.SIGN_ISSUER_URL;
+  if (!issuerUrl) {
+    throw new Error('SIGN_ISSUER_URL environment variable is required for serve mode.');
+  }
+
+  const jwtSecret = process.env.SIGN_JWT_SECRET;
+  if (!jwtSecret) {
+    throw new Error('SIGN_JWT_SECRET environment variable is required for serve mode.');
+  }
+  if (jwtSecret.length < 32) {
+    throw new Error(
+      'SIGN_JWT_SECRET must be at least 32 characters. Use a cryptographically random value: openssl rand -hex 32',
+    );
+  }
+
+  const signClientId = process.env.FREEE_SIGN_CLIENT_ID;
+  const signClientSecret = process.env.FREEE_SIGN_CLIENT_SECRET;
+
+  if (!signClientId || !signClientSecret) {
+    throw new Error(
+      'FREEE_SIGN_CLIENT_ID and FREEE_SIGN_CLIENT_SECRET environment variables are required for serve mode.',
+    );
+  }
+
+  return {
+    port: parsePort(process.env.SIGN_PORT, 3002),
+    issuerUrl,
+    jwtSecret,
+    signClientId,
+    signClientSecret,
+    signAuthorizationEndpoint:
+      process.env.SIGN_AUTHORIZATION_ENDPOINT || SIGN_AUTHORIZATION_ENDPOINT,
+    signTokenEndpoint: process.env.SIGN_TOKEN_ENDPOINT || SIGN_TOKEN_ENDPOINT,
+    signScope: process.env.SIGN_SCOPE || SIGN_OAUTH_SCOPE,
+    redisUrl: process.env.SIGN_REDIS_URL || 'redis://localhost:6379',
+    corsAllowedOrigins: process.env.SIGN_CORS_ALLOWED_ORIGINS,
+    rateLimitEnabled: process.env.SIGN_RATE_LIMIT_ENABLED === 'true',
+    logLevel: process.env.SIGN_LOG_LEVEL || 'info',
+  };
+}

--- a/src/sign/config.ts
+++ b/src/sign/config.ts
@@ -188,7 +188,8 @@ export function loadSignRemoteServerConfig(): SignRemoteServerConfig {
       process.env.SIGN_AUTHORIZATION_ENDPOINT || SIGN_AUTHORIZATION_ENDPOINT,
     signTokenEndpoint: process.env.SIGN_TOKEN_ENDPOINT || SIGN_TOKEN_ENDPOINT,
     signScope: process.env.SIGN_SCOPE || SIGN_OAUTH_SCOPE,
-    redisUrl: process.env.SIGN_REDIS_URL || 'redis://localhost:6379',
+    // freee 本体 (DB 0) と allkeys-lru で evict しあうのを防ぐため Sign は DB 1 を既定にする
+    redisUrl: process.env.SIGN_REDIS_URL || 'redis://localhost:6379/1',
     corsAllowedOrigins: process.env.SIGN_CORS_ALLOWED_ORIGINS,
     rateLimitEnabled: process.env.SIGN_RATE_LIMIT_ENABLED === 'true',
     logLevel: process.env.SIGN_LOG_LEVEL || 'info',

--- a/src/sign/entry-remote.ts
+++ b/src/sign/entry-remote.ts
@@ -1,0 +1,15 @@
+import { createRequire } from 'node:module';
+import { initTelemetry } from '../telemetry/init.js';
+
+const require = createRequire(import.meta.url);
+// ビルド後は bin/freee-sign-remote-mcp.js に配置されるため、package.json は ../package.json
+const { version } = require('../package.json') as { version: string };
+const otel = initTelemetry(version);
+
+const { getLogger } = await import('../server/logger.js');
+const { startSignHttpServer } = await import('./server/sign-http-server.js');
+
+startSignHttpServer({ otelShutdown: otel?.shutdown }).catch((error) => {
+  getLogger().fatal({ err: error }, 'Fatal error');
+  process.exit(1);
+});

--- a/src/sign/handlers.test.ts
+++ b/src/sign/handlers.test.ts
@@ -1,15 +1,19 @@
-import { describe, expect, it, vi } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createSignMcpServer } from './handlers.js';
+import { addSignAuthenticationTools } from './tools.js';
 
 vi.mock('./config.js', () => ({
-  SIGN_SERVER_INSTRUCTIONS:
-    'freee サイン（電子契約）APIと連携するMCPサーバー。',
+  SIGN_SERVER_INSTRUCTIONS: 'freee サイン（電子契約）APIと連携するMCPサーバー。',
   SIGN_API_URL: 'https://ninja-sign.com',
   SIGN_AUTHORIZATION_ENDPOINT: 'https://ninja-sign.com/oauth/authorize',
   SIGN_TOKEN_ENDPOINT: 'https://ninja-sign.com/oauth/token',
   SIGN_OAUTH_SCOPE: 'all',
-  getSignCredentials: (): Promise<{ clientId: string; clientSecret: string; callbackPort: number }> =>
-    Promise.resolve({ clientId: 'id', clientSecret: 'secret', callbackPort: 54322 }),
+  getSignCredentials: (): Promise<{
+    clientId: string;
+    clientSecret: string;
+    callbackPort: number;
+  }> => Promise.resolve({ clientId: 'id', clientSecret: 'secret', callbackPort: 54322 }),
 }));
 
 vi.mock('./tokens.js', () => ({
@@ -29,7 +33,6 @@ vi.mock('../auth/server.js', () => ({
 describe('sign/handlers', () => {
   it('createSignMcpServer が sign_* ツールを登録する', () => {
     const server = createSignMcpServer();
-    // McpServer is created without error and has the correct name
     expect(server).toBeDefined();
   });
 
@@ -37,5 +40,74 @@ describe('sign/handlers', () => {
     const { SIGN_SERVER_INSTRUCTIONS } = await import('./config.js');
     expect(SIGN_SERVER_INSTRUCTIONS).toContain('サイン');
     expect(SIGN_SERVER_INSTRUCTIONS).not.toContain('会計');
+  });
+
+  it('createSignMcpServer({ remote: true }) でもエラーなく生成される', () => {
+    const server = createSignMcpServer({ remote: true });
+    expect(server).toBeDefined();
+  });
+
+  describe('remote mode でのツール登録', () => {
+    let mockServer: McpServer;
+    let mockTool: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockTool = vi.fn();
+      mockServer = {
+        registerTool: mockTool,
+      } as unknown as McpServer;
+      vi.clearAllMocks();
+    });
+
+    it('remote: true 時に sign_authenticate が登録されない', () => {
+      addSignAuthenticationTools(mockServer, { remote: true });
+
+      const toolNames = mockTool.mock.calls.map((call: unknown[]) => call[0]);
+      expect(toolNames).not.toContain('sign_authenticate');
+      expect(toolNames).toContain('sign_auth_status');
+      expect(toolNames).toContain('sign_clear_auth');
+      expect(toolNames).toContain('sign_server_info');
+    });
+
+    it('remote: false 時に sign_authenticate が登録される', () => {
+      addSignAuthenticationTools(mockServer, { remote: false });
+
+      const toolNames = mockTool.mock.calls.map((call: unknown[]) => call[0]);
+      expect(toolNames).toContain('sign_authenticate');
+      expect(toolNames).toContain('sign_auth_status');
+      expect(toolNames).toContain('sign_clear_auth');
+      expect(toolNames).toContain('sign_server_info');
+    });
+
+    it('options 未指定時に sign_authenticate が登録される', () => {
+      addSignAuthenticationTools(mockServer);
+
+      const toolNames = mockTool.mock.calls.map((call: unknown[]) => call[0]);
+      expect(toolNames).toContain('sign_authenticate');
+      expect(toolNames).toContain('sign_server_info');
+    });
+
+    it('sign_server_info が stdio transport を返す（デフォルト）', async () => {
+      addSignAuthenticationTools(mockServer);
+      const handler = mockTool.mock.calls.find(
+        (call: unknown[]) => call[0] === 'sign_server_info',
+      )?.[2];
+
+      const result = await handler();
+
+      expect(result.content[0].text).toContain('freee-sign-mcp server info:');
+      expect(result.content[0].text).toContain('transport: stdio');
+    });
+
+    it('sign_server_info が remote transport を返す（remote: true）', async () => {
+      addSignAuthenticationTools(mockServer, { remote: true });
+      const handler = mockTool.mock.calls.find(
+        (call: unknown[]) => call[0] === 'sign_server_info',
+      )?.[2];
+
+      const result = await handler();
+
+      expect(result.content[0].text).toContain('transport: remote');
+    });
   });
 });

--- a/src/sign/handlers.ts
+++ b/src/sign/handlers.ts
@@ -4,7 +4,7 @@ import { PACKAGE_VERSION } from '../constants.js';
 import { SIGN_SERVER_INSTRUCTIONS } from './config.js';
 import { addSignApiTools, addSignAuthenticationTools } from './tools.js';
 
-export function createSignMcpServer(): McpServer {
+export function createSignMcpServer(options?: { remote?: boolean }): McpServer {
   const server = new McpServer(
     {
       name: 'freee-sign',
@@ -15,8 +15,8 @@ export function createSignMcpServer(): McpServer {
     },
   );
 
-  addSignAuthenticationTools(server);
-  addSignApiTools(server);
+  addSignAuthenticationTools(server, options);
+  addSignApiTools(server, options);
 
   return server;
 }

--- a/src/sign/server/sign-callback.ts
+++ b/src/sign/server/sign-callback.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
 import type { Request, Response } from 'express';
+import { z } from 'zod';
 import { createTokenData } from '../../auth/token-utils.js';
 import { OAuthTokenResponseSchema } from '../../auth/tokens.js';
 import { FETCH_TIMEOUT_TOKEN_MS, FETCH_TIMEOUT_USERINFO_MS } from '../../constants.js';
@@ -9,6 +10,10 @@ import type { OAuthStateStore } from '../../server/oauth-store.js';
 import { getUserAgent } from '../../server/user-agent.js';
 import { SIGN_CALLBACK_PATH } from '../config.js';
 import type { SignTokenStore } from './sign-redis-token-store.js';
+
+const SignUserResponseSchema = z.object({
+  id: z.number().int().nonnegative(),
+});
 
 export interface SignCallbackDeps {
   oauthStore: OAuthStateStore;
@@ -76,12 +81,12 @@ async function fetchSignUserId(accessToken: string, apiUrl: string): Promise<str
     throw new Error(`Sign /v1/users/me failed: ${response.status}`);
   }
 
-  const data = (await response.json()) as { id?: number };
-  const userId = data.id;
-  if (userId == null) {
-    throw new Error('Sign /v1/users/me did not return id');
+  const json: unknown = await response.json();
+  const parsed = SignUserResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new Error(`Sign /v1/users/me returned unexpected shape: ${parsed.error.message}`);
   }
-  return String(userId);
+  return String(parsed.data.id);
 }
 
 function buildRedirectUrl(baseUri: string, state: string, params: Record<string, string>): string {

--- a/src/sign/server/sign-callback.ts
+++ b/src/sign/server/sign-callback.ts
@@ -1,0 +1,211 @@
+import { randomUUID } from 'node:crypto';
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import type { Request, Response } from 'express';
+import { createTokenData } from '../../auth/token-utils.js';
+import { OAuthTokenResponseSchema } from '../../auth/tokens.js';
+import { FETCH_TIMEOUT_TOKEN_MS, FETCH_TIMEOUT_USERINFO_MS } from '../../constants.js';
+import { getLogger } from '../../server/logger.js';
+import type { OAuthStateStore } from '../../server/oauth-store.js';
+import { getUserAgent } from '../../server/user-agent.js';
+import { SIGN_CALLBACK_PATH } from '../config.js';
+import type { SignTokenStore } from './sign-redis-token-store.js';
+
+export interface SignCallbackDeps {
+  oauthStore: OAuthStateStore;
+  tokenStore: SignTokenStore;
+  clientStore?: OAuthRegisteredClientsStore;
+  signClientId: string;
+  signClientSecret: string;
+  signTokenEndpoint: string;
+  signScope: string;
+  callbackBaseUrl: string;
+}
+
+async function exchangeSignCode(
+  code: string,
+  redirectUri: string,
+  clientId: string,
+  clientSecret: string,
+  tokenEndpoint: string,
+): Promise<{ accessToken: string; refreshToken: string; expiresIn: number; scope?: string }> {
+  const response = await fetch(tokenEndpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': getUserAgent(),
+    },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      redirect_uri: redirectUri,
+    }),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_TOKEN_MS),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    // レスポンス本文に PII や shorter ID が含まれる可能性があるため先頭 200 文字に制限
+    throw new Error(`Sign token exchange failed: ${response.status} ${text.slice(0, 200)}`);
+  }
+
+  const json: unknown = await response.json();
+  const result = OAuthTokenResponseSchema.safeParse(json);
+  if (!result.success) {
+    throw new Error(`Invalid Sign token response: ${result.error.message}`);
+  }
+  return {
+    accessToken: result.data.access_token,
+    refreshToken: result.data.refresh_token || '',
+    expiresIn: result.data.expires_in,
+    scope: result.data.scope,
+  };
+}
+
+async function fetchSignUserId(accessToken: string, apiUrl: string): Promise<string> {
+  const response = await fetch(`${apiUrl}/v1/users/me`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'User-Agent': getUserAgent(),
+    },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_USERINFO_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Sign /v1/users/me failed: ${response.status}`);
+  }
+
+  const data = (await response.json()) as { id?: number };
+  const userId = data.id;
+  if (!userId) {
+    throw new Error('Sign /v1/users/me did not return id');
+  }
+  return String(userId);
+}
+
+function buildRedirectUrl(baseUri: string, state: string, params: Record<string, string>): string {
+  const url = new URL(baseUri);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  if (state) {
+    url.searchParams.set('state', state);
+  }
+  return url.toString();
+}
+
+export function createSignCallbackHandler(
+  deps: SignCallbackDeps,
+  signApiUrl: string,
+): (req: Request, res: Response) => void {
+  const callbackRedirectUri = `${deps.callbackBaseUrl}${SIGN_CALLBACK_PATH}`;
+
+  return (req: Request, res: Response) => {
+    handleSignCallback(req, res, deps, signApiUrl, callbackRedirectUri).catch((err: unknown) => {
+      getLogger().error({ err }, 'Sign callback error');
+      if (!res.headersSent) {
+        res.status(500).send('Internal server error during Sign OAuth callback');
+      }
+    });
+  };
+}
+
+async function handleSignCallback(
+  req: Request,
+  res: Response,
+  deps: SignCallbackDeps,
+  signApiUrl: string,
+  callbackRedirectUri: string,
+): Promise<void> {
+  const code = req.query.code as string | undefined;
+  const state = req.query.state as string | undefined;
+  const error = req.query.error as string | undefined;
+
+  if (error) {
+    const session = state ? await deps.oauthStore.consumeSession(state) : null;
+    if (!session) {
+      res.status(400).type('text/plain').send(`Sign OAuth error: ${error}`);
+      return;
+    }
+
+    const errorDescription =
+      (req.query.error_description as string) || 'Sign authentication failed';
+    const redirectTarget = buildRedirectUrl(session.redirectUri, session.state, {
+      error,
+      error_description: errorDescription,
+    });
+    res.redirect(302, redirectTarget);
+    return;
+  }
+
+  if (!code || !state) {
+    res.status(400).send('Missing code or state parameter');
+    return;
+  }
+
+  const session = await deps.oauthStore.consumeSession(state);
+  if (!session) {
+    res.status(400).send('Invalid or expired OAuth session');
+    return;
+  }
+
+  // Validate redirect_uri against registered client (defense-in-depth).
+  // Wrapped in try-catch: session is already consumed above, so a Redis failure here
+  // must not abort the flow — the user cannot retry without restarting OAuth.
+  if (deps.clientStore) {
+    try {
+      const client = await deps.clientStore.getClient(session.clientId);
+      if (client?.redirect_uris && !client.redirect_uris.includes(session.redirectUri)) {
+        getLogger().error({ clientId: session.clientId }, 'redirect_uri mismatch');
+        res.status(400).send('redirect_uri mismatch');
+        return;
+      }
+    } catch (err) {
+      getLogger().error({ clientId: session.clientId, err }, 'Failed to validate redirect_uri');
+    }
+  }
+
+  try {
+    const signTokens = await exchangeSignCode(
+      code,
+      callbackRedirectUri,
+      deps.signClientId,
+      deps.signClientSecret,
+      deps.signTokenEndpoint,
+    );
+
+    const userId = await fetchSignUserId(signTokens.accessToken, signApiUrl);
+
+    const tokenData = createTokenData(
+      {
+        access_token: signTokens.accessToken,
+        refresh_token: signTokens.refreshToken,
+        expires_in: signTokens.expiresIn,
+        scope: signTokens.scope,
+      },
+      { scope: deps.signScope },
+    );
+    await deps.tokenStore.saveTokens(userId, tokenData);
+
+    const mcpCode = randomUUID();
+    await deps.oauthStore.saveAuthCode(mcpCode, {
+      userId,
+      clientId: session.clientId,
+      codeChallenge: session.codeChallenge,
+      scopes: session.scopes,
+      redirectUri: session.redirectUri,
+      resource: session.resource,
+    });
+
+    const redirectTarget = buildRedirectUrl(session.redirectUri, session.state, { code: mcpCode });
+    res.redirect(302, redirectTarget);
+  } catch (err) {
+    getLogger().error({ err }, 'Sign OAuth callback processing failed');
+    const redirectTarget = buildRedirectUrl(session.redirectUri, session.state, {
+      error: 'server_error',
+      error_description: 'Failed to complete Sign authentication',
+    });
+    res.redirect(302, redirectTarget);
+  }
+}

--- a/src/sign/server/sign-callback.ts
+++ b/src/sign/server/sign-callback.ts
@@ -78,7 +78,7 @@ async function fetchSignUserId(accessToken: string, apiUrl: string): Promise<str
 
   const data = (await response.json()) as { id?: number };
   const userId = data.id;
-  if (!userId) {
+  if (userId == null) {
     throw new Error('Sign /v1/users/me did not return id');
   }
   return String(userId);

--- a/src/sign/server/sign-http-server.ts
+++ b/src/sign/server/sign-http-server.ts
@@ -1,0 +1,353 @@
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { Request, Response } from 'express';
+import { RedisClientStore } from '../../server/client-store.js';
+import { makeErrorChain, serializeErrorChain } from '../../server/error-serializer.js';
+import { RedisUnavailableError } from '../../server/errors.js';
+import { initLogger } from '../../server/logger.js';
+import { OAuthStateStore } from '../../server/oauth-store.js';
+import { getCurrentRecorder } from '../../server/request-context.js';
+import { initUserAgentTransportMode } from '../../server/user-agent.js';
+import type { Redis } from '../../storage/redis-client.js';
+import { closeRedisClient, getRedisClient } from '../../storage/redis-client.js';
+import { createTracingMiddleware } from '../../telemetry/middleware.js';
+import { loadSignRemoteServerConfig, SIGN_API_URL, SIGN_CALLBACK_PATH } from '../config.js';
+import { createSignMcpServer } from '../handlers.js';
+import { createSignCallbackHandler } from './sign-callback.js';
+import { SignOAuthProvider } from './sign-oauth-provider.js';
+import { SignRedisTokenStore } from './sign-redis-token-store.js';
+
+const BODY_SIZE_LIMIT = 1_048_576; // 1 MB
+
+declare module 'express' {
+  interface Request {
+    requestId?: string;
+  }
+}
+
+const SHUTDOWN_TIMEOUT_MS = 30_000; // 30 seconds
+
+export async function startSignHttpServer(options?: {
+  otelShutdown?: () => Promise<void>;
+}): Promise<void> {
+  const signRemoteConfig = loadSignRemoteServerConfig();
+
+  const logger = initLogger({
+    level: signRemoteConfig.logLevel,
+    transportMode: 'remote',
+    serviceName: 'freee-sign-mcp',
+  });
+  initUserAgentTransportMode('remote');
+
+  const redis = getRedisClient(signRemoteConfig.redisUrl);
+
+  // Verify Redis connection before starting the server
+  try {
+    await redis.ping();
+    logger.info('Redis connected');
+  } catch (err) {
+    logger.error(
+      { err },
+      'Failed to connect to Redis. Make sure Redis is running. For development: docker compose up -d',
+    );
+    process.exit(1);
+  }
+
+  const tokenStore = new SignRedisTokenStore(redis, {
+    clientId: signRemoteConfig.signClientId,
+    clientSecret: signRemoteConfig.signClientSecret,
+    tokenEndpoint: signRemoteConfig.signTokenEndpoint,
+    scope: signRemoteConfig.signScope,
+  });
+
+  // OAuth 2.1 AS dependencies
+  const oauthStore = new OAuthStateStore(redis, 'freee-sign-mcp:oauth');
+  const clientStore = new RedisClientStore({ redis, prefix: 'freee-sign-mcp:oauth' });
+  const provider = new SignOAuthProvider({
+    clientStore,
+    oauthStore,
+    tokenStore,
+    jwtSecret: signRemoteConfig.jwtSecret,
+    issuerUrl: signRemoteConfig.issuerUrl,
+    signClientId: signRemoteConfig.signClientId,
+    signAuthorizationEndpoint: signRemoteConfig.signAuthorizationEndpoint,
+    signScope: signRemoteConfig.signScope,
+    callbackBaseUrl: signRemoteConfig.issuerUrl,
+  });
+
+  const signCallbackHandler = createSignCallbackHandler(
+    {
+      oauthStore,
+      tokenStore,
+      clientStore,
+      signClientId: signRemoteConfig.signClientId,
+      signClientSecret: signRemoteConfig.signClientSecret,
+      signTokenEndpoint: signRemoteConfig.signTokenEndpoint,
+      signScope: signRemoteConfig.signScope,
+      callbackBaseUrl: signRemoteConfig.issuerUrl,
+    },
+    SIGN_API_URL,
+  );
+
+  // Dynamic import of express (only loaded in serve mode)
+  const express = (await import('express')).default;
+  const app = express();
+  // Trust first proxy (required for express-rate-limit behind reverse proxy / tunnel)
+  app.set('trust proxy', 1);
+
+  // --- Tracing middleware (must be first to wrap entire request lifecycle) ---
+  app.use(createTracingMiddleware());
+
+  // --- Security middleware ---
+
+  // Security headers (helmet)
+  const helmet = (await import('helmet')).default;
+  app.use(
+    helmet({
+      hsts: { maxAge: 31536000, preload: true },
+      contentSecurityPolicy: { directives: { defaultSrc: ["'none'"] } },
+      frameguard: { action: 'deny' },
+    }),
+  );
+
+  // CORS
+  const cors = (await import('cors')).default;
+  const allowedOrigins = signRemoteConfig.corsAllowedOrigins
+    ? signRemoteConfig.corsAllowedOrigins.split(',').map((s) => s.trim())
+    : [signRemoteConfig.issuerUrl];
+  app.use(
+    cors({
+      origin: allowedOrigins,
+      methods: ['GET', 'POST', 'DELETE'],
+      allowedHeaders: ['Content-Type', 'Authorization', 'Mcp-Session-Id', 'Accept'],
+    }),
+  );
+
+  // Body size limit (Content-Length check, does not consume the stream)
+  app.use((req: Request, res: Response, next: () => void) => {
+    const contentLength = req.headers['content-length'];
+    if (contentLength && Number.parseInt(contentLength, 10) > BODY_SIZE_LIMIT) {
+      getCurrentRecorder()?.recordError({
+        source: 'middleware',
+        status_code: 413,
+        error_type: 'payload_too_large',
+        chain: makeErrorChain(
+          'PayloadTooLargeError',
+          'Content-Length exceeds configured body size limit',
+        ),
+      });
+      res.status(413).json({ error: 'Payload too large' });
+      return;
+    }
+    next();
+  });
+
+  // --- Rate limiting (opt-in) ---
+  if (signRemoteConfig.rateLimitEnabled) {
+    await setupRateLimiting(app, redis, logger);
+  }
+
+  // Health check endpoint (no auth required)
+  app.get('/health', async (_req: Request, res: Response) => {
+    try {
+      await redis.ping();
+      res.json({
+        status: 'ok',
+        redis: 'connected',
+      });
+    } catch {
+      res.status(503).json({
+        status: 'degraded',
+        redis: 'disconnected',
+      });
+    }
+  });
+
+  // Sign OAuth callback (browser redirect, no MCP auth required)
+  app.get(SIGN_CALLBACK_PATH, signCallbackHandler);
+
+  // MCP Auth Router: /.well-known/*, /authorize, /token, /register, /revoke
+  const { mcpAuthRouter } = await import('@modelcontextprotocol/sdk/server/auth/router.js');
+  const issuerUrl = new URL(signRemoteConfig.issuerUrl);
+  const mcpResourceUrl = new URL('/mcp', issuerUrl);
+  app.use(
+    mcpAuthRouter({
+      provider,
+      issuerUrl,
+      resourceServerUrl: mcpResourceUrl,
+      scopesSupported: ['mcp:read', 'mcp:write'],
+      resourceName: 'freee Sign MCP Server',
+    }),
+  );
+
+  // MCP endpoints (Bearer JWT auth required)
+  const { requireBearerAuth } = await import(
+    '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js'
+  );
+  const { getOAuthProtectedResourceMetadataUrl } = await import(
+    '@modelcontextprotocol/sdk/server/auth/router.js'
+  );
+  const bearerAuth = requireBearerAuth({
+    verifier: provider,
+    resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(mcpResourceUrl),
+  });
+
+  // MCP endpoint handler (stateless: each request creates a fresh transport)
+  async function handleMcpRequest(req: Request, res: Response): Promise<void> {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+    const authExtra = (req as unknown as Record<string, unknown>).auth as
+      | { extra?: Record<string, unknown> }
+      | undefined;
+    const userId =
+      typeof authExtra?.extra?.userId === 'string' ? authExtra.extra.userId : undefined;
+    getCurrentRecorder()?.updateContext({ user_id: userId, session_id: sessionId });
+
+    // Unknown session ID: return 404 per MCP spec (stateless mode never issues session IDs)
+    if (sessionId) {
+      getCurrentRecorder()?.recordError({
+        source: 'mcp_handler',
+        status_code: 404,
+        error_type: 'unknown_session',
+        chain: makeErrorChain('SessionNotFound', 'Unknown session id supplied'),
+      });
+      res.status(404).json({ error: 'Session not found' });
+      return;
+    }
+
+    // Create a fresh transport for each request (stateless)
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    const mcpServer = createSignMcpServer({ remote: true });
+    await mcpServer.connect(transport);
+
+    // Clean up transport when the HTTP response finishes (normal completion or client disconnect).
+    // Cannot use a finally block here because handleRequest resolves before SSE streaming completes.
+    res.on('close', () => {
+      transport.close().catch(() => {});
+    });
+
+    await transport.handleRequest(req, res);
+  }
+
+  function mcpHandler(req: Request, res: Response): void {
+    handleMcpRequest(req, res).catch((err: unknown) => {
+      getCurrentRecorder()?.recordError({
+        source: 'mcp_handler',
+        status_code: 500,
+        error_type: 'unhandled_exception',
+        chain: serializeErrorChain(err),
+      });
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    });
+  }
+
+  app.post('/mcp', bearerAuth, mcpHandler);
+  app.get('/mcp', bearerAuth, mcpHandler);
+
+  app.delete('/mcp', bearerAuth, mcpHandler);
+
+  // Express error handler (must be after all routes)
+  app.use((err: unknown, _req: Request, res: Response, next: (err?: unknown) => void) => {
+    if (err instanceof RedisUnavailableError) {
+      if (!res.headersSent) {
+        res.status(503).json({
+          error: 'service_unavailable',
+          message: 'Storage backend temporarily unavailable',
+        });
+      }
+      getCurrentRecorder()?.recordError({
+        source: 'redis_unavailable',
+        status_code: 503,
+        error_type: 'redis_unavailable',
+        chain: serializeErrorChain(err),
+      });
+      return;
+    }
+    if (res.headersSent) {
+      next(err);
+      return;
+    }
+    res.status(500).json({ error: 'Internal server error' });
+    getCurrentRecorder()?.recordError({
+      source: 'middleware',
+      status_code: 500,
+      error_type: 'unhandled_middleware_error',
+      chain: serializeErrorChain(err),
+    });
+  });
+
+  const server = app.listen(signRemoteConfig.port, () => {
+    logger.info({ port: signRemoteConfig.port }, 'freee Sign MCP HTTP server listening');
+  });
+
+  // Graceful shutdown
+  let shuttingDown = false;
+  async function shutdown(signal: string): Promise<void> {
+    if (shuttingDown) return;
+    shuttingDown = true;
+
+    logger.info({ signal }, 'Shutting down gracefully...');
+
+    // Force exit after timeout if graceful shutdown hangs
+    const forceExitTimer = setTimeout(() => {
+      logger.warn('Shutdown timeout, forcing exit');
+      process.exit(1);
+    }, SHUTDOWN_TIMEOUT_MS);
+    forceExitTimer.unref();
+
+    // Stop accepting new requests first
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        logger.info('HTTP server closed');
+        resolve();
+      });
+    });
+
+    // Flush pending OTel spans before closing connections
+    await options?.otelShutdown?.();
+
+    // Close Redis after all in-flight requests have drained
+    await closeRedisClient();
+
+    process.exit(0);
+  }
+
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+}
+
+async function setupRateLimiting(
+  app: import('express').Express,
+  redis: Redis,
+  logger: ReturnType<typeof initLogger>,
+): Promise<void> {
+  const rateLimitModule = await import('express-rate-limit');
+  const rateLimit = rateLimitModule.rateLimit ?? rateLimitModule.default;
+  const redisStoreModule = await import('rate-limit-redis');
+  const RedisStore = redisStoreModule.RedisStore ?? redisStoreModule.default;
+
+  const createLimiter = (windowMs: number, max: number, prefix: string) =>
+    rateLimit({
+      windowMs,
+      max,
+      standardHeaders: true,
+      legacyHeaders: false,
+      store: new RedisStore({
+        sendCommand: (...args: string[]) => redis.call(args[0], ...args.slice(1)) as never,
+        // freee 本体と同一 Redis を共有する場合にカウンタが合算されるのを防ぐため sign namespace を付与
+        prefix: `rl:sign:${prefix}:`,
+      }),
+    });
+
+  app.use('/authorize', createLimiter(5 * 60 * 1000, 10, 'authorize'));
+  app.use('/token', createLimiter(60 * 1000, 10, 'token'));
+  app.use('/register', createLimiter(60 * 60 * 1000, 3, 'register'));
+  app.use(SIGN_CALLBACK_PATH, createLimiter(5 * 60 * 1000, 10, 'sign-cb'));
+  app.use('/mcp', createLimiter(60 * 1000, 100, 'mcp'));
+
+  logger.info('Rate limiting enabled');
+}

--- a/src/sign/server/sign-oauth-provider.ts
+++ b/src/sign/server/sign-oauth-provider.ts
@@ -1,0 +1,184 @@
+import { randomUUID } from 'node:crypto';
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import { InvalidGrantError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import type {
+  AuthorizationParams,
+  OAuthServerProvider,
+} from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type {
+  OAuthClientInformationFull,
+  OAuthTokenRevocationRequest,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import type { Response } from 'express';
+import type { RedisClientStore } from '../../server/client-store.js';
+import { signAccessToken, verifyAccessToken as verifyJwt } from '../../server/jwt.js';
+import type { OAuthStateStore } from '../../server/oauth-store.js';
+import { SIGN_CALLBACK_PATH } from '../config.js';
+import type { SignTokenStore } from './sign-redis-token-store.js';
+
+export interface SignOAuthProviderDeps {
+  clientStore: RedisClientStore;
+  oauthStore: OAuthStateStore;
+  tokenStore: SignTokenStore;
+  jwtSecret: string;
+  issuerUrl: string;
+  signClientId: string;
+  signAuthorizationEndpoint: string;
+  signScope: string;
+  callbackBaseUrl: string;
+}
+
+const ACCESS_TOKEN_EXPIRES_IN = 3600;
+
+export class SignOAuthProvider implements OAuthServerProvider {
+  private readonly deps: SignOAuthProviderDeps;
+
+  constructor(deps: SignOAuthProviderDeps) {
+    this.deps = deps;
+  }
+
+  get clientsStore(): OAuthRegisteredClientsStore {
+    return this.deps.clientStore;
+  }
+
+  async authorize(
+    client: OAuthClientInformationFull,
+    params: AuthorizationParams,
+    res: Response,
+  ): Promise<void> {
+    const sessionId = randomUUID();
+
+    // Sign は PKCE 非対応。callback で読まれないため空文字列で型を通すだけ
+    await this.deps.oauthStore.saveSession(sessionId, {
+      clientId: client.client_id,
+      redirectUri: params.redirectUri,
+      codeChallenge: params.codeChallenge,
+      state: params.state || '',
+      scopes: params.scopes || [],
+      freeePkceVerifier: '',
+      resource: params.resource?.href,
+    });
+
+    const signCallbackUri = `${this.deps.callbackBaseUrl}${SIGN_CALLBACK_PATH}`;
+    const signParams = new URLSearchParams({
+      response_type: 'code',
+      client_id: this.deps.signClientId,
+      redirect_uri: signCallbackUri,
+      scope: this.deps.signScope,
+      state: sessionId,
+    });
+
+    res.redirect(302, `${this.deps.signAuthorizationEndpoint}?${signParams.toString()}`);
+  }
+
+  async challengeForAuthorizationCode(
+    _client: OAuthClientInformationFull,
+    authorizationCode: string,
+  ): Promise<string> {
+    const codeData = await this.deps.oauthStore.getAuthCode(authorizationCode);
+    if (!codeData) {
+      throw new InvalidGrantError('Authorization code not found or expired');
+    }
+    return codeData.codeChallenge;
+  }
+
+  async exchangeAuthorizationCode(
+    client: OAuthClientInformationFull,
+    authorizationCode: string,
+    _codeVerifier?: string,
+    _redirectUri?: string,
+    _resource?: URL,
+  ): Promise<OAuthTokens> {
+    const codeData = await this.deps.oauthStore.consumeAuthCode(authorizationCode);
+    if (!codeData) {
+      throw new InvalidGrantError('Authorization code not found or already used');
+    }
+
+    if (codeData.clientId !== client.client_id) {
+      throw new InvalidGrantError('Authorization code was not issued to this client');
+    }
+
+    return this.issueTokens(codeData.userId, client.client_id, codeData.scopes);
+  }
+
+  async exchangeRefreshToken(
+    client: OAuthClientInformationFull,
+    refreshToken: string,
+    scopes?: string[],
+    _resource?: URL,
+  ): Promise<OAuthTokens> {
+    // Read first (non-destructive) to validate before consuming
+    const tokenData = await this.deps.oauthStore.getRefreshToken(refreshToken);
+    if (!tokenData) {
+      throw new InvalidGrantError('Invalid or expired refresh token');
+    }
+
+    if (tokenData.clientId !== client.client_id) {
+      throw new InvalidGrantError('Refresh token was issued to a different client');
+    }
+
+    if (scopes && !scopes.every((s) => tokenData.scopes.includes(s))) {
+      throw new InvalidGrantError('Requested scopes exceed originally granted scopes');
+    }
+
+    // Consume only after validation passes
+    const consumed = await this.deps.oauthStore.consumeRefreshToken(refreshToken);
+    if (!consumed) {
+      throw new InvalidGrantError('Refresh token already used');
+    }
+
+    const grantedScopes = scopes || tokenData.scopes;
+    return this.issueTokens(tokenData.userId, client.client_id, grantedScopes);
+  }
+
+  async verifyAccessToken(token: string): Promise<AuthInfo> {
+    const payload = await verifyJwt(token, this.deps.jwtSecret, this.deps.issuerUrl);
+    return {
+      token,
+      clientId: payload.client_id,
+      scopes: payload.scope.split(' '),
+      expiresAt: payload.exp,
+      extra: {
+        userId: payload.sub,
+        tokenStore: this.deps.tokenStore,
+      },
+    };
+  }
+
+  async revokeToken(
+    _client: OAuthClientInformationFull,
+    request: OAuthTokenRevocationRequest,
+  ): Promise<void> {
+    await this.deps.oauthStore.revokeRefreshToken(request.token);
+  }
+
+  private async issueTokens(
+    userId: string,
+    clientId: string,
+    scopes: string[],
+  ): Promise<OAuthTokens> {
+    const scope = scopes.join(' ');
+    const jwt = await signAccessToken(
+      { sub: userId, scope, clientId },
+      this.deps.jwtSecret,
+      this.deps.issuerUrl,
+    );
+
+    const refreshToken = randomUUID();
+    await this.deps.oauthStore.saveRefreshToken(refreshToken, {
+      userId,
+      clientId,
+      scopes,
+    });
+
+    return {
+      access_token: jwt,
+      token_type: 'bearer',
+      expires_in: ACCESS_TOKEN_EXPIRES_IN,
+      scope,
+      refresh_token: refreshToken,
+    };
+  }
+}

--- a/src/sign/server/sign-redis-token-store.test.ts
+++ b/src/sign/server/sign-redis-token-store.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TokenData } from '../../auth/tokens.js';
+import { REFRESH_TOKEN_TTL_SECONDS } from '../../constants.js';
+import { SignRedisTokenStore } from './sign-redis-token-store.js';
+
+vi.mock('../../auth/tokens.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../auth/tokens.js')>();
+  return {
+    ...actual,
+    isTokenValid: vi.fn(),
+    refreshFreeeTokenRaw: vi.fn(),
+  };
+});
+
+vi.mock('../../server/logger.js', () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('../../server/errors.js', () => ({
+  withRedis: vi.fn(async (_op: string, fn: () => Promise<unknown>) => fn()),
+}));
+
+const { isTokenValid, refreshFreeeTokenRaw } = await import('../../auth/tokens.js');
+
+function createMockRedis() {
+  const store = new Map<string, string>();
+
+  return {
+    get: vi.fn(async (key: string) => store.get(key) || null),
+    set: vi.fn(async (key: string, value: string, _ex?: string, _ttl?: number) => {
+      store.set(key, value);
+      return 'OK';
+    }),
+    del: vi.fn(async (key: string) => {
+      store.delete(key);
+      return 1;
+    }),
+    _store: store,
+  };
+}
+
+const oauthConfig = {
+  clientId: 'sign-client-1',
+  clientSecret: 'sign-secret-1',
+  tokenEndpoint: 'https://accounts.secure.freee.co.jp/public_api/token',
+  scope: 'sign',
+};
+
+const validTokens: TokenData = {
+  access_token: 'access-abc',
+  refresh_token: 'refresh-xyz',
+  expires_at: Date.now() + 3600_000,
+  token_type: 'Bearer',
+  scope: 'sign',
+};
+
+describe('SignRedisTokenStore', () => {
+  let redis: ReturnType<typeof createMockRedis>;
+  let store: SignRedisTokenStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redis = createMockRedis();
+    store = new SignRedisTokenStore(redis as never, oauthConfig);
+  });
+
+  describe('loadTokens', () => {
+    it('returns TokenData when Redis has valid data', async () => {
+      redis._store.set('freee-sign-mcp:tokens:user-1', JSON.stringify(validTokens));
+
+      const result = await store.loadTokens('user-1');
+      expect(result).toEqual(validTokens);
+      expect(redis.get).toHaveBeenCalledWith('freee-sign-mcp:tokens:user-1');
+    });
+
+    it('returns null when Redis has no data', async () => {
+      const result = await store.loadTokens('user-2');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for invalid JSON', async () => {
+      redis._store.set('freee-sign-mcp:tokens:user-3', 'not-json{');
+
+      const result = await store.loadTokens('user-3');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('saveTokens', () => {
+    it('stores tokens in Redis with TTL', async () => {
+      await store.saveTokens('user-1', validTokens);
+
+      expect(redis.set).toHaveBeenCalledWith(
+        'freee-sign-mcp:tokens:user-1',
+        JSON.stringify(validTokens),
+        'EX',
+        REFRESH_TOKEN_TTL_SECONDS,
+      );
+    });
+  });
+
+  describe('clearTokens', () => {
+    it('deletes tokens from Redis', async () => {
+      redis._store.set('freee-sign-mcp:tokens:user-1', JSON.stringify(validTokens));
+
+      await store.clearTokens('user-1');
+
+      expect(redis.del).toHaveBeenCalledWith('freee-sign-mcp:tokens:user-1');
+    });
+  });
+
+  describe('getValidAccessToken', () => {
+    it('returns access_token when token is valid', async () => {
+      redis._store.set('freee-sign-mcp:tokens:user-1', JSON.stringify(validTokens));
+      vi.mocked(isTokenValid).mockReturnValue(true);
+
+      const result = await store.getValidAccessToken('user-1');
+      expect(result).toBe('access-abc');
+      expect(refreshFreeeTokenRaw).not.toHaveBeenCalled();
+    });
+
+    it('refreshes and returns new access_token when token is expired', async () => {
+      const expiredTokens: TokenData = {
+        ...validTokens,
+        expires_at: Date.now() - 1000,
+      };
+      redis._store.set('freee-sign-mcp:tokens:user-1', JSON.stringify(expiredTokens));
+      vi.mocked(isTokenValid).mockReturnValue(false);
+
+      const refreshedTokens: TokenData = {
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        expires_at: Date.now() + 3600_000,
+        token_type: 'Bearer',
+        scope: 'sign',
+      };
+      vi.mocked(refreshFreeeTokenRaw).mockResolvedValue(refreshedTokens);
+
+      const result = await store.getValidAccessToken('user-1');
+      expect(result).toBe('new-access-token');
+      expect(refreshFreeeTokenRaw).toHaveBeenCalledWith(expiredTokens.refresh_token, oauthConfig);
+      expect(redis.set).toHaveBeenCalledWith(
+        'freee-sign-mcp:tokens:user-1',
+        JSON.stringify(refreshedTokens),
+        'EX',
+        REFRESH_TOKEN_TTL_SECONDS,
+      );
+    });
+
+    it('returns null when Redis has no data', async () => {
+      const result = await store.getValidAccessToken('user-no-data');
+      expect(result).toBeNull();
+      expect(isTokenValid).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/sign/server/sign-redis-token-store.ts
+++ b/src/sign/server/sign-redis-token-store.ts
@@ -1,0 +1,88 @@
+import {
+  isTokenValid,
+  type OAuthClientConfig,
+  refreshFreeeTokenRaw,
+  type TokenData,
+  TokenDataSchema,
+} from '../../auth/tokens.js';
+import { REFRESH_TOKEN_TTL_SECONDS } from '../../constants.js';
+import { withRedis } from '../../server/errors.js';
+import { getLogger } from '../../server/logger.js';
+import type { Redis } from '../../storage/redis-client.js';
+
+const TOKEN_KEY_PREFIX = 'freee-sign-mcp:tokens:';
+
+export interface SignTokenStore {
+  loadTokens(userId: string): Promise<TokenData | null>;
+  saveTokens(userId: string, tokens: TokenData): Promise<void>;
+  clearTokens(userId: string): Promise<void>;
+  getValidAccessToken(userId: string): Promise<string | null>;
+}
+
+export class SignRedisTokenStore implements SignTokenStore {
+  private redis: Redis;
+  private oauthConfig: OAuthClientConfig;
+
+  constructor(redis: Redis, oauthConfig: OAuthClientConfig) {
+    this.redis = redis;
+    this.oauthConfig = oauthConfig;
+  }
+
+  async loadTokens(userId: string): Promise<TokenData | null> {
+    const raw = await withRedis('loadTokens', () => this.redis.get(this.tokenKey(userId)));
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      const parsed = JSON.parse(raw);
+      const result = TokenDataSchema.safeParse(parsed);
+      if (!result.success) {
+        getLogger().error(
+          { userId, error: result.error.message },
+          'Invalid Sign token data in Redis',
+        );
+        return null;
+      }
+      return result.data;
+    } catch {
+      getLogger().error({ userId }, 'Failed to parse Sign token data from Redis');
+      return null;
+    }
+  }
+
+  async saveTokens(userId: string, tokens: TokenData): Promise<void> {
+    await withRedis('saveTokens', () =>
+      this.redis.set(
+        this.tokenKey(userId),
+        JSON.stringify(tokens),
+        'EX',
+        REFRESH_TOKEN_TTL_SECONDS,
+      ),
+    );
+  }
+
+  async clearTokens(userId: string): Promise<void> {
+    await withRedis('clearTokens', () => this.redis.del(this.tokenKey(userId)));
+  }
+
+  async getValidAccessToken(userId: string): Promise<string | null> {
+    const tokens = await this.loadTokens(userId);
+    if (!tokens) {
+      return null;
+    }
+
+    if (isTokenValid(tokens)) {
+      return tokens.access_token;
+    }
+
+    // refreshFreeeTokenRaw may throw a freee API error -- that is NOT a Redis error
+    const newTokens = await refreshFreeeTokenRaw(tokens.refresh_token, this.oauthConfig);
+    await this.saveTokens(userId, newTokens);
+    return newTokens.access_token;
+  }
+
+  private tokenKey(userId: string): string {
+    return `${TOKEN_KEY_PREFIX}${userId}`;
+  }
+}

--- a/src/sign/tools.ts
+++ b/src/sign/tools.ts
@@ -1,66 +1,80 @@
 import crypto from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import {
-  getDefaultAuthManager,
-  startCallbackServerWithAutoStop,
-} from '../auth/server.js';
-import { AUTH_TIMEOUT_MS } from '../constants.js';
+import { getDefaultAuthManager, startCallbackServerWithAutoStop } from '../auth/server.js';
+import { AUTH_TIMEOUT_MS, PACKAGE_VERSION } from '../constants.js';
 import { createTextResponse, formatErrorMessage } from '../utils/error.js';
+import type { SignTokenContext } from './client.js';
 import { makeSignApiRequest } from './client.js';
 import { getSignCredentials } from './config.js';
 import { buildSignAuthUrl, exchangeSignCodeForTokens } from './oauth.js';
-import {
-  clearSignTokens,
-  isSignTokenValid,
-  loadSignTokens,
-} from './tokens.js';
+import type { SignTokenStore } from './server/sign-redis-token-store.js';
+import { clearSignTokens, isSignTokenValid, loadSignTokens } from './tokens.js';
 
-function addSignAuthTools(server: McpServer): void {
-  server.registerTool(
-    'sign_authenticate',
-    {
-      title: 'Sign OAuth認証',
-      description: 'freee サイン OAuth認証を開始（初回のみ必要）',
-      annotations: { destructiveHint: false },
-    },
-    async () => {
-      try {
-        const { clientId, callbackPort } = await getSignCredentials();
+type SignAuthExtra = { authInfo?: { extra?: Record<string, unknown> } };
 
-        await startCallbackServerWithAutoStop(AUTH_TIMEOUT_MS, callbackPort);
+function extractSignTokenContext(extra?: SignAuthExtra): SignTokenContext | undefined {
+  const authExtra = extra?.authInfo?.extra;
+  if (authExtra?.tokenStore && typeof authExtra.userId === 'string') {
+    return {
+      tokenStore: authExtra.tokenStore as SignTokenStore,
+      userId: authExtra.userId,
+    };
+  }
+  return undefined;
+}
 
-        const state = crypto.randomBytes(16).toString('hex');
-        const redirectUri = `http://127.0.0.1:${callbackPort}/callback`;
-        const authUrl = buildSignAuthUrl(state, redirectUri, clientId);
+function addSignAuthTools(server: McpServer, options?: { remote?: boolean }): void {
+  // sign_authenticate は CLI mode のみ（remote は MCP OAuth で認証する）
+  if (!options?.remote) {
+    server.registerTool(
+      'sign_authenticate',
+      {
+        title: 'Sign OAuth認証',
+        description: 'freee サイン OAuth認証を開始（初回のみ必要）',
+        annotations: { destructiveHint: false },
+      },
+      async () => {
+        try {
+          const { clientId, callbackPort } = await getSignCredentials();
 
-        // コールバック受信時にトークン交換を実行するハンドラを登録
-        const authManager = getDefaultAuthManager();
-        authManager.registerCliAuthHandler(state, {
-          resolve: (code: string): void => {
-            exchangeSignCodeForTokens(code, redirectUri).then(() => {
-              console.error('Sign authentication completed successfully');
-            }).catch((err) => {
-              console.error('Sign token exchange failed:', err);
-            }).finally(() => {
+          await startCallbackServerWithAutoStop(AUTH_TIMEOUT_MS, callbackPort);
+
+          const state = crypto.randomBytes(16).toString('hex');
+          const redirectUri = `http://127.0.0.1:${callbackPort}/callback`;
+          const authUrl = buildSignAuthUrl(state, redirectUri, clientId);
+
+          // コールバック受信時にトークン交換を実行するハンドラを登録
+          const authManager = getDefaultAuthManager();
+          authManager.registerCliAuthHandler(state, {
+            resolve: (code: string): void => {
+              exchangeSignCodeForTokens(code, redirectUri)
+                .then(() => {
+                  console.error('Sign authentication completed successfully');
+                })
+                .catch((err) => {
+                  console.error('Sign token exchange failed:', err);
+                })
+                .finally(() => {
+                  authManager.removeCliAuthHandler(state);
+                });
+            },
+            reject: (error: Error): void => {
+              console.error('Sign authentication failed:', error);
               authManager.removeCliAuthHandler(state);
-            });
-          },
-          reject: (error: Error): void => {
-            console.error('Sign authentication failed:', error);
-            authManager.removeCliAuthHandler(state);
-          },
-          codeVerifier: '',
-        });
+            },
+            codeVerifier: '',
+          });
 
-        return createTextResponse(
-          `認証URL: ${authUrl}\n\nブラウザで開いて認証してください。5分でタイムアウトします。`,
-        );
-      } catch (error) {
-        return createTextResponse(`認証開始に失敗: ${formatErrorMessage(error)}`);
-      }
-    },
-  );
+          return createTextResponse(
+            `認証URL: ${authUrl}\n\nブラウザで開いて認証してください。5分でタイムアウトします。`,
+          );
+        } catch (error) {
+          return createTextResponse(`認証開始に失敗: ${formatErrorMessage(error)}`);
+        }
+      },
+    );
+  }
 
   server.registerTool(
     'sign_auth_status',
@@ -69,8 +83,22 @@ function addSignAuthTools(server: McpServer): void {
       description: 'freee サインの認証状態を確認',
       annotations: { readOnlyHint: true },
     },
-    async () => {
+    async (extra?: SignAuthExtra) => {
       try {
+        const tokenContext = extractSignTokenContext(extra);
+        if (tokenContext) {
+          const tokens = await tokenContext.tokenStore.loadTokens(tokenContext.userId);
+          if (!tokens) {
+            return createTextResponse('未認証です。MCP OAuth で認証を行ってください。');
+          }
+          if (isSignTokenValid(tokens)) {
+            const expiresAt = new Date(tokens.expires_at).toLocaleString('ja-JP');
+            return createTextResponse(`認証済み（有効）\n有効期限: ${expiresAt}`);
+          }
+          return createTextResponse(
+            'トークンの有効期限が切れていますが、次回API使用時に自動更新されます。',
+          );
+        }
         const tokens = await loadSignTokens();
         if (!tokens) {
           return createTextResponse(
@@ -100,8 +128,13 @@ function addSignAuthTools(server: McpServer): void {
       description: 'freee サインの認証情報をクリア',
       annotations: { destructiveHint: true },
     },
-    async () => {
+    async (extra?: SignAuthExtra) => {
       try {
+        const tokenContext = extractSignTokenContext(extra);
+        if (tokenContext) {
+          await tokenContext.tokenStore.clearTokens(tokenContext.userId);
+          return createTextResponse('freee サインの認証情報をクリアしました。');
+        }
         await clearSignTokens();
         return createTextResponse('freee サインの認証情報をクリアしました。');
       } catch (error) {
@@ -111,7 +144,7 @@ function addSignAuthTools(server: McpServer): void {
   );
 }
 
-export function addSignApiTools(server: McpServer): void {
+export function addSignApiTools(server: McpServer, _options?: { remote?: boolean }): void {
   const methods = [
     { name: 'sign_api_get', method: 'GET', desc: 'freee サイン API GET' },
     { name: 'sign_api_post', method: 'POST', desc: 'freee サイン API POST' },
@@ -122,13 +155,17 @@ export function addSignApiTools(server: McpServer): void {
 
   for (const { name, method, desc } of methods) {
     // サイン API の DELETE は user_id 等を body で要求するエンドポイントがある
-    const hasBody = method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
+    const hasBody =
+      method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
     const baseSchema = {
       path: z.string().describe('APIパス (例: /v1/documents)'),
       query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ'),
     };
     const inputSchema = hasBody
-      ? { ...baseSchema, body: z.record(z.string(), z.unknown()).optional().describe('リクエストボディ') }
+      ? {
+          ...baseSchema,
+          body: z.record(z.string(), z.unknown()).optional().describe('リクエストボディ'),
+        }
       : baseSchema;
 
     server.registerTool(
@@ -139,9 +176,19 @@ export function addSignApiTools(server: McpServer): void {
         inputSchema,
         annotations: { readOnlyHint: method === 'GET' },
       },
-      async (args: { path: string; query?: Record<string, unknown>; body?: Record<string, unknown> }) => {
+      async (
+        args: { path: string; query?: Record<string, unknown>; body?: Record<string, unknown> },
+        extra?: SignAuthExtra,
+      ) => {
         try {
-          const apiResponse = await makeSignApiRequest(method, args.path, args.query, args.body);
+          const tokenContext = extractSignTokenContext(extra);
+          const apiResponse = await makeSignApiRequest(
+            method,
+            args.path,
+            args.query,
+            args.body,
+            tokenContext,
+          );
           if (apiResponse === null) {
             return createTextResponse('操作が完了しました（レスポンスなし）。');
           }
@@ -154,6 +201,24 @@ export function addSignApiTools(server: McpServer): void {
   }
 }
 
-export function addSignAuthenticationTools(server: McpServer): void {
-  addSignAuthTools(server);
+export function addSignAuthenticationTools(
+  server: McpServer,
+  options?: { remote?: boolean },
+): void {
+  addSignAuthTools(server, options);
+
+  const transport = options?.remote ? 'remote' : 'stdio';
+  server.registerTool(
+    'sign_server_info',
+    {
+      title: 'Sign サーバー情報',
+      description: 'freee-sign-mcp サーバーの情報を取得',
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    async () => {
+      return createTextResponse(
+        `freee-sign-mcp server info:\n- version: ${PACKAGE_VERSION}\n- transport: ${transport}`,
+      );
+    },
+  );
 }

--- a/src/sign/tools.ts
+++ b/src/sign/tools.ts
@@ -174,10 +174,14 @@ export function addSignApiTools(server: McpServer, options?: { remote?: boolean 
       method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
     const baseSchema = {
       // 絶対 URL や protocol-relative URL を受け付けると new URL(path, base) が
-      // base を無視して外部ホストに Bearer トークンを送出してしまうため /v1/ 始まりに制限
+      // base を無視して外部ホストに Bearer トークンを送出してしまうため /v1/ 始まりに制限。
+      // `..` / `%2e%2e` は new URL の normalize で /v1/ 外に逸脱するため Zod で事前拒否
       path: z
         .string()
         .regex(/^\/v1\//, 'path は /v1/ から始まる相対パスを指定してください')
+        .refine((p) => !/(\.\.|%2e%2e)/i.test(p), {
+          message: 'path に path traversal (.. / %2e%2e) を含めることはできません',
+        })
         .describe('APIパス (例: /v1/documents)'),
       query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ'),
     };

--- a/src/sign/tools.ts
+++ b/src/sign/tools.ts
@@ -24,6 +24,21 @@ function extractSignTokenContext(extra?: SignAuthExtra): SignTokenContext | unde
   return undefined;
 }
 
+// Remote 時に tokenContext が取れない場合、local filesystem トークンへ fallback させると
+// 他ユーザーの資格情報を共有する impersonation になるため、明示的に失敗させる
+function resolveTokenContext(
+  extra: SignAuthExtra | undefined,
+  isRemote: boolean,
+): SignTokenContext | undefined {
+  const ctx = extractSignTokenContext(extra);
+  if (isRemote && !ctx) {
+    throw new Error(
+      'Remote モードで認証コンテキストが取得できませんでした。MCP クライアントを再接続してください。',
+    );
+  }
+  return ctx;
+}
+
 function addSignAuthTools(server: McpServer, options?: { remote?: boolean }): void {
   // sign_authenticate は CLI mode のみ（remote は MCP OAuth で認証する）
   if (!options?.remote) {
@@ -85,7 +100,7 @@ function addSignAuthTools(server: McpServer, options?: { remote?: boolean }): vo
     },
     async (extra?: SignAuthExtra) => {
       try {
-        const tokenContext = extractSignTokenContext(extra);
+        const tokenContext = resolveTokenContext(extra, options?.remote ?? false);
         if (tokenContext) {
           const tokens = await tokenContext.tokenStore.loadTokens(tokenContext.userId);
           if (!tokens) {
@@ -130,7 +145,7 @@ function addSignAuthTools(server: McpServer, options?: { remote?: boolean }): vo
     },
     async (extra?: SignAuthExtra) => {
       try {
-        const tokenContext = extractSignTokenContext(extra);
+        const tokenContext = resolveTokenContext(extra, options?.remote ?? false);
         if (tokenContext) {
           await tokenContext.tokenStore.clearTokens(tokenContext.userId);
           return createTextResponse('freee サインの認証情報をクリアしました。');
@@ -144,7 +159,7 @@ function addSignAuthTools(server: McpServer, options?: { remote?: boolean }): vo
   );
 }
 
-export function addSignApiTools(server: McpServer, _options?: { remote?: boolean }): void {
+export function addSignApiTools(server: McpServer, options?: { remote?: boolean }): void {
   const methods = [
     { name: 'sign_api_get', method: 'GET', desc: 'freee サイン API GET' },
     { name: 'sign_api_post', method: 'POST', desc: 'freee サイン API POST' },
@@ -158,7 +173,12 @@ export function addSignApiTools(server: McpServer, _options?: { remote?: boolean
     const hasBody =
       method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
     const baseSchema = {
-      path: z.string().describe('APIパス (例: /v1/documents)'),
+      // 絶対 URL や protocol-relative URL を受け付けると new URL(path, base) が
+      // base を無視して外部ホストに Bearer トークンを送出してしまうため /v1/ 始まりに制限
+      path: z
+        .string()
+        .regex(/^\/v1\//, 'path は /v1/ から始まる相対パスを指定してください')
+        .describe('APIパス (例: /v1/documents)'),
       query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ'),
     };
     const inputSchema = hasBody
@@ -181,7 +201,7 @@ export function addSignApiTools(server: McpServer, _options?: { remote?: boolean
         extra?: SignAuthExtra,
       ) => {
         try {
-          const tokenContext = extractSignTokenContext(extra);
+          const tokenContext = resolveTokenContext(extra, options?.remote ?? false);
           const apiResponse = await makeSignApiRequest(
             method,
             args.path,


### PR DESCRIPTION
## 概要

freee サイン（ninja-sign.com）用の Remote MCP サーバー `freee-sign-remote-mcp` を追加。freee 本体と同一構成で OAuth 2.1 AS + Streamable HTTP transport + Redis トークンストア + canonical log line + OTel tracing を提供する。

<!-- 変更内容を簡潔に記述 -->

## 変更種別

- [x] 新機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント
- [ ] その他