### PR TITLE
Add Agent Package Manager (APM) support for freee-api-skill

### DIFF
--- a/.changeset/apm-support.md
+++ b/.changeset/apm-support.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+Microsoft の [Agent Package Manager (APM)](https://github.com/microsoft/apm) による配布に対応。`skills/freee-api-skill/` に `apm.yml` を追加し、`apm install freee/freee-mcp/skills/freee-api-skill` コマンドでスキルをインストール可能にした。APM は対象プロジェクトに存在する `.github/`、`.claude/`、`.cursor/`、`.opencode/`、`.codex/` の各ディレクトリへスキルを自動デプロイする。

--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ npx skills add freee/freee-mcp
 
 グローバルインストール(`-g`)や特定スキルのみのインストール(`-s`)も可能です。
 
+[Agent Package Manager (APM)](https://github.com/microsoft/apm) を利用している場合は、以下のコマンドでもインストールできます。GitHub Copilot / Claude Code / Cursor / OpenCode / Codex など、プロジェクトに存在する対象ディレクトリに自動でデプロイされます。
+
+```bash
+apm install freee/freee-mcp/skills/freee-api-skill
+```
+
 ## Claude Code Plugin として使う
 
 Claude Code でプラグインとしてインストールすると、MCP サーバーと Agent Skills（API リファレンス・操作レシピ）がまとめて利用できます。

--- a/skills/freee-api-skill/apm.yml
+++ b/skills/freee-api-skill/apm.yml
@@ -1,0 +1,3 @@
+name: freee-api-skill
+version: 0.24.0
+description: freee の会計・人事労務・請求書・工数管理・販売・サイン（電子契約）API と連携するスキル。API リファレンスと操作レシピを提供し、freee-mcp / freee-sign-mcp 経由で正確な API 利用をガイドする。


### PR DESCRIPTION
## 概要

Microsoft の Agent Package Manager (APM) による配布に対応しました。`skills/freee-api-skill/` に `apm.yml` を追加し、`apm install freee/freee-mcp/skills/freee-api-skill` コマンドでスキルをインストール可能にしました。

APM を使用することで、GitHub Copilot、Claude Code、Cursor、OpenCode、Codex などのプロジェクトに存在する対象ディレクトリ（`.github/`、`.claude/`、`.cursor/`、`.opencode/`、`.codex/`）へスキルが自動でデプロイされます。

## 変更内容

- **apm.yml の追加**: `skills/freee-api-skill/` に APM 設定ファイルを追加
  - スキル名、バージョン、説明を定義
  - freee API との連携とリファレンス・操作レシピの提供を明記

- **README.md の更新**: APM によるインストール方法をドキュメントに追加
  - 既存の npx skills コマンドに加えて、APM コマンドでのインストール手順を記載

## 変更種別

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他

## テスト

APM の設定ファイルは静的な構成ファイルであり、実際の APM インストール動作は APM ツール側で検証されます。ドキュメント更新は記述内容の正確性を確認済みです。

https://claude.ai/code/session_01AjsqSnLx9Nz9sqnuxxNGwY