### PR TITLE
Add GitHub CLI `gh skill` command support

### DIFF
--- a/.changeset/add-gh-skill-support.md
+++ b/.changeset/add-gh-skill-support.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+GitHub CLI の `gh skill` コマンド（v2.90.0 以降）経由でのスキルインストールをサポート。`skills/freee-api-skill/SKILL.md` のフロントマターに `license` と `metadata` を追加し、README に `gh skill install freee/freee-mcp freee-api-skill` のインストール手順を記載。

--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ npx skills add freee/freee-mcp
 
 グローバルインストール(`-g`)や特定スキルのみのインストール(`-s`)も可能です。
 
+GitHub CLI（v2.90.0 以降）の [`gh skill`](https://cli.github.com/manual/gh_skill) コマンドからもインストールできます。
+
+```bash
+gh skill install freee/freee-mcp freee-api-skill
+```
+
+`--agent`（例: `claude-code`, `copilot`, `cursor`, `codex`, `gemini-cli`）や `--scope user`／`--scope project` の指定、`--pin` による特定タグ/コミットへの固定にも対応しています。
+
 ## Claude Code Plugin として使う
 
 Claude Code でプラグインとしてインストールすると、MCP サーバーと Agent Skills（API リファレンス・操作レシピ）がまとめて利用できます。

--- a/skills/freee-api-skill/SKILL.md
+++ b/skills/freee-api-skill/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: freee-api-skill
 description: "freee-mcp / freee-sign-mcp と連携するスキル。会計・人事労務・請求書・工数管理・販売・サイン（電子契約）の詳細APIリファレンスと使い方ガイドを提供。freee の経費申請・取引登録・勤怠打刻・給与明細・見積書・試算表・仕訳・従業員管理・工数登録・売上管理・電子契約の文書管理などの操作やAPI仕様を調べたいときに使う。ユーザーが freee のデータ操作、会計処理、人事労務管理、請求・見積、プロジェクト工数管理、販売管理、電子契約について質問や操作を依頼してきた場合は、明示的に freee と言及していなくても、このスキルの利用を検討すること。サインは別途 freee-sign-mcp の設定が必要。"
+license: Apache-2.0
+metadata:
+  author: freee_jp
+  homepage: https://github.com/freee/freee-mcp
 ---
 
 # freee API スキル


### PR DESCRIPTION
## 概要

GitHub CLI（v2.90.0 以降）の `gh skill` コマンド経由でのスキルインストールをサポートしました。SKILL.md のフロントマターに `license` と `metadata` フィールドを追加し、README にインストール手順を記載しました。

## 変更内容

- **SKILL.md**: フロントマターに以下を追加
  - `license: Apache-2.0`
  - `metadata` セクション（author、homepage）
  
- **README.md**: GitHub CLI での `gh skill install` コマンドの使用方法を記載
  - 基本的なインストール手順
  - `--agent`、`--scope`、`--pin` オプションの対応状況を説明

- **.changeset**: パッチバージョン変更の記録

## 変更種別

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他

## テスト

README の記載内容は GitHub CLI の公式ドキュメントに準拠しており、SKILL.md のフロントマター形式は GitHub Skills の仕様に従っています。CI による検証で確認可能です。

https://claude.ai/code/session_01JKb3rgi9p5QaZUCHvtUdXw