### PR TITLE
chore(release): リリース時に apm.yml のバージョンを同期

### DIFF
--- a/.changeset/sync-apm-version.md
+++ b/.changeset/sync-apm-version.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+リリース時に `skills/freee-api-skill/apm.yml` の `version` フィールドを `package.json` に自動追従させるよう publish ワークフローを拡張。既存の `.claude-plugin/plugin.json` / `marketplace.json` の同期ステップと同じコミットでまとめて push される。

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,13 +188,14 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
 
-      - name: Sync plugin.json version
+      - name: Sync plugin.json and apm.yml version
         if: steps.check-npm.outputs.skip != 'true'
         run: |
           VERSION=${{ steps.version.outputs.version }}
           jq --arg v "$VERSION" '.version = $v' .claude-plugin/plugin.json > tmp.json && mv tmp.json .claude-plugin/plugin.json
           jq --arg v "$VERSION" '.plugins[0].version = $v' .claude-plugin/marketplace.json > tmp.json && mv tmp.json .claude-plugin/marketplace.json
-          git add .claude-plugin/
-          git commit -m "chore: sync plugin version to $VERSION" || echo "No changes to commit"
+          sed -i "s/^version: .*/version: $VERSION/" skills/freee-api-skill/apm.yml
+          git add .claude-plugin/ skills/freee-api-skill/apm.yml
+          git commit -m "chore: sync plugin and skill version to $VERSION" || echo "No changes to commit"
           git push
-          echo "✅ Synced plugin.json version"
+          echo "✅ Synced plugin.json and apm.yml versions"


### PR DESCRIPTION
## 概要

リリース時に `skills/freee-api-skill/apm.yml` の `version` を `package.json` の値に自動追従させる。これまで同期対象は `.claude-plugin/plugin.json` / `marketplace.json` のみで、APM (Microsoft Agent Package Manager) 向けの `apm.yml` はハードコードのままだったため、次回以降のリリースで version が drift する状態だった。

## 変更内容

- `.github/workflows/publish.yml` の \"Sync plugin.json version\" ステップを拡張
  - `sed -i \"s/^version: .*/version: \$VERSION/\" skills/freee-api-skill/apm.yml` を追加
  - `git add` / commit メッセージも skill を含む形に更新
- changeset (patch) を追加

## 動作確認

- ローカルで `sed \"s/^version: .*/version: 9.9.9/\" skills/freee-api-skill/apm.yml` を実行し、`version` 行のみ置換され他の行に影響しないことを確認
- Pre-flight: `bun run typecheck && bun run lint && bun run test:run && bun run build` すべて green

## 補足

APM manifest schema (v0.1 Working Draft) では `version` は REQUIRED かつ semver (`^\d+\.\d+\.\d+`) でなければならないため、`package.json` に追従させるのが自然。解決 (lockfile への pin) は commit SHA で行われるので、この値はメタデータ用途。