### PR TITLE
feat(telemetry): W3C trace context extraction and SSE/transport observability

### DIFF
--- a/.changeset/distributed-trace-context-extract.md
+++ b/.changeset/distributed-trace-context-extract.md
@@ -1,0 +1,11 @@
+---
+"freee-mcp": patch
+---
+
+Remote モードで W3C `traceparent` を抽出して上流ゲートウェイの trace に server span を接続するようにし、SSE と JSON-RPC を区別できる観測ラベルを追加。
+
+- middleware で `propagation.extract` を呼び、サーバー span を上流（Envoy/Istio）の child として紐付け
+- span 名を `http.server.request` に変更（Datadog operation 命名に整合）
+- `http.transport` (`sse` | `jsonrpc`)、`http.response.close_reason` (`completed` | `client_disconnect`) を span attribute と canonical log に追加
+- 新ヒストグラム `mcp.sse.connection.duration` を追加 — SSE 接続寿命を専用バケットで観測
+- propagator を `CompositePropagator([W3CTraceContext, W3CBaggage])` に拡張、resource に `deployment.environment` を付与

--- a/src/server/request-context.ts
+++ b/src/server/request-context.ts
@@ -87,6 +87,31 @@ export interface RequestRecorderContext {
 }
 
 /**
+ * Inbound transport classification for a single MCP request.
+ *
+ * - `sse`: a long-lived SSE GET (Streamable-HTTP transport). Duration tracks
+ *   the connection lifetime, not the time to produce a JSON-RPC response.
+ * - `jsonrpc`: a short POST that yields a single JSON-RPC response.
+ *
+ * This distinction matters operationally because a 9-minute SSE connection
+ * looks identical to a 9-minute slow JSON-RPC call when filtering on
+ * duration alone.
+ */
+export type CanonicalRequestTransport = 'sse' | 'jsonrpc';
+
+/**
+ * How the response stream actually ended.
+ *
+ * - `completed`: server emitted the full response and `res.on('finish')` fired.
+ * - `client_disconnect`: client closed the socket before completion;
+ *   `res.on('close')` fired without prior `finish`.
+ *
+ * Distinguishes legitimate SSE max-stream timeouts (`completed` at the route's
+ * stream limit) from client-side aborts.
+ */
+export type CanonicalCloseReason = 'completed' | 'client_disconnect';
+
+/**
  * Canonical log line: the complete payload emitted as one JSON log entry
  * per HTTP request at `res.on('finish')`. Consumers (pino, Datadog) see
  * exactly this shape.
@@ -114,6 +139,8 @@ export interface CanonicalLogPayload {
     path: string;
     status: number;
     duration_ms: number;
+    transport: CanonicalRequestTransport;
+    close_reason: CanonicalCloseReason;
   };
   mcp: {
     tool_calls: ToolCallInfo[];
@@ -185,7 +212,12 @@ export class RequestRecorder {
   }
 
   /** Builds the canonical log payload; caller passes it to pino. */
-  buildPayload(http: { status: number; duration_ms: number }): CanonicalLogPayload {
+  buildPayload(http: {
+    status: number;
+    duration_ms: number;
+    transport: CanonicalRequestTransport;
+    close_reason: CanonicalCloseReason;
+  }): CanonicalLogPayload {
     return {
       request_id: this.context.request_id,
       source_ip: this.context.source_ip,
@@ -197,6 +229,8 @@ export class RequestRecorder {
         path: this.context.path,
         status: http.status,
         duration_ms: http.duration_ms,
+        transport: http.transport,
+        close_reason: http.close_reason,
       },
       mcp: {
         tool_calls: this.toolCalls,

--- a/src/telemetry/init.ts
+++ b/src/telemetry/init.ts
@@ -1,6 +1,10 @@
 import { SpanKind, SpanStatusCode, context, metrics, propagation, trace } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
-import { W3CTraceContextPropagator } from '@opentelemetry/core';
+import {
+  CompositePropagator,
+  W3CBaggagePropagator,
+  W3CTraceContextPropagator,
+} from '@opentelemetry/core';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { resourceFromAttributes } from '@opentelemetry/resources';
@@ -114,9 +118,13 @@ export function initTelemetry(serviceVersion: string): OtelHandle | null {
   const serviceName = process.env.OTEL_SERVICE_NAME || 'freee-mcp';
   const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://localhost:4318';
 
+  const deploymentEnv =
+    process.env.OTEL_DEPLOYMENT_ENVIRONMENT ?? process.env.NODE_ENV ?? 'unknown';
+
   const resource = resourceFromAttributes({
     'service.name': serviceName,
     'service.version': serviceVersion,
+    'deployment.environment': deploymentEnv,
   });
 
   const exporter = new OTLPTraceExporter({
@@ -139,10 +147,17 @@ export function initTelemetry(serviceVersion: string): OtelHandle | null {
     spanProcessors: [new BatchSpanProcessor(exporter)],
   });
 
-  // Register global context manager, propagator, and tracer provider
+  // Register global context manager, propagator, and tracer provider.
+  // CompositePropagator wraps W3C Trace Context (parent linkage) + W3C Baggage
+  // (cross-cutting attributes) so future propagators can be added without
+  // changing call sites.
   const contextManager = new AsyncLocalStorageContextManager();
   context.setGlobalContextManager(contextManager);
-  propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+  propagation.setGlobalPropagator(
+    new CompositePropagator({
+      propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
+    }),
+  );
   trace.setGlobalTracerProvider(provider);
 
   // Initialize MeterProvider for metrics export

--- a/src/telemetry/init.ts
+++ b/src/telemetry/init.ts
@@ -25,6 +25,17 @@ export function isOtelEnabled(): boolean {
   return _enabled;
 }
 
+/**
+ * Build the propagator stack the server uses for both incoming extract and
+ * outgoing inject. Exported so test setup can register the exact same
+ * propagator chain — keeping prod and test invariants in sync.
+ */
+export function createDefaultPropagator(): CompositePropagator {
+  return new CompositePropagator({
+    propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
+  });
+}
+
 const SENSITIVE_PARAMS = new Set([
   'code',
   'code_verifier',
@@ -153,11 +164,7 @@ export function initTelemetry(serviceVersion: string): OtelHandle | null {
   // changing call sites.
   const contextManager = new AsyncLocalStorageContextManager();
   context.setGlobalContextManager(contextManager);
-  propagation.setGlobalPropagator(
-    new CompositePropagator({
-      propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
-    }),
-  );
+  propagation.setGlobalPropagator(createDefaultPropagator());
   trace.setGlobalTracerProvider(provider);
 
   // Initialize MeterProvider for metrics export

--- a/src/telemetry/metrics.test.ts
+++ b/src/telemetry/metrics.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   getHttpRequestDuration,
   getHttpRequestErrorCount,
+  getMcpSseConnectionDuration,
   getToolErrorCount,
   getToolInvocationDuration,
 } from './metrics.js';
@@ -54,6 +55,29 @@ describe('HTTP metrics', () => {
       (m) => m.descriptor.name === 'http.server.error.count',
     );
     expect(metric).toBeDefined();
+
+    await provider.shutdown();
+  });
+
+  it('records mcp.sse.connection.duration with seconds unit', async () => {
+    // The new SSE-only histogram is the signal that distinguishes a normal
+    // long-lived stream (ends at the platform stream timeout) from an
+    // anomalous one (ends much earlier or later). Locking the unit to "s"
+    // keeps the Datadog/Grafana axis legible.
+    const { reader, provider } = setupTestMetrics();
+
+    getMcpSseConnectionDuration().record(599.9, {
+      path: '/mcp',
+      status: '200',
+      close_reason: 'completed',
+    });
+
+    const result = await reader.collect();
+    const metric = result.resourceMetrics.scopeMetrics[0]?.metrics.find(
+      (m) => m.descriptor.name === 'mcp.sse.connection.duration',
+    );
+    expect(metric).toBeDefined();
+    expect(metric?.descriptor.unit).toBe('s');
 
     await provider.shutdown();
   });

--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -6,6 +6,7 @@ const METER_NAME = 'freee-mcp';
 // HTTP server metrics
 let _httpRequestDuration: Histogram | null = null;
 let _httpRequestErrorCount: Counter | null = null;
+let _mcpSseConnectionDuration: Histogram | null = null;
 
 // MCP tool metrics
 let _toolInvocationDuration: Histogram | null = null;
@@ -13,7 +14,7 @@ let _toolErrorCount: Counter | null = null;
 
 /**
  * HTTP request duration histogram (seconds).
- * Labels: method, path, status
+ * Labels: method, path, status, transport, close_reason
  */
 export function getHttpRequestDuration(): Histogram {
   if (!_httpRequestDuration) {
@@ -23,6 +24,28 @@ export function getHttpRequestDuration(): Histogram {
     });
   }
   return _httpRequestDuration;
+}
+
+/**
+ * SSE (Streamable-HTTP) connection lifetime histogram (seconds).
+ *
+ * Recorded only for `transport=sse` requests at connection close. The expected
+ * distribution clusters near the route's `streamIdleTimeout` (e.g. ~600s on
+ * Istio's default HTTPRoute), so the p99 reveals whether SSE clients are
+ * disconnecting early or running until the platform max — useful when
+ * triaging `envoy.cluster.upstream_rq_timeout` alerts which alone cannot
+ * distinguish "long but normal SSE" from "slow JSON-RPC".
+ *
+ * Labels: path, status, close_reason
+ */
+export function getMcpSseConnectionDuration(): Histogram {
+  if (!_mcpSseConnectionDuration) {
+    _mcpSseConnectionDuration = metrics.getMeter(METER_NAME).createHistogram('mcp.sse.connection.duration', {
+      description: 'SSE (Streamable-HTTP) connection lifetime',
+      unit: 's',
+    });
+  }
+  return _mcpSseConnectionDuration;
 }
 
 /**

--- a/src/telemetry/middleware.test.ts
+++ b/src/telemetry/middleware.test.ts
@@ -1,7 +1,11 @@
 import http from 'node:http';
 import { context, propagation, trace } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
-import { W3CTraceContextPropagator } from '@opentelemetry/core';
+import {
+  CompositePropagator,
+  W3CBaggagePropagator,
+  W3CTraceContextPropagator,
+} from '@opentelemetry/core';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import {
   BasicTracerProvider,
@@ -44,7 +48,11 @@ function setupInMemoryOtel(): { exporter: InMemorySpanExporter; provider: BasicT
 
   const contextManager = new AsyncLocalStorageContextManager();
   context.setGlobalContextManager(contextManager);
-  propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+  propagation.setGlobalPropagator(
+    new CompositePropagator({
+      propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
+    }),
+  );
   trace.setGlobalTracerProvider(provider);
 
   return { exporter, provider };
@@ -112,7 +120,14 @@ describe('createTracingMiddleware', () => {
 
     const spans = exporter.getFinishedSpans();
     expect(spans.length).toBe(1);
-    expect(spans[0].name).toBe('HTTP GET /test');
+    // Span name follows the OTel/Datadog `http.server.request` convention
+    // so existing Datadog facets continue to match. Method and path are
+    // kept as attributes (`http.request.method`, `url.path`) instead of
+    // being baked into the span name.
+    expect(spans[0].name).toBe('http.server.request');
+    expect(spans[0].attributes['http.request.method']).toBe('GET');
+    expect(spans[0].attributes['url.path']).toBe('/test');
+    expect(spans[0].attributes['http.transport']).toBe('jsonrpc');
 
     await provider.shutdown();
     await new Promise<void>((resolve) => {
@@ -217,6 +232,171 @@ describe('createTracingMiddleware', () => {
       server.close(() => resolve());
     });
   });
+
+  it('extracts incoming W3C traceparent so the span links to the upstream gateway trace', async () => {
+    process.env.OTEL_ENABLED = 'true';
+    const { exporter, provider } = setupInMemoryOtel();
+
+    vi.doMock('./init.js', () => ({ isOtelEnabled: () => true }));
+    const { createTracingMiddleware } = await import('./middleware.js');
+    const app = express();
+    app.use(createTracingMiddleware());
+    app.post('/mcp', (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    server = app.listen(0);
+    const addr = server.address();
+    port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    // traceparent: version-traceid-parentspanid-flags
+    const upstreamTraceId = '0af7651916cd43dd8448eb211c80319c';
+    const upstreamSpanId = 'b7ad6b7169203331';
+    await makeRequest(port, '/mcp', 'POST', {
+      traceparent: `00-${upstreamTraceId}-${upstreamSpanId}-01`,
+    });
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+    // The server span MUST inherit the upstream trace_id and treat the
+    // upstream span as its parent. Without `propagation.extract` the span
+    // would start a fresh trace and Datadog APM would render two
+    // disconnected services.
+    expect(spans[0].spanContext().traceId).toBe(upstreamTraceId);
+    expect(spans[0].parentSpanContext?.spanId).toBe(upstreamSpanId);
+
+    await provider.shutdown();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it('starts a fresh root trace when no incoming traceparent header is present', async () => {
+    // Regression guard: when nothing upstream sets a traceparent (e.g. local
+    // CLI mode or an internal cron), the server span must be a brand-new
+    // root, not silently reuse a stale parent.
+    process.env.OTEL_ENABLED = 'true';
+    const { exporter, provider } = setupInMemoryOtel();
+
+    vi.doMock('./init.js', () => ({ isOtelEnabled: () => true }));
+    const { createTracingMiddleware } = await import('./middleware.js');
+    const app = express();
+    app.use(createTracingMiddleware());
+    app.post('/mcp', (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    server = app.listen(0);
+    const addr = server.address();
+    port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    await makeRequest(port, '/mcp', 'POST');
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+    // No upstream parent → parentSpanContext is undefined (root span).
+    expect(spans[0].parentSpanContext).toBeUndefined();
+    // The synthesized traceId should still be a valid 32-hex (sanity check
+    // that the span itself is well-formed).
+    expect(spans[0].spanContext().traceId).toMatch(/^[0-9a-f]{32}$/);
+
+    await provider.shutdown();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it('classifies GET /mcp as the SSE transport and POST /mcp as JSON-RPC', async () => {
+    process.env.OTEL_ENABLED = 'true';
+    const { exporter, provider } = setupInMemoryOtel();
+
+    vi.doMock('./init.js', () => ({ isOtelEnabled: () => true }));
+    const { createTracingMiddleware } = await import('./middleware.js');
+    const app = express();
+    app.use(createTracingMiddleware());
+    app.all('/mcp', (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    server = app.listen(0);
+    const addr = server.address();
+    port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    await makeRequest(port, '/mcp', 'GET');
+    await makeRequest(port, '/mcp', 'POST');
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(2);
+    const byMethod = Object.fromEntries(
+      spans.map((s) => [s.attributes['http.request.method'] as string, s]),
+    );
+    expect(byMethod.GET.attributes['http.transport']).toBe('sse');
+    expect(byMethod.POST.attributes['http.transport']).toBe('jsonrpc');
+
+    await provider.shutdown();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it('classifies non-/mcp GET requests as JSON-RPC, not SSE', async () => {
+    // OAuth callbacks and other GET endpoints are one-shot, not streaming.
+    // The transport label exists to separate SSE long-lived connections
+    // from one-shot handlers, so it must be path-aware.
+    process.env.OTEL_ENABLED = 'true';
+    const { exporter, provider } = setupInMemoryOtel();
+
+    vi.doMock('./init.js', () => ({ isOtelEnabled: () => true }));
+    const { createTracingMiddleware } = await import('./middleware.js');
+    const app = express();
+    app.use(createTracingMiddleware());
+    app.get('/oauth/authorize', (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    server = app.listen(0);
+    const addr = server.address();
+    port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    await makeRequest(port, '/oauth/authorize', 'GET');
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+    expect(spans[0].attributes['http.transport']).toBe('jsonrpc');
+
+    await provider.shutdown();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it('records http.response.close_reason=completed when the server finishes the response', async () => {
+    process.env.OTEL_ENABLED = 'true';
+    const { exporter, provider } = setupInMemoryOtel();
+
+    vi.doMock('./init.js', () => ({ isOtelEnabled: () => true }));
+    const { createTracingMiddleware } = await import('./middleware.js');
+    const app = express();
+    app.use(createTracingMiddleware());
+    app.post('/mcp', (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    server = app.listen(0);
+    const addr = server.address();
+    port = typeof addr === 'object' && addr ? addr.port : 0;
+
+    await makeRequest(port, '/mcp', 'POST');
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+    expect(spans[0].attributes['http.response.close_reason']).toBe('completed');
+
+    await provider.shutdown();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
 });
 
 describe('createTracingMiddleware - canonical log line', () => {
@@ -301,6 +481,11 @@ describe('createTracingMiddleware - canonical log line', () => {
         path: '/mcp',
         status: 200,
         duration_ms: expect.any(Number),
+        // Triage facets surfaced into the canonical log line so Datadog
+        // queries can split SSE long-lived connections from JSON-RPC
+        // one-shot calls without joining the trace span attributes.
+        transport: 'sse',
+        close_reason: 'completed',
       },
       mcp: { tool_calls: [], tool_call_count: 0 },
       api: { calls: [], call_count: 0 },

--- a/src/telemetry/middleware.test.ts
+++ b/src/telemetry/middleware.test.ts
@@ -1,11 +1,6 @@
 import http from 'node:http';
 import { context, propagation, trace } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
-import {
-  CompositePropagator,
-  W3CBaggagePropagator,
-  W3CTraceContextPropagator,
-} from '@opentelemetry/core';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import {
   BasicTracerProvider,
@@ -14,6 +9,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import express from 'express';
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import { createDefaultPropagator } from './init.js';
 
 function makeRequest(
   port: number,
@@ -48,11 +44,7 @@ function setupInMemoryOtel(): { exporter: InMemorySpanExporter; provider: BasicT
 
   const contextManager = new AsyncLocalStorageContextManager();
   context.setGlobalContextManager(contextManager);
-  propagation.setGlobalPropagator(
-    new CompositePropagator({
-      propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
-    }),
-  );
+  propagation.setGlobalPropagator(createDefaultPropagator());
   trace.setGlobalTracerProvider(provider);
 
   return { exporter, provider };

--- a/src/telemetry/middleware.ts
+++ b/src/telemetry/middleware.ts
@@ -134,14 +134,15 @@ export function createTracingMiddleware(): (
     });
 
     const startTime = performance.now();
-    // GET /mcp under MCP Streamable-HTTP is a long-lived SSE stream; POST /mcp
-    // is a short JSON-RPC exchange. OAuth/token endpoints are also one-shot.
-    // Classify here so duration interpretation, metric labels, and span
-    // attributes are consistent — duration of an SSE connection ≠ duration
-    // of a JSON-RPC handler.
+    // GET /mcp under MCP Streamable-HTTP is a long-lived SSE stream; everything
+    // else (POST /mcp, OAuth, /token) is a one-shot exchange. The transport
+    // label is path-aware so OAuth GET endpoints don't pollute the SSE bucket.
     const transport: CanonicalRequestTransport =
       req.method === 'GET' && req.path === '/mcp' ? 'sse' : 'jsonrpc';
-    let closeReason: CanonicalCloseReason | undefined;
+    // Default to 'completed'; only overwritten when `close` fires before
+    // `finish` (client aborted the stream). flushOnce() guards the payload
+    // so a late post-flush mutation is harmless.
+    let closeReason: CanonicalCloseReason = 'completed';
     let otelSpan: Span | undefined;
 
     if (isOtelEnabled()) {
@@ -170,9 +171,6 @@ export function createTracingMiddleware(): (
 
       const durationMs = Math.round(performance.now() - startTime);
       const status = res.statusCode;
-      // One of finish/close always fires; default `completed` is a defensive
-      // fallback for hypothetical synthetic invocations.
-      const finalCloseReason: CanonicalCloseReason = closeReason ?? 'completed';
 
       // Safety net for the canonical-log "1 line = full debug context"
       // promise. See RequestRecorder.synthesizeFallbackErrorIfMissing.
@@ -184,7 +182,7 @@ export function createTracingMiddleware(): (
         status,
         duration_ms: durationMs,
         transport,
-        close_reason: finalCloseReason,
+        close_reason: closeReason,
       });
       const message = messageFor(status);
       const level = levelFor(status);
@@ -209,13 +207,13 @@ export function createTracingMiddleware(): (
           transport,
         };
         otelSpan.setAttribute('http.response.status_code', status);
-        otelSpan.setAttribute('http.response.close_reason', finalCloseReason);
+        otelSpan.setAttribute('http.response.close_reason', closeReason);
         getHttpRequestDuration().record(durationMs / 1000, httpAttrs);
         if (transport === 'sse') {
           getMcpSseConnectionDuration().record(durationMs / 1000, {
             path: req.path,
             status: String(status),
-            close_reason: finalCloseReason,
+            close_reason: closeReason,
           });
         }
         if (level === 'error') {
@@ -226,16 +224,14 @@ export function createTracingMiddleware(): (
       }
     };
 
-    // Attach flush to both events. flushOnce() inside ensures it runs at most
-    // once regardless of which fires first. Capturing which listener won the
-    // race lets us distinguish a server-completed response (`finish`) from a
-    // client-aborted SSE stream (`close` without prior `finish`).
-    res.on('finish', () => {
-      closeReason ??= 'completed';
-      flush();
-    });
+    // flushOnce() inside flush ensures it runs at most once regardless of
+    // which event fires first. The `close` listener overwrites closeReason
+    // unconditionally — when `close` arrives after `finish`, the payload was
+    // already built; when `close` arrives without prior `finish`, the
+    // overwrite reflects a client-aborted SSE stream.
+    res.on('finish', flush);
     res.on('close', () => {
-      closeReason ??= 'client_disconnect';
+      closeReason = 'client_disconnect';
       flush();
     });
 

--- a/src/telemetry/middleware.ts
+++ b/src/telemetry/middleware.ts
@@ -1,12 +1,28 @@
 import { randomUUID } from 'node:crypto';
-import { SpanKind, SpanStatusCode, context, trace, type Span } from '@opentelemetry/api';
+import {
+  SpanKind,
+  SpanStatusCode,
+  context,
+  propagation,
+  trace,
+  type Span,
+} from '@opentelemetry/api';
 import type { NextFunction, Request, Response } from 'express';
 import { scrubErrorMessage } from '../server/error-serializer.js';
 import { getClientIp } from '../server/http-utils.js';
 import { getLogger } from '../server/logger.js';
-import { RequestRecorder, withRequestRecorder } from '../server/request-context.js';
+import {
+  type CanonicalCloseReason,
+  type CanonicalRequestTransport,
+  RequestRecorder,
+  withRequestRecorder,
+} from '../server/request-context.js';
 import { isOtelEnabled } from './init.js';
-import { getHttpRequestDuration, getHttpRequestErrorCount } from './metrics.js';
+import {
+  getHttpRequestDuration,
+  getHttpRequestErrorCount,
+  getMcpSseConnectionDuration,
+} from './metrics.js';
 
 /**
  * Hard cap on the inbound User-Agent string length before it is logged.
@@ -118,17 +134,35 @@ export function createTracingMiddleware(): (
     });
 
     const startTime = performance.now();
+    // GET /mcp under MCP Streamable-HTTP is a long-lived SSE stream; POST /mcp
+    // is a short JSON-RPC exchange. OAuth/token endpoints are also one-shot.
+    // Classify here so duration interpretation, metric labels, and span
+    // attributes are consistent — duration of an SSE connection ≠ duration
+    // of a JSON-RPC handler.
+    const transport: CanonicalRequestTransport =
+      req.method === 'GET' && req.path === '/mcp' ? 'sse' : 'jsonrpc';
+    let closeReason: CanonicalCloseReason | undefined;
     let otelSpan: Span | undefined;
 
     if (isOtelEnabled()) {
       const tracer = trace.getTracer('freee-mcp');
-      otelSpan = tracer.startSpan(`HTTP ${req.method} ${req.path}`, {
-        kind: SpanKind.SERVER,
-        attributes: {
-          'http.request.method': req.method,
-          'url.path': req.path,
+      // Extract upstream W3C trace context (`traceparent` / `tracestate` /
+      // `baggage`) from inbound headers so the server span becomes a child
+      // of the gateway/Envoy span — without this the trace would always
+      // start fresh and Datadog APM would show two disconnected traces.
+      const parentCtx = propagation.extract(context.active(), req.headers);
+      otelSpan = tracer.startSpan(
+        'http.server.request',
+        {
+          kind: SpanKind.SERVER,
+          attributes: {
+            'http.request.method': req.method,
+            'url.path': req.path,
+            'http.transport': transport,
+          },
         },
-      });
+        parentCtx,
+      );
     }
 
     const flush = (): void => {
@@ -136,6 +170,9 @@ export function createTracingMiddleware(): (
 
       const durationMs = Math.round(performance.now() - startTime);
       const status = res.statusCode;
+      // One of finish/close always fires; default `completed` is a defensive
+      // fallback for hypothetical synthetic invocations.
+      const finalCloseReason: CanonicalCloseReason = closeReason ?? 'completed';
 
       // Safety net for the canonical-log "1 line = full debug context"
       // promise. See RequestRecorder.synthesizeFallbackErrorIfMissing.
@@ -143,7 +180,12 @@ export function createTracingMiddleware(): (
         recorder.synthesizeFallbackErrorIfMissing(status);
       }
 
-      const payload = recorder.buildPayload({ status, duration_ms: durationMs });
+      const payload = recorder.buildPayload({
+        status,
+        duration_ms: durationMs,
+        transport,
+        close_reason: finalCloseReason,
+      });
       const message = messageFor(status);
       const level = levelFor(status);
       const logger = getLogger();
@@ -160,22 +202,42 @@ export function createTracingMiddleware(): (
       }
 
       if (otelSpan) {
-        const attrs = { method: req.method, path: req.path, status: String(status) };
+        const httpAttrs = {
+          method: req.method,
+          path: req.path,
+          status: String(status),
+          transport,
+        };
         otelSpan.setAttribute('http.response.status_code', status);
-        getHttpRequestDuration().record(durationMs / 1000, attrs);
+        otelSpan.setAttribute('http.response.close_reason', finalCloseReason);
+        getHttpRequestDuration().record(durationMs / 1000, httpAttrs);
+        if (transport === 'sse') {
+          getMcpSseConnectionDuration().record(durationMs / 1000, {
+            path: req.path,
+            status: String(status),
+            close_reason: finalCloseReason,
+          });
+        }
         if (level === 'error') {
           otelSpan.setStatus({ code: SpanStatusCode.ERROR, message: `HTTP ${status}` });
-          getHttpRequestErrorCount().add(1, attrs);
+          getHttpRequestErrorCount().add(1, httpAttrs);
         }
         otelSpan.end();
       }
     };
 
     // Attach flush to both events. flushOnce() inside ensures it runs at most
-    // once regardless of which fires first (normal completion vs. client
-    // disconnect during SSE streaming).
-    res.on('finish', flush);
-    res.on('close', flush);
+    // once regardless of which fires first. Capturing which listener won the
+    // race lets us distinguish a server-completed response (`finish`) from a
+    // client-aborted SSE stream (`close` without prior `finish`).
+    res.on('finish', () => {
+      closeReason ??= 'completed';
+      flush();
+    });
+    res.on('close', () => {
+      closeReason ??= 'client_disconnect';
+      flush();
+    });
 
     const runDownstream = (): void => {
       withRequestRecorder(recorder, () => {


### PR DESCRIPTION
## 概要

### 背景

APM で 2 つの観測課題が発生していた。

1. 分散 trace の分断: 上流 proxy（Envoy など）の trace と `freee-mcp` アプリの trace が別々の trace_id で表示され、proxy → freee-mcp のフレームグラフが繋がらない
2. upstream timeout アラートの根本原因不明: `envoy.cluster.upstream_rq_timeout.count` 系のアラートが、正常な SSE 長時間接続によるものなのか、アプリの本当の遅延なのかを区別する手段がなかった

### 変更内容

1. W3C trace context 伝播の修正（課題 1 解決）

`propagation.extract(context.active(), req.headers)` を追加し、server span を upstream proxy の child として接続。span 名も `http.server.request` に変更（OTel/Datadog operation 命名規約）。

2. SSE/transport 観測性の強化（課題 2 解決）

- `http.transport`: `sse`（GET /mcp）/ `jsonrpc`（その他）
- `http.response.close_reason`: `completed` / `client_disconnect`
- 新ヒストグラム `mcp.sse.connection.duration`（秒）: SSE 接続寿命専用
- canonical log に `http.transport`, `http.close_reason` フィールドを追加

3. その他

- propagator を `CompositePropagator([W3CTraceContext, W3CBaggage])` に拡張
- resource attributes に `deployment.environment` を追加

## 変更種別

- [x] 新機能

## 動作確認

ローカルで docker compose（redis + OTel collector + Jaeger）を使った e2e 検証済み。

Jaeger クエリ結果（trace_id 直接指定）:
```
送信:   traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
Jaeger: trace_id        = 0af7651916cd43dd8448eb211c80319c  ← 一致
        parent_span_id  = b7ad6b7169203331                  ← 一致
        operation       = http.server.request
        http.transport  = jsonrpc
        close_reason    = completed
```

traceparent ヘッダーなし（root span 生成）・GET /mcp（transport=sse）も Jaeger で確認済み。

## デプロイ後の検証方法

1. デプロイ後 `curl -X POST https://<your-mcp-host>/mcp -H 'traceparent: 00-<32hex>-<16hex>-01' ...` でリクエスト送信
2. APM で 上流 proxy の trace_id → freee-mcp span が children に表示されることを確認
3. upstream timeout 系アラート発火時、`http.transport` + `http.response.close_reason` 属性で正常 SSE timeout か本物のアプリ遅延かを即時分類
