### PR TITLE
fix(auth): support HTTP Basic client authentication (RFC 6749 §2.3.1)

### DIFF
--- a/.changeset/oauth-client-secret-basic.md
+++ b/.changeset/oauth-client-secret-basic.md
@@ -1,0 +1,9 @@
+---
+"freee-mcp": patch
+---
+
+OAuth トークン/取消エンドポイントが HTTP Basic 認証を受理するよう修正 (RFC 6749 §2.3.1 準拠)
+
+- `/.well-known/oauth-authorization-server` の `token_endpoint_auth_methods_supported` / `revocation_endpoint_auth_methods_supported` に `client_secret_basic` を追加
+- `Authorization: Basic` ヘッダー付きトークン要求を受理。失敗時は 401 + `WWW-Authenticate: Basic ...`
+- ヘッダーとリクエストボディの両方に資格情報がある場合は 400 invalid_request で拒否（RFC 6749 §2.3）

--- a/bun.lock
+++ b/bun.lock
@@ -36,9 +36,11 @@
         "@types/express": "^5.0.0",
         "@types/node": "^24.10.1",
         "@types/prompts": "^2.4.9",
+        "@types/supertest": "^7.2.0",
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/ui": "^3.2.4",
         "knip": "^5.78.0",
+        "supertest": "^7.2.2",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4",
         "yaml": "^2.8.2",
@@ -214,6 +216,8 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
@@ -285,6 +289,8 @@
     "@oxc-resolver/binding-win32-ia32-msvc": ["@oxc-resolver/binding-win32-ia32-msvc@11.19.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA=="],
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.19.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw=="],
+
+    "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
@@ -452,6 +458,8 @@
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
+    "@types/cookiejar": ["@types/cookiejar@2.1.5", "", {}, "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q=="],
+
     "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -464,6 +472,8 @@
 
     "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
 
+    "@types/methods": ["@types/methods@1.1.4", "", {}, "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ=="],
+
     "@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
     "@types/prompts": ["@types/prompts@2.4.9", "", { "dependencies": { "@types/node": "*", "kleur": "^3.0.3" } }, "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA=="],
@@ -475,6 +485,10 @@
     "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
 
     "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
+
+    "@types/superagent": ["@types/superagent@8.1.9", "", { "dependencies": { "@types/cookiejar": "^2.1.5", "@types/methods": "^1.1.4", "@types/node": "*", "form-data": "^4.0.0" } }, "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ=="],
+
+    "@types/supertest": ["@types/supertest@7.2.0", "", { "dependencies": { "@types/methods": "^1.1.4", "@types/superagent": "^8.1.0" } }, "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw=="],
 
     "@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.4", "vitest": "3.2.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ=="],
 
@@ -518,9 +532,13 @@
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
+    "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.12", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
@@ -566,7 +584,11 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+
+    "component-emitter": ["component-emitter@1.3.1", "", {}, "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -579,6 +601,8 @@
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cookiejar": ["cookiejar@2.1.4", "", {}, "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
@@ -598,6 +622,8 @@
 
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
@@ -605,6 +631,8 @@
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "dezalgo": ["dezalgo@1.0.4", "", { "dependencies": { "asap": "^2.0.0", "wrappy": "1" } }, "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig=="],
 
     "diff": ["diff@4.0.4", "", {}, "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ=="],
 
@@ -629,6 +657,8 @@
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
 
@@ -660,6 +690,8 @@
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
+
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
@@ -682,9 +714,13 @@
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "formidable": ["formidable@3.5.4", "", { "dependencies": { "@paralleldrive/cuid2": "^2.2.2", "dezalgo": "^1.0.4", "once": "^1.4.0" } }, "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -719,6 +755,8 @@
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
@@ -828,7 +866,11 @@
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
+    "methods": ["methods@1.1.2", "", {}, "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="],
+
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime": ["mime@2.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -1066,6 +1108,10 @@
 
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
+    "superagent": ["superagent@10.3.0", "", { "dependencies": { "component-emitter": "^1.3.1", "cookiejar": "^2.1.4", "debug": "^4.3.7", "fast-safe-stringify": "^2.1.1", "form-data": "^4.0.5", "formidable": "^3.5.4", "methods": "^1.1.2", "mime": "2.6.0", "qs": "^6.14.1" } }, "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ=="],
+
+    "supertest": ["supertest@7.2.2", "", { "dependencies": { "cookie-signature": "^1.2.2", "methods": "^1.1.2", "superagent": "^10.3.0" } }, "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA=="],
+
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
@@ -1214,6 +1260,8 @@
 
     "cmdk/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
+    "form-data/mime-types": ["mime-types@2.1.18", "", { "dependencies": { "mime-db": "~1.33.0" } }, "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ=="],
+
     "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -1259,6 +1307,8 @@
     "@modelcontextprotocol/inspector-server/@modelcontextprotocol/sdk/jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
 
     "@modelcontextprotocol/inspector/@modelcontextprotocol/sdk/jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
+
+    "form-data/mime-types/mime-db": ["mime-db@1.33.0", "", {}, "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/package.json
+++ b/package.json
@@ -43,9 +43,11 @@
     "@types/express": "^5.0.0",
     "@types/node": "^24.10.1",
     "@types/prompts": "^2.4.9",
+    "@types/supertest": "^7.2.0",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "knip": "^5.78.0",
+    "supertest": "^7.2.2",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4",
     "yaml": "^2.8.2"

--- a/src/server/auth-basic.integration.test.ts
+++ b/src/server/auth-basic.integration.test.ts
@@ -1,0 +1,230 @@
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import type {
+  AuthorizationParams,
+  OAuthServerProvider,
+} from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import type {
+  OAuthClientInformationFull,
+  OAuthTokenRevocationRequest,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { decodeBasicAuth } from './client-auth-basic.js';
+import { createOverrideMetadataHandler } from './oauth-metadata-override.js';
+
+// Integration test that wires the real SDK mcpAuthRouter together with our
+// adapter middleware. The test exercises the public HTTP surface (metadata
+// + /token + /revoke) the same way an MCP client would.
+
+function basicHeader(id: string, secret: string): string {
+  return `Basic ${Buffer.from(`${id}:${secret}`, 'utf8').toString('base64')}`;
+}
+
+function makeClientStore(
+  clients: Record<string, OAuthClientInformationFull>,
+): OAuthRegisteredClientsStore {
+  return {
+    getClient: async (id: string) => clients[id],
+  };
+}
+
+function makeProvider(clientStore: OAuthRegisteredClientsStore): OAuthServerProvider {
+  return {
+    clientsStore: clientStore,
+    async authorize(_client: OAuthClientInformationFull, _params: AuthorizationParams, res) {
+      res.redirect(302, 'https://upstream.example/authorize');
+    },
+    async challengeForAuthorizationCode(_client, _code) {
+      return 'unused-challenge';
+    },
+    async exchangeAuthorizationCode(_client, _code, _verifier, _redirect, _resource) {
+      const tokens: OAuthTokens = {
+        access_token: 'mock-access',
+        token_type: 'bearer',
+        expires_in: 3600,
+        refresh_token: 'mock-refresh',
+        scope: 'mcp:read',
+      };
+      return tokens;
+    },
+    async exchangeRefreshToken(_client, refreshToken, _scopes, _resource) {
+      if (refreshToken !== 'mock-refresh') {
+        throw new Error('invalid refresh');
+      }
+      const tokens: OAuthTokens = {
+        access_token: 'rotated-access',
+        token_type: 'bearer',
+        expires_in: 3600,
+        refresh_token: 'rotated-refresh',
+        scope: 'mcp:read',
+      };
+      return tokens;
+    },
+    async verifyAccessToken(_token) {
+      throw new Error('not used in this test');
+    },
+    async revokeToken(_client, _request: OAuthTokenRevocationRequest) {
+      // no-op for the test
+    },
+    skipLocalPkceValidation: true,
+  };
+}
+
+async function buildApp(clients: Record<string, OAuthClientInformationFull>): Promise<Express> {
+  const app = express();
+  app.set('trust proxy', 1);
+  const clientStore = makeClientStore(clients);
+  const provider = makeProvider(clientStore);
+  const issuerUrl = new URL('https://mcp.example/');
+
+  app.get(
+    '/.well-known/oauth-authorization-server',
+    createOverrideMetadataHandler({
+      provider,
+      issuerUrl,
+      scopesSupported: ['mcp:read', 'mcp:write'],
+    }),
+  );
+  app.use('/token', decodeBasicAuth({ clientStore, realm: 'freee MCP test' }));
+  app.use('/revoke', decodeBasicAuth({ clientStore, realm: 'freee MCP test' }));
+
+  const { mcpAuthRouter } = await import('@modelcontextprotocol/sdk/server/auth/router.js');
+  app.use(
+    mcpAuthRouter({
+      provider,
+      issuerUrl,
+      resourceServerUrl: new URL('/mcp', issuerUrl),
+      scopesSupported: ['mcp:read', 'mcp:write'],
+      resourceName: 'freee MCP test',
+    }),
+  );
+  return app;
+}
+
+const confidentialClient: OAuthClientInformationFull = {
+  client_id: 'confid-1',
+  client_secret: 'super-secret-1',
+  redirect_uris: ['https://client.example/cb'],
+  token_endpoint_auth_method: 'client_secret_basic',
+  grant_types: ['authorization_code', 'refresh_token'],
+  response_types: ['code'],
+};
+
+const publicClient: OAuthClientInformationFull = {
+  client_id: 'public-1',
+  redirect_uris: ['https://client.example/cb'],
+  token_endpoint_auth_method: 'none',
+  grant_types: ['authorization_code', 'refresh_token'],
+  response_types: ['code'],
+};
+
+describe('OAuth AS — Basic auth integration', () => {
+  it('advertises client_secret_basic in /.well-known/oauth-authorization-server', async () => {
+    const app = await buildApp({});
+    const res = await request(app).get('/.well-known/oauth-authorization-server');
+    expect(res.status).toBe(200);
+    expect(res.body.token_endpoint_auth_methods_supported).toContain('client_secret_basic');
+    expect(res.body.token_endpoint_auth_methods_supported).toContain('client_secret_post');
+    expect(res.body.token_endpoint_auth_methods_supported).toContain('none');
+    expect(res.body.revocation_endpoint_auth_methods_supported).toContain('client_secret_basic');
+  });
+
+  it('accepts a token request with Authorization: Basic for a confidential client', async () => {
+    const app = await buildApp({ [confidentialClient.client_id]: confidentialClient });
+    const res = await request(app)
+      .post('/token')
+      .set('Authorization', basicHeader('confid-1', 'super-secret-1'))
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send('grant_type=refresh_token&refresh_token=mock-refresh');
+
+    expect(res.status).toBe(200);
+    expect(res.body.access_token).toBe('rotated-access');
+  });
+
+  it('still accepts client_secret_post token requests (no regression)', async () => {
+    const app = await buildApp({ [confidentialClient.client_id]: confidentialClient });
+    const res = await request(app)
+      .post('/token')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send(
+        'grant_type=refresh_token&refresh_token=mock-refresh&client_id=confid-1&client_secret=super-secret-1',
+      );
+
+    expect(res.status).toBe(200);
+    expect(res.body.access_token).toBe('rotated-access');
+  });
+
+  it('still accepts public clients via body without secret (none auth method)', async () => {
+    const app = await buildApp({ [publicClient.client_id]: publicClient });
+    const res = await request(app)
+      .post('/token')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send('grant_type=refresh_token&refresh_token=mock-refresh&client_id=public-1');
+
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects Basic with wrong secret with 401 + WWW-Authenticate', async () => {
+    const app = await buildApp({ [confidentialClient.client_id]: confidentialClient });
+    const res = await request(app)
+      .post('/token')
+      .set('Authorization', basicHeader('confid-1', 'wrong'))
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send('grant_type=refresh_token&refresh_token=mock-refresh');
+
+    expect(res.status).toBe(401);
+    expect(res.headers['www-authenticate']).toMatch(/^Basic realm=/);
+    expect(res.body.error).toBe('invalid_client');
+  });
+
+  it('rejects Basic with malformed payload with 401', async () => {
+    const app = await buildApp({});
+    const res = await request(app)
+      .post('/token')
+      .set('Authorization', 'Basic !!!notbase64!!!')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send('grant_type=refresh_token&refresh_token=mock-refresh');
+
+    expect(res.status).toBe(401);
+    expect(res.headers['www-authenticate']).toMatch(/^Basic realm=/);
+  });
+
+  it('rejects body+header credential collision with 400 invalid_request', async () => {
+    const app = await buildApp({ [confidentialClient.client_id]: confidentialClient });
+    const res = await request(app)
+      .post('/token')
+      .set('Authorization', basicHeader('confid-1', 'super-secret-1'))
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send(
+        'grant_type=refresh_token&refresh_token=mock-refresh&client_id=confid-1&client_secret=super-secret-1',
+      );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_request');
+  });
+
+  it('rejects public clients attempting Basic with 401', async () => {
+    const app = await buildApp({ [publicClient.client_id]: publicClient });
+    const res = await request(app)
+      .post('/token')
+      .set('Authorization', basicHeader('public-1', 'whatever'))
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send('grant_type=refresh_token&refresh_token=mock-refresh');
+
+    expect(res.status).toBe(401);
+    expect(res.body.error_description).toMatch(/public client/i);
+  });
+
+  it('accepts /revoke with Authorization: Basic', async () => {
+    const app = await buildApp({ [confidentialClient.client_id]: confidentialClient });
+    const res = await request(app)
+      .post('/revoke')
+      .set('Authorization', basicHeader('confid-1', 'super-secret-1'))
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send('token=any-token');
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/server/client-auth-basic.test.ts
+++ b/src/server/client-auth-basic.test.ts
@@ -1,0 +1,292 @@
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import type { OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+import { decodeBasicAuth } from './client-auth-basic.js';
+import { RequestRecorder, withRequestRecorder } from './request-context.js';
+
+function basicHeader(id: string, secret: string): string {
+  return `Basic ${Buffer.from(`${id}:${secret}`, 'utf8').toString('base64')}`;
+}
+
+function makeClientStore(
+  clients: Record<string, Partial<OAuthClientInformationFull>>,
+): OAuthRegisteredClientsStore {
+  return {
+    getClient: vi.fn(async (id: string) => {
+      const found = clients[id];
+      return found ? (found as OAuthClientInformationFull) : undefined;
+    }),
+  };
+}
+
+function buildApp(
+  clientStore: OAuthRegisteredClientsStore,
+  recorderHolder: { recorder?: RequestRecorder } = {},
+): Express {
+  const app = express();
+  app.use((req, _res, next) => {
+    const recorder = new RequestRecorder({
+      request_id: 'test-req',
+      source_ip: '127.0.0.1',
+      method: req.method,
+      path: req.path,
+    });
+    recorderHolder.recorder = recorder;
+    withRequestRecorder(recorder, () => next());
+  });
+  app.use('/token', decodeBasicAuth({ clientStore, realm: 'freee MCP test' }));
+  app.post('/token', express.urlencoded({ extended: false }), (req, res) => {
+    res.status(200).json({ ok: true, body: req.body });
+  });
+  app.options('/token', (_req, res) => res.status(204).send());
+  return app;
+}
+
+async function postToken(
+  app: Express,
+  opts: { headers?: Record<string, string>; body?: string; method?: 'POST' | 'OPTIONS' } = {},
+) {
+  const agent = request(app);
+  const builder = opts.method === 'OPTIONS' ? agent.options('/token') : agent.post('/token');
+  const withType = builder.set('Content-Type', 'application/x-www-form-urlencoded');
+  for (const [k, v] of Object.entries(opts.headers ?? {})) {
+    withType.set(k, v);
+  }
+  return opts.body !== undefined ? withType.send(opts.body) : withType.send();
+}
+
+describe('decodeBasicAuth', () => {
+  it('passes through when no Authorization header is present', async () => {
+    const clientStore = makeClientStore({});
+    const app = buildApp(clientStore);
+    const res = await postToken(app, { body: 'grant_type=client_credentials' });
+    expect(res.status).toBe(200);
+    expect(clientStore.getClient).not.toHaveBeenCalled();
+  });
+
+  it('passes through Bearer scheme without modification', async () => {
+    const clientStore = makeClientStore({});
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: 'Bearer abc' },
+      body: 'grant_type=refresh_token',
+    });
+    expect(res.status).toBe(200);
+    expect(clientStore.getClient).not.toHaveBeenCalled();
+  });
+
+  it('passes through OPTIONS preflight without invoking the validator', async () => {
+    const clientStore = makeClientStore({});
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      method: 'OPTIONS',
+      headers: { Authorization: basicHeader('id', 'secret') },
+    });
+    expect(res.status).not.toBe(401);
+    expect(clientStore.getClient).not.toHaveBeenCalled();
+  });
+
+  it('decodes a valid Basic header and merges into req.body', async () => {
+    const clientStore = makeClientStore({
+      'client-a': { client_id: 'client-a', client_secret: 'secret-x' },
+    });
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: basicHeader('client-a', 'secret-x') },
+      body: 'grant_type=client_credentials',
+    });
+    expect(res.status).toBe(200);
+    expect((res.body as { body: Record<string, string> }).body).toMatchObject({
+      grant_type: 'client_credentials',
+      client_id: 'client-a',
+      client_secret: 'secret-x',
+    });
+  });
+
+  it('accepts colon characters inside client_secret', async () => {
+    const clientStore = makeClientStore({
+      'client-a': { client_id: 'client-a', client_secret: 'sec:ret:withcolons' },
+    });
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: basicHeader('client-a', 'sec:ret:withcolons') },
+      body: 'grant_type=client_credentials',
+    });
+    expect(res.status).toBe(200);
+    expect((res.body as { body: Record<string, string> }).body.client_secret).toBe(
+      'sec:ret:withcolons',
+    );
+  });
+
+  it('URL-decodes credentials per application/x-www-form-urlencoded', async () => {
+    const id = 'a b';
+    const secret = 's@c+t';
+    const encoded = `${encodeURIComponent(id).replace(/%20/g, '+')}:${encodeURIComponent(secret)}`;
+    const header = `Basic ${Buffer.from(encoded, 'utf8').toString('base64')}`;
+    const clientStore = makeClientStore({ [id]: { client_id: id, client_secret: secret } });
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: header },
+      body: 'grant_type=client_credentials',
+    });
+    expect(res.status).toBe(200);
+    expect((res.body as { body: Record<string, string> }).body.client_id).toBe(id);
+    expect((res.body as { body: Record<string, string> }).body.client_secret).toBe(secret);
+  });
+
+  it('rejects malformed base64 with 401 + WWW-Authenticate', async () => {
+    const clientStore = makeClientStore({});
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: 'Basic !!!notbase64!!!' },
+      body: 'grant_type=client_credentials',
+    });
+    expect(res.status).toBe(401);
+    expect((res.headers['www-authenticate'] ?? '').toString()).toMatch(/^Basic realm=/);
+    expect((res.body as { error: string }).error).toBe('invalid_client');
+  });
+
+  it('includes charset="UTF-8" in WWW-Authenticate per RFC 7617 §2.1', async () => {
+    const clientStore = makeClientStore({});
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: basicHeader('missing', 'secret') },
+      body: 'grant_type=client_credentials',
+    });
+    expect((res.headers['www-authenticate'] ?? '').toString()).toMatch(/charset="UTF-8"/);
+  });
+
+  it('rejects missing colon with 401', async () => {
+    const encoded = Buffer.from('noColonHere', 'utf8').toString('base64');
+    const clientStore = makeClientStore({});
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: `Basic ${encoded}` },
+      body: 'grant_type=client_credentials',
+    });
+    expect(res.status).toBe(401);
+    expect((res.body as { error: string }).error).toBe('invalid_client');
+  });
+
+  it('rejects malformed percent-encoding with 401', async () => {
+    const encoded = Buffer.from('client%ZZ:secret', 'utf8').toString('base64');
+    const clientStore = makeClientStore({});
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: `Basic ${encoded}` },
+      body: 'grant_type=client_credentials',
+    });
+    expect(res.status).toBe(401);
+    expect((res.body as { error: string }).error).toBe('invalid_client');
+  });
+
+  it('rejects empty client_id (e.g. ":secret") with 401', async () => {
+    const encoded = Buffer.from(':secret', 'utf8').toString('base64');
+    const clientStore = makeClientStore({});
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: `Basic ${encoded}` },
+      body: 'grant_type=client_credentials',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects unknown client_id with 401 + WWW-Authenticate', async () => {
+    const clientStore = makeClientStore({});
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: basicHeader('missing', 'secret') },
+      body: 'grant_type=client_credentials',
+    });
+    expect(res.status).toBe(401);
+    expect((res.body as { error: string }).error).toBe('invalid_client');
+  });
+
+  it('rejects wrong client_secret with 401 (timing-safe compare)', async () => {
+    const clientStore = makeClientStore({
+      'client-a': { client_id: 'client-a', client_secret: 'right' },
+    });
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: basicHeader('client-a', 'wrong') },
+      body: 'grant_type=client_credentials',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects public clients (no client_secret) attempting Basic with 401', async () => {
+    const clientStore = makeClientStore({
+      'public-a': { client_id: 'public-a' },
+    });
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: basicHeader('public-a', 'whatever') },
+      body: 'grant_type=client_credentials',
+    });
+    expect(res.status).toBe(401);
+    expect((res.body as { error_description: string }).error_description).toMatch(/public client/i);
+  });
+
+  it('rejects expired client_secret with 401', async () => {
+    const clientStore = makeClientStore({
+      'client-a': {
+        client_id: 'client-a',
+        client_secret: 'sec',
+        client_secret_expires_at: 1,
+      },
+    });
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: basicHeader('client-a', 'sec') },
+      body: 'grant_type=client_credentials',
+    });
+    expect(res.status).toBe(401);
+    expect((res.body as { error_description: string }).error_description).toMatch(/expire/i);
+  });
+
+  it('rejects body+header credential collision with 400 invalid_request', async () => {
+    const clientStore = makeClientStore({
+      'client-a': { client_id: 'client-a', client_secret: 'sec' },
+    });
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: basicHeader('client-a', 'sec') },
+      body: 'grant_type=client_credentials&client_id=client-a&client_secret=sec',
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toBe('invalid_request');
+  });
+
+  it('does not leak client_secret into the response body or headers', async () => {
+    const clientStore = makeClientStore({
+      'client-a': { client_id: 'client-a', client_secret: 'super-secret' },
+    });
+    const app = buildApp(clientStore);
+    const res = await postToken(app, {
+      headers: { Authorization: basicHeader('client-a', 'wrong-guess') },
+      body: 'grant_type=client_credentials',
+    });
+    expect(res.status).toBe(401);
+    const serialized = JSON.stringify({ body: res.body, headers: res.headers });
+    expect(serialized).not.toContain('super-secret');
+    expect(serialized).not.toContain('wrong-guess');
+  });
+
+  it('records canonical log error with source=auth on rejection', async () => {
+    const clientStore = makeClientStore({});
+    const recorderHolder: { recorder?: RequestRecorder } = {};
+    const app = buildApp(clientStore, recorderHolder);
+    await postToken(app, {
+      headers: { Authorization: basicHeader('missing', 'secret') },
+      body: 'grant_type=client_credentials',
+    });
+    const payload = recorderHolder.recorder?.buildPayload({ status: 401, duration_ms: 0 });
+    expect(payload?.errors.length ?? 0).toBeGreaterThan(0);
+    const err = payload?.errors[0];
+    expect(err?.source).toBe('auth');
+    expect(err?.status_code).toBe(401);
+    expect(err?.error_type).toBe('invalid_client');
+  });
+});

--- a/src/server/client-auth-basic.ts
+++ b/src/server/client-auth-basic.ts
@@ -1,0 +1,217 @@
+import { timingSafeEqual } from 'node:crypto';
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import express, { type RequestHandler } from 'express';
+import { makeErrorChain } from './error-serializer.js';
+import { getCurrentRecorder } from './request-context.js';
+
+export interface DecodeBasicAuthOptions {
+  clientStore: OAuthRegisteredClientsStore;
+  realm: string;
+}
+
+interface CredentialsFromBody {
+  client_id?: unknown;
+  client_secret?: unknown;
+}
+
+function safeStringEquals(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+function buildWwwAuthenticate(realm: string, error: string, description: string): string {
+  // RFC 7617 §2.1 charset, RFC 6749 §5.2 error / error_description.
+  // description is callsite-controlled (no user-supplied content), so static-quoting is safe.
+  return `Basic realm="${realm}", charset="UTF-8", error="${error}", error_description="${description}"`;
+}
+
+function reject401(
+  res: express.Response,
+  realm: string,
+  description: string,
+  errorTypeForLog: string,
+  errorName: string,
+): void {
+  const wwwAuthenticate = buildWwwAuthenticate(realm, 'invalid_client', description);
+  getCurrentRecorder()?.recordError({
+    source: 'auth',
+    status_code: 401,
+    error_type: errorTypeForLog,
+    chain: makeErrorChain(errorName, description),
+  });
+  res.setHeader('WWW-Authenticate', wwwAuthenticate);
+  res.status(401).json({ error: 'invalid_client', error_description: description });
+}
+
+function reject400(
+  res: express.Response,
+  description: string,
+  errorTypeForLog: string,
+  errorName: string,
+): void {
+  getCurrentRecorder()?.recordError({
+    source: 'auth',
+    status_code: 400,
+    error_type: errorTypeForLog,
+    chain: makeErrorChain(errorName, description),
+  });
+  res.status(400).json({ error: 'invalid_request', error_description: description });
+}
+
+/**
+ * Per RFC 6749 §2.3.1, client credentials in the Authorization header are
+ * `application/x-www-form-urlencoded` encoded inside the base64 payload.
+ * `decodeURIComponent` throws `URIError` on malformed `%` escapes; the caller
+ * must treat that as a credential decoding failure (401), never let it surface
+ * as a 500.
+ */
+function decodeFormUrlEncoded(input: string): string {
+  return decodeURIComponent(input.replace(/\+/g, ' '));
+}
+
+function parseBasicHeader(
+  header: string,
+): { ok: true; clientId: string; clientSecret: string } | { ok: false; reason: string } {
+  if (!/^Basic\s+/i.test(header)) return { ok: false, reason: 'Authorization scheme is not Basic' };
+  const encoded = header.replace(/^Basic\s+/i, '').trim();
+  if (encoded.length === 0) return { ok: false, reason: 'Empty Basic credentials' };
+
+  // Buffer.from('...', 'base64') silently ignores invalid characters and
+  // returns whatever bytes can be decoded. We rely on the downstream
+  // colon-and-non-empty checks to catch garbage input — random base64-invalid
+  // strings either decode to nothing or to bytes lacking a colon separator.
+  const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+
+  const colonIdx = decoded.indexOf(':');
+  if (colonIdx === -1) {
+    return { ok: false, reason: 'Basic credentials missing colon separator' };
+  }
+  const rawId = decoded.slice(0, colonIdx);
+  const rawSecret = decoded.slice(colonIdx + 1);
+
+  let clientId: string;
+  let clientSecret: string;
+  try {
+    clientId = decodeFormUrlEncoded(rawId);
+    clientSecret = decodeFormUrlEncoded(rawSecret);
+  } catch {
+    return { ok: false, reason: 'Malformed percent-encoding in Basic credentials' };
+  }
+
+  if (clientId.length === 0) {
+    return { ok: false, reason: 'Empty client_id in Basic credentials' };
+  }
+  return { ok: true, clientId, clientSecret };
+}
+
+/**
+ * Adapter middleware that brings the SDK's token / revocation endpoints up to
+ * RFC 6749 §2.3.1 (HTTP Basic) compliance without forking the SDK router.
+ *
+ * Behavior:
+ * - No Authorization header → pass through; SDK's body-based authenticateClient handles it.
+ * - Non-POST (e.g., OPTIONS preflight) → pass through.
+ * - Authorization: Basic with malformed payload → 401 + WWW-Authenticate, never reaches SDK.
+ * - Authorization: Basic with valid payload but client validation fails → 401 + WWW-Authenticate.
+ * - Authorization: Basic + body credentials present → 400 invalid_request (RFC §2.3 ambiguity).
+ * - Public client attempting Basic → 401 (RFC §2.3.1 limits Basic to clients with passwords).
+ * - Authorization: Basic with valid creds → merge into req.body so SDK's authenticateClient
+ *   re-validates the same data and proceeds. timingSafeEqual is used for our pre-validation;
+ *   the SDK's `!==` second check is unavoidable (its own concern, not addressed here).
+ */
+export function decodeBasicAuth(options: DecodeBasicAuthOptions): RequestHandler {
+  const { clientStore, realm } = options;
+  const bodyParser = express.urlencoded({ extended: false });
+
+  const handler: RequestHandler = (req, res, next) => {
+    if (req.method !== 'POST') return next();
+
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !/^Basic\s+/i.test(authHeader)) {
+      // Bearer or no header → SDK validates body, no change.
+      return next();
+    }
+
+    // Body parser must run before we can detect collisions with body credentials.
+    // Body-parser is a no-op when req._body is already true.
+    bodyParser(req, res, (parseErr) => {
+      if (parseErr) {
+        reject400(res, 'Invalid request body', 'invalid_request', 'InvalidRequestError');
+        return;
+      }
+
+      const body = (req.body ?? {}) as CredentialsFromBody;
+      if (typeof body.client_id === 'string' || typeof body.client_secret === 'string') {
+        reject400(
+          res,
+          'Client credentials must not be sent both via Authorization header and request body',
+          'invalid_request',
+          'InvalidRequestError',
+        );
+        return;
+      }
+
+      const parsed = parseBasicHeader(authHeader);
+      if (!parsed.ok) {
+        reject401(res, realm, parsed.reason, 'invalid_client', 'InvalidClientError');
+        return;
+      }
+
+      void (async () => {
+        try {
+          const client = await clientStore.getClient(parsed.clientId);
+          if (!client) {
+            reject401(res, realm, 'Invalid client_id', 'invalid_client', 'InvalidClientError');
+            return;
+          }
+          if (!client.client_secret) {
+            // Public client: per RFC 6749 §2.3.1, Basic is only for clients with a password.
+            reject401(
+              res,
+              realm,
+              'Basic authentication is not permitted for public clients',
+              'invalid_client',
+              'InvalidClientError',
+            );
+            return;
+          }
+          if (!safeStringEquals(client.client_secret, parsed.clientSecret)) {
+            reject401(res, realm, 'Invalid client_secret', 'invalid_client', 'InvalidClientError');
+            return;
+          }
+          if (
+            client.client_secret_expires_at &&
+            client.client_secret_expires_at < Math.floor(Date.now() / 1000)
+          ) {
+            reject401(
+              res,
+              realm,
+              'Client secret has expired',
+              'invalid_client',
+              'InvalidClientError',
+            );
+            return;
+          }
+
+          // Merge into body so the SDK's authenticateClient sees the same credentials
+          // and produces the same `req.client` populated state downstream.
+          (req.body as Record<string, unknown>).client_id = parsed.clientId;
+          (req.body as Record<string, unknown>).client_secret = parsed.clientSecret;
+          next();
+        } catch (err) {
+          reject401(
+            res,
+            realm,
+            'Unable to validate Basic credentials',
+            'invalid_client',
+            err instanceof Error ? err.name : 'InvalidClientError',
+          );
+        }
+      })();
+    });
+  };
+
+  return handler;
+}

--- a/src/server/http-server.test.ts
+++ b/src/server/http-server.test.ts
@@ -103,6 +103,31 @@ vi.mock('./freee-callback.js', () => ({
 
 vi.mock('@modelcontextprotocol/sdk/server/auth/router.js', () => ({
   mcpAuthRouter: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
+  // createOAuthMetadata is imported by oauth-metadata-override.ts; provide a
+  // minimal stub so that module loads successfully under this mock.
+  createOAuthMetadata: vi.fn(() => ({
+    issuer: 'https://test/',
+    authorization_endpoint: 'https://test/authorize',
+    token_endpoint: 'https://test/token',
+    response_types_supported: ['code'],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint_auth_methods_supported: ['client_secret_post', 'none'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+  })),
+  getOAuthProtectedResourceMetadataUrl: vi.fn(
+    () => 'https://test/.well-known/oauth-protected-resource',
+  ),
+}));
+
+vi.mock('./oauth-metadata-override.js', () => ({
+  createOverrideMetadataHandler: vi.fn(
+    () => (_req: unknown, res: { status: (n: number) => { json: (v: unknown) => void } }) =>
+      res.status(200).json({}),
+  ),
+}));
+
+vi.mock('./client-auth-basic.js', () => ({
+  decodeBasicAuth: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
 }));
 
 vi.mock('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js', () => ({

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -171,6 +171,24 @@ export async function startHttpServer(options?: {
   const { mcpAuthRouter } = await import('@modelcontextprotocol/sdk/server/auth/router.js');
   const issuerUrl = new URL(remoteConfig.issuerUrl);
   const mcpResourceUrl = new URL('/mcp', issuerUrl);
+  // Override the SDK's authorization-server metadata to advertise
+  // client_secret_basic (RFC 6749 §2.3.1). Mounted before mcpAuthRouter so
+  // Express first-match-wins routes /.well-known here instead of into the SDK.
+  const { createOverrideMetadataHandler } = await import('./oauth-metadata-override.js');
+  app.get(
+    '/.well-known/oauth-authorization-server',
+    createOverrideMetadataHandler({
+      provider,
+      issuerUrl,
+      scopesSupported: ['mcp:read', 'mcp:write'],
+    }),
+  );
+  // Adapter middleware that extends the SDK's body-only client auth to also
+  // accept Authorization: Basic. RFC 6749 §2.3.1 requires Basic to be
+  // supported when client passwords are issued.
+  const { decodeBasicAuth } = await import('./client-auth-basic.js');
+  app.use('/token', decodeBasicAuth({ clientStore, realm: 'freee MCP' }));
+  app.use('/revoke', decodeBasicAuth({ clientStore, realm: 'freee MCP' }));
   app.use(
     mcpAuthRouter({
       provider,

--- a/src/server/oauth-metadata-override.test.ts
+++ b/src/server/oauth-metadata-override.test.ts
@@ -116,7 +116,7 @@ describe('createOverrideMetadataHandler', () => {
       setHeader: vi.fn(),
     } as unknown as import('express').Response;
 
-    handler({} as import('express').Request, res, vi.fn());
+    handler({} as import('express').Request, res);
 
     expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'public, max-age=3600');
     expect(res.status).toHaveBeenCalledWith(200);

--- a/src/server/oauth-metadata-override.test.ts
+++ b/src/server/oauth-metadata-override.test.ts
@@ -1,0 +1,128 @@
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import type { OAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import { createOAuthMetadata } from '@modelcontextprotocol/sdk/server/auth/router.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildOverriddenMetadata,
+  createOverrideMetadataHandler,
+} from './oauth-metadata-override.js';
+
+function makeProvider(opts: {
+  registerClient?: boolean;
+  revokeToken?: boolean;
+}): OAuthServerProvider {
+  const clientsStore = {
+    getClient: vi.fn(),
+  } as unknown as OAuthRegisteredClientsStore;
+  if (opts.registerClient) {
+    (clientsStore as unknown as { registerClient: () => void }).registerClient = () => {};
+  }
+  const provider: Partial<OAuthServerProvider> = {
+    clientsStore,
+    authorize: vi.fn(),
+    challengeForAuthorizationCode: vi.fn(),
+    exchangeAuthorizationCode: vi.fn(),
+    exchangeRefreshToken: vi.fn(),
+    verifyAccessToken: vi.fn(),
+  };
+  if (opts.revokeToken) {
+    provider.revokeToken = vi.fn();
+  }
+  return provider as OAuthServerProvider;
+}
+
+const issuerUrl = new URL('https://mcp.example.com/');
+
+describe('buildOverriddenMetadata', () => {
+  it('advertises client_secret_basic alongside client_secret_post and none', () => {
+    const provider = makeProvider({ registerClient: true, revokeToken: true });
+    const metadata = buildOverriddenMetadata({
+      provider,
+      issuerUrl,
+      scopesSupported: ['mcp:read', 'mcp:write'],
+    });
+
+    expect(metadata.token_endpoint_auth_methods_supported).toEqual([
+      'client_secret_basic',
+      'client_secret_post',
+      'none',
+    ]);
+  });
+
+  it('advertises client_secret_basic on revocation endpoint when revoke is supported', () => {
+    const provider = makeProvider({ registerClient: true, revokeToken: true });
+    const metadata = buildOverriddenMetadata({ provider, issuerUrl });
+
+    expect(metadata.revocation_endpoint).toBeDefined();
+    expect(metadata.revocation_endpoint_auth_methods_supported).toEqual([
+      'client_secret_basic',
+      'client_secret_post',
+    ]);
+  });
+
+  it('omits revocation_endpoint_auth_methods_supported when revoke not supported', () => {
+    const provider = makeProvider({ registerClient: true, revokeToken: false });
+    const metadata = buildOverriddenMetadata({ provider, issuerUrl });
+
+    expect(metadata.revocation_endpoint).toBeUndefined();
+    expect(metadata.revocation_endpoint_auth_methods_supported).toBeUndefined();
+  });
+
+  it('preserves other fields from the SDK baseline', () => {
+    const provider = makeProvider({ registerClient: true, revokeToken: true });
+    const baseline = createOAuthMetadata({
+      provider,
+      issuerUrl,
+      scopesSupported: ['mcp:read'],
+    });
+    const overridden = buildOverriddenMetadata({
+      provider,
+      issuerUrl,
+      scopesSupported: ['mcp:read'],
+    });
+
+    expect(overridden.issuer).toBe(baseline.issuer);
+    expect(overridden.authorization_endpoint).toBe(baseline.authorization_endpoint);
+    expect(overridden.token_endpoint).toBe(baseline.token_endpoint);
+    expect(overridden.registration_endpoint).toBe(baseline.registration_endpoint);
+    expect(overridden.code_challenge_methods_supported).toEqual(
+      baseline.code_challenge_methods_supported,
+    );
+    expect(overridden.scopes_supported).toEqual(baseline.scopes_supported);
+    expect(overridden.grant_types_supported).toEqual(baseline.grant_types_supported);
+  });
+
+  // SDK shape guard: this asserts that the SDK baseline still omits
+  // client_secret_basic. When the SDK starts advertising it natively this
+  // test will turn red, signaling that buildOverriddenMetadata is no longer
+  // necessary and can be removed.
+  it('SDK baseline does not yet advertise client_secret_basic (override still necessary)', () => {
+    const provider = makeProvider({ registerClient: true, revokeToken: true });
+    const baseline = createOAuthMetadata({ provider, issuerUrl });
+    expect(baseline.token_endpoint_auth_methods_supported ?? []).not.toContain(
+      'client_secret_basic',
+    );
+  });
+});
+
+describe('createOverrideMetadataHandler', () => {
+  it('returns 200 with the overridden metadata and sets Cache-Control', () => {
+    const provider = makeProvider({ registerClient: true, revokeToken: true });
+    const handler = createOverrideMetadataHandler({ provider, issuerUrl });
+
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+      setHeader: vi.fn(),
+    } as unknown as import('express').Response;
+
+    handler({} as import('express').Request, res, vi.fn());
+
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'public, max-age=3600');
+    expect(res.status).toHaveBeenCalledWith(200);
+    const payload = (res.json as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+      token_endpoint_auth_methods_supported?: string[];
+    };
+    expect(payload.token_endpoint_auth_methods_supported).toContain('client_secret_basic');
+  });
+});

--- a/src/server/oauth-metadata-override.ts
+++ b/src/server/oauth-metadata-override.ts
@@ -1,0 +1,45 @@
+import type { OAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import { createOAuthMetadata } from '@modelcontextprotocol/sdk/server/auth/router.js';
+import type { OAuthMetadata } from '@modelcontextprotocol/sdk/shared/auth.js';
+import type { RequestHandler } from 'express';
+
+export interface OverrideMetadataOptions {
+  provider: OAuthServerProvider;
+  issuerUrl: URL;
+  baseUrl?: URL;
+  scopesSupported?: string[];
+  serviceDocumentationUrl?: URL;
+}
+
+// SDK @modelcontextprotocol/sdk@1.28.0 hardcodes ['client_secret_post', 'none']
+// in createOAuthMetadata, omitting client_secret_basic. RFC 6749 §2.3.1 requires
+// HTTP Basic to be supported, so we re-advertise it here. Drop this module when
+// the SDK starts advertising client_secret_basic natively (the unit test on
+// SDK_BASELINE_AUTH_METHODS will fail loudly when that happens).
+const TOKEN_AUTH_METHODS_WITH_BASIC = [
+  'client_secret_basic',
+  'client_secret_post',
+  'none',
+] as const;
+
+const REVOCATION_AUTH_METHODS_WITH_BASIC = ['client_secret_basic', 'client_secret_post'] as const;
+
+export function buildOverriddenMetadata(options: OverrideMetadataOptions): OAuthMetadata {
+  const baseline = createOAuthMetadata(options);
+  const overridden: OAuthMetadata = {
+    ...baseline,
+    token_endpoint_auth_methods_supported: [...TOKEN_AUTH_METHODS_WITH_BASIC],
+  };
+  if (baseline.revocation_endpoint) {
+    overridden.revocation_endpoint_auth_methods_supported = [...REVOCATION_AUTH_METHODS_WITH_BASIC];
+  }
+  return overridden;
+}
+
+export function createOverrideMetadataHandler(options: OverrideMetadataOptions): RequestHandler {
+  const metadata = buildOverriddenMetadata(options);
+  return (_req, res) => {
+    res.setHeader('Cache-Control', 'public, max-age=3600');
+    res.status(200).json(metadata);
+  };
+}

--- a/src/sign/server/sign-auth-basic.integration.test.ts
+++ b/src/sign/server/sign-auth-basic.integration.test.ts
@@ -1,0 +1,126 @@
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import type {
+  AuthorizationParams,
+  OAuthServerProvider,
+} from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import type {
+  OAuthClientInformationFull,
+  OAuthTokenRevocationRequest,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { decodeBasicAuth } from '../../server/client-auth-basic.js';
+import { createOverrideMetadataHandler } from '../../server/oauth-metadata-override.js';
+
+// Sign-side smoke test: confirms the same adapter middleware integrates with
+// the SDK on the Sign HTTP server. Sign and accounting share the middleware
+// modules; this proves wiring at the integration boundary.
+
+function basicHeader(id: string, secret: string): string {
+  return `Basic ${Buffer.from(`${id}:${secret}`, 'utf8').toString('base64')}`;
+}
+
+const signClient: OAuthClientInformationFull = {
+  client_id: 'sign-client-1',
+  client_secret: 'sign-secret-1',
+  redirect_uris: ['https://client.example/cb'],
+  token_endpoint_auth_method: 'client_secret_basic',
+  grant_types: ['authorization_code', 'refresh_token'],
+  response_types: ['code'],
+};
+
+function makeClientStore(): OAuthRegisteredClientsStore {
+  return {
+    getClient: async (id: string) => (id === signClient.client_id ? signClient : undefined),
+  };
+}
+
+function makeProvider(clientStore: OAuthRegisteredClientsStore): OAuthServerProvider {
+  return {
+    clientsStore: clientStore,
+    async authorize(_client: OAuthClientInformationFull, _params: AuthorizationParams, res) {
+      res.redirect(302, 'https://upstream.example/authorize');
+    },
+    async challengeForAuthorizationCode(_client, _code) {
+      return 'unused-challenge';
+    },
+    async exchangeAuthorizationCode(_client, _code, _v, _r, _res) {
+      const tokens: OAuthTokens = {
+        access_token: 'sign-access',
+        token_type: 'bearer',
+        expires_in: 3600,
+        scope: 'mcp:read',
+      };
+      return tokens;
+    },
+    async exchangeRefreshToken(_client, refresh, _scopes, _resource) {
+      if (refresh !== 'sign-refresh') throw new Error('invalid');
+      const tokens: OAuthTokens = {
+        access_token: 'sign-rotated',
+        token_type: 'bearer',
+        expires_in: 3600,
+        scope: 'mcp:read',
+      };
+      return tokens;
+    },
+    async verifyAccessToken(_token) {
+      throw new Error('not used in this test');
+    },
+    async revokeToken(_client, _request: OAuthTokenRevocationRequest) {},
+    skipLocalPkceValidation: true,
+  };
+}
+
+async function buildSignApp(): Promise<Express> {
+  const app = express();
+  app.set('trust proxy', 1);
+  const clientStore = makeClientStore();
+  const provider = makeProvider(clientStore);
+  const issuerUrl = new URL('https://sign.example/');
+
+  app.get(
+    '/.well-known/oauth-authorization-server',
+    createOverrideMetadataHandler({
+      provider,
+      issuerUrl,
+      scopesSupported: ['mcp:read', 'mcp:write'],
+    }),
+  );
+  app.use('/token', decodeBasicAuth({ clientStore, realm: 'freee Sign MCP test' }));
+  app.use('/revoke', decodeBasicAuth({ clientStore, realm: 'freee Sign MCP test' }));
+
+  const { mcpAuthRouter } = await import('@modelcontextprotocol/sdk/server/auth/router.js');
+  app.use(
+    mcpAuthRouter({
+      provider,
+      issuerUrl,
+      resourceServerUrl: new URL('/mcp', issuerUrl),
+      scopesSupported: ['mcp:read', 'mcp:write'],
+      resourceName: 'freee Sign MCP test',
+    }),
+  );
+  return app;
+}
+
+describe('Sign OAuth AS — Basic auth smoke', () => {
+  it('advertises client_secret_basic in metadata', async () => {
+    const app = await buildSignApp();
+    const res = await request(app).get('/.well-known/oauth-authorization-server');
+    expect(res.status).toBe(200);
+    expect(res.body.token_endpoint_auth_methods_supported).toContain('client_secret_basic');
+  });
+
+  it('accepts /token with Authorization: Basic for a confidential Sign client', async () => {
+    const app = await buildSignApp();
+    const res = await request(app)
+      .post('/token')
+      .set('Authorization', basicHeader('sign-client-1', 'sign-secret-1'))
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send('grant_type=refresh_token&refresh_token=sign-refresh');
+
+    expect(res.status).toBe(200);
+    expect(res.body.access_token).toBe('sign-rotated');
+  });
+});

--- a/src/sign/server/sign-http-server.ts
+++ b/src/sign/server/sign-http-server.ts
@@ -169,6 +169,26 @@ export async function startSignHttpServer(options?: {
   const { mcpAuthRouter } = await import('@modelcontextprotocol/sdk/server/auth/router.js');
   const issuerUrl = new URL(signRemoteConfig.issuerUrl);
   const mcpResourceUrl = new URL('/mcp', issuerUrl);
+  // Override the SDK's authorization-server metadata to advertise
+  // client_secret_basic (RFC 6749 §2.3.1). Mounted before mcpAuthRouter so
+  // Express first-match-wins routes /.well-known here instead of into the SDK.
+  const { createOverrideMetadataHandler } = await import(
+    '../../server/oauth-metadata-override.js'
+  );
+  app.get(
+    '/.well-known/oauth-authorization-server',
+    createOverrideMetadataHandler({
+      provider,
+      issuerUrl,
+      scopesSupported: ['mcp:read', 'mcp:write'],
+    }),
+  );
+  // Adapter middleware that extends the SDK's body-only client auth to also
+  // accept Authorization: Basic. RFC 6749 §2.3.1 requires Basic to be
+  // supported when client passwords are issued.
+  const { decodeBasicAuth } = await import('../../server/client-auth-basic.js');
+  app.use('/token', decodeBasicAuth({ clientStore, realm: 'freee Sign MCP' }));
+  app.use('/revoke', decodeBasicAuth({ clientStore, realm: 'freee Sign MCP' }));
   app.use(
     mcpAuthRouter({
       provider,


### PR DESCRIPTION
## Overview

This PR implements RFC 6749 §2.3.1 HTTP Basic client authentication support for the OAuth authorization server.

### Problem

The OAuth authorization server was not advertising or accepting `client_secret_basic` (HTTP Basic authentication), violating RFC 6749 §2.3.1 which mandates Basic support for clients issued a password.

**Issue**: freee/freee-mcp#413

### Root Cause

- SDK @modelcontextprotocol/sdk@1.28.0 hardcodes `token_endpoint_auth_methods_supported` to `['client_secret_post', 'none']`
- `mcpAuthRouter` only processes `req.body` (ignoring Authorization headers)

### Solution

Non-destructive adapter middleware pattern:

1. **createOverrideMetadataHandler**: Wraps SDK's `createOAuthMetadata` and patches `token_endpoint_auth_methods_supported` to include `client_secret_basic`. Mounted at `/.well-known/oauth-authorization-server` before `mcpAuthRouter`.

2. **decodeBasicAuth**: Middleware that parses `Authorization: Basic` headers, URL-decodes credentials per `application/x-www-form-urlencoded`, validates against clientStore with timing-safe comparison (`crypto.timingSafeEqual`), and merges validated credentials into `req.body`. SDK's existing `authenticateClient` then processes the decorated request.
   - Returns 401 + WWW-Authenticate (RFC 7617) on auth failure
   - Returns 400 invalid_request on body+header collision (RFC 6749 §2.3)

Applied to both accounting server and Sign server.

### Testing

- ✅ 18 unit tests (client-auth-basic.test.ts)
- ✅ 6 unit tests (oauth-metadata-override.test.ts)  
- ✅ 9 integration tests with real SDK router (auth-basic.integration.test.ts)
- ✅ 2 smoke tests (sign-auth-basic.integration.test.ts)
- ✅ Canonical log integration with makeErrorChain() and getCurrentRecorder()
- ✅ RFC 6749 §5.2 compliance verified
- ✅ Timing-safe comparison against timing attacks
- ✅ Public client rejection for Basic attempts
- ✅ OPTIONS preflight pass-through
- ✅ Body+header collision detection

### Verification

All pre-flight checks pass:
```bash
bun run typecheck && bun run lint && bun run test:run && bun run build
```

- ✅ 669 tests passed
- ✅ TypeScript type checking passed
- ✅ Biome linting passed (127 files)
- ✅ Build successful

### Changes

- New: `src/server/client-auth-basic.ts` (217 lines) - Core Basic authentication middleware
- New: `src/server/oauth-metadata-override.ts` (45 lines) - Metadata patch handler
- New: Test files (client-auth-basic.test.ts, oauth-metadata-override.test.ts, auth-basic.integration.test.ts)
- New: Sign server smoke tests (sign-auth-basic.integration.test.ts)
- Modified: `src/server/http-server.ts` - Mount Basic decoder and metadata override
- Modified: `src/sign/server/sign-http-server.ts` - Mirror implementation
- Modified: `src/server/http-server.test.ts` - Add mocks for new middleware
- New: `.changeset/oauth-client-secret-basic.md` - Changeset for version bump

Closes freee/freee-mcp#413
