### PR TITLE
fix(auth): fail-closed redirect_uri validation in OAuth callback

### DIFF
--- a/.changeset/qw-redirect-uri-fail-closed.md
+++ b/.changeset/qw-redirect-uri-fail-closed.md
@@ -1,0 +1,8 @@
+---
+"freee-mcp": patch
+---
+
+OAuth callback の redirect_uri 検証を fail-closed に変更 (深層防御)
+
+- clientStore.getClient 等の例外発生時に 400 を返すよう変更
+- これまでは catch 節で warn ログのみで処理継続 (fail-open) だった

--- a/src/server/freee-callback.test.ts
+++ b/src/server/freee-callback.test.ts
@@ -452,6 +452,40 @@ describe('createFreeeCallbackHandler', () => {
     expect(res.send).toHaveBeenCalledWith('redirect_uri mismatch');
   });
 
+  it('returns 400 (fail-closed) when redirect_uri validation throws', async () => {
+    const oauthStore = createMockOAuthStore();
+    const mockClientStore = {
+      getClient: vi.fn(async () => {
+        throw new Error('redis unavailable');
+      }),
+    };
+
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+
+    const handler = createFreeeCallbackHandler({
+      oauthStore,
+      tokenStore: createMockTokenStore(),
+      clientStore: mockClientStore as never,
+      freeeClientId: 'id',
+      freeeClientSecret: 'secret',
+      freeeTokenEndpoint: 'https://token.example.com',
+      freeeScope: 'read write',
+      callbackBaseUrl: 'https://mcp.example.com',
+    });
+
+    const { req, res } = createMockReqRes({ code: 'auth-code', state: 'session-id' });
+    handler(req, res);
+
+    await vi.waitFor(() => {
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    expect(res.send).toHaveBeenCalledWith('redirect_uri validation failed');
+    // Downstream token exchange and redirect must NOT happen.
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(res.redirect).not.toHaveBeenCalled();
+  });
+
   it('allows matching redirect_uri from registered client', async () => {
     const oauthStore = createMockOAuthStore();
     const mockClientStore = {

--- a/src/server/freee-callback.ts
+++ b/src/server/freee-callback.ts
@@ -242,8 +242,10 @@ async function handleCallback(
   }
 
   // Validate redirect_uri against registered client (defense-in-depth).
-  // Wrapped in try-catch: session is already consumed above, so a Redis failure here
-  // must not abort the flow — the user cannot retry without restarting OAuth.
+  // Fail-closed on validation errors: any exception during lookup (e.g. Redis failure)
+  // results in a 400 response so a malformed/unverifiable redirect_uri can never bypass
+  // the check. Trade-off: the session is already consumed above, so the user must restart
+  // the OAuth flow — accepted security cost vs. a potential validation bypass.
   if (deps.clientStore) {
     try {
       const client = await deps.clientStore.getClient(session.clientId);
@@ -254,7 +256,8 @@ async function handleCallback(
       }
     } catch (err) {
       getLogger().error({ clientId: session.clientId, err }, 'Failed to validate redirect_uri');
-      // Continue — redirect_uri validation is defense-in-depth, not critical path
+      res.status(400).send('redirect_uri validation failed');
+      return;
     }
   }
 

--- a/src/server/freee-callback.ts
+++ b/src/server/freee-callback.ts
@@ -242,10 +242,9 @@ async function handleCallback(
   }
 
   // Validate redirect_uri against registered client (defense-in-depth).
-  // Fail-closed on validation errors: any exception during lookup (e.g. Redis failure)
-  // results in a 400 response so a malformed/unverifiable redirect_uri can never bypass
-  // the check. Trade-off: the session is already consumed above, so the user must restart
-  // the OAuth flow — accepted security cost vs. a potential validation bypass.
+  // Fail-closed: any exception during lookup (e.g. Redis failure) returns 400 so
+  // an unverifiable redirect_uri cannot bypass the check. The session is already
+  // consumed above, so the user must restart the OAuth flow on failure.
   if (deps.clientStore) {
     try {
       const client = await deps.clientStore.getClient(session.clientId);


### PR DESCRIPTION
## Summary

The OAuth callback handler validates the inbound `redirect_uri` against the registered client as a defense-in-depth check. Previously, exceptions during that check (e.g. Redis lookup failure) were swallowed and the flow continued — fail-open. This PR converts that catch path to fail-closed: any exception during validation returns `400 redirect_uri validation failed`.

## Motivation

When the registered-client lookup throws, the server has lost the ability to verify whether the inbound `redirect_uri` matches a registered URI for the client. Continuing the OAuth flow under that condition lets a hostile or misconfigured client steer the authorization code to an unverified destination — exactly the attack the registration check exists to prevent.

The session is consumed earlier in the handler, so the user must restart the OAuth flow on a validation failure. That is an intentional trade-off: a single restart on transient infrastructure failure is far cheaper than a silently bypassed redirect_uri check.

## Changes

### `src/server/freee-callback.ts`

```diff
   } catch (err) {
     getLogger().error({ clientId: session.clientId, err }, 'Failed to validate redirect_uri');
-    // Continue — redirect_uri validation is defense-in-depth, not critical path
+    res.status(400).send('redirect_uri validation failed');
+    return;
   }
```

The companion comment block was rewritten to a durable WHY explanation (fail-closed rationale + session-already-consumed trade-off).

### `src/server/freee-callback.test.ts`

New test:

```
it('returns 400 (fail-closed) when redirect_uri validation throws', ...)
  getClient: vi.fn(async () => { throw new Error('redis unavailable'); })
  → expect(res.send).toHaveBeenCalledWith('redirect_uri validation failed');
```

## Functional verification

End-to-end via `bun run src/entry-remote.ts` + a fake session/client pair injected into Redis:

| Scenario | Expected | Observed |
|---|---|---|
| invalid `state` | `400 Invalid or expired OAuth session` | `400 Invalid or expired OAuth session` ✅ |
| `redirect_uri` mismatch (session and registered client disagree) | `400 redirect_uri mismatch` | `400 redirect_uri mismatch` ✅ |

Catch-path coverage (clientStore throw) is provided by the new unit test cited above; the live path requires taking down Redis, which would interfere with parallel test setups, so it is intentionally covered at the unit layer.

## Type of change

- [x] Bug fix (security defense-in-depth hardening)
