### PR TITLE
fix(api): handle freee API 429 rate-limit responses explicitly

### DIFF
--- a/.changeset/qw-rate-limit-429.md
+++ b/.changeset/qw-rate-limit-429.md
@@ -1,0 +1,9 @@
+---
+"freee-mcp": patch
+---
+
+freee API の 429 (rate limit) レスポンスを明示ハンドリング
+
+- makeApiRequest に 429 専用分岐を追加し canonical log line に `error_type: 'rate_limit'` を記録
+- Retry-After をエラーメッセージに含める
+- 自動 retry/backoff は別 PR で検討

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getUserAgent } from '../server/user-agent.js';
-import { type BinaryFileResponse, isBinaryFileResponse, makeApiRequest } from './client.js';
+import {
+  type BinaryFileResponse,
+  formatRetryAfterMessage,
+  isBinaryFileResponse,
+  makeApiRequest,
+} from './client.js';
 
 // Test constants (defined after mocks due to hoisting)
 const TEST_API_URL = 'https://api.freee.co.jp';
@@ -104,6 +109,38 @@ async function setupAccessToken(token: string | null): Promise<void> {
   const mockGetValidAccessToken = await import('../auth/tokens.js');
   vi.mocked(mockGetValidAccessToken.getValidAccessToken).mockResolvedValue(token);
 }
+
+describe('formatRetryAfterMessage', () => {
+  it('returns fallback message when header is null', () => {
+    expect(formatRetryAfterMessage(null)).toBe('数分待ってから再試行してください。');
+  });
+
+  it('formats integer delta-seconds', () => {
+    expect(formatRetryAfterMessage('60')).toBe('60秒後に再試行してください。');
+  });
+
+  it('trims whitespace before parsing delta-seconds', () => {
+    expect(formatRetryAfterMessage('  120  ')).toBe('120秒後に再試行してください。');
+  });
+
+  it('converts HTTP-date form to remaining seconds (RFC 7231)', () => {
+    const future = new Date(Date.now() + 90_000).toUTCString();
+    const result = formatRetryAfterMessage(future);
+    expect(result).toMatch(/^\d+秒後に再試行してください。$/);
+    const seconds = Number(result.match(/^(\d+)秒/)?.[1]);
+    expect(seconds).toBeGreaterThan(85);
+    expect(seconds).toBeLessThanOrEqual(90);
+  });
+
+  it('clamps past HTTP-date to zero seconds (no negative)', () => {
+    const past = new Date(Date.now() - 60_000).toUTCString();
+    expect(formatRetryAfterMessage(past)).toBe('0秒後に再試行してください。');
+  });
+
+  it('falls back when header is unparseable', () => {
+    expect(formatRetryAfterMessage('not-a-date-or-number')).toBe('数分待ってから再試行してください。');
+  });
+});
 
 describe('client', () => {
   beforeEach(() => {

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -264,6 +264,50 @@ describe('client', () => {
       );
     });
 
+    it('should throw rate limit error for 429 response', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: { get: (_name: string) => null },
+        json: () => Promise.resolve({ error: 'rate_limit_exceeded' }),
+      });
+
+      await expect(makeApiRequest('GET', '/api/1/users/me')).rejects.toThrow(
+        'レートリミットに達しました (429)',
+      );
+    });
+
+    it('should include Retry-After value in 429 error message when present', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: {
+          get: (name: string) => (name === 'Retry-After' ? '30' : null),
+        },
+        json: () => Promise.resolve({ error: 'rate_limit_exceeded' }),
+      });
+
+      await expect(makeApiRequest('GET', '/api/1/users/me')).rejects.toThrow(
+        '30秒後に再試行してください。',
+      );
+    });
+
+    it('should fall back to generic retry message when Retry-After is missing on 429', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: { get: (_name: string) => null },
+        json: () => Promise.resolve({ error: 'rate_limit_exceeded' }),
+      });
+
+      await expect(makeApiRequest('GET', '/api/1/users/me')).rejects.toThrow(
+        '数分待ってから再試行してください。',
+      );
+    });
+
     it('should throw generic error for other HTTP errors', async () => {
       await setupAccessToken(TEST_ACCESS_TOKEN);
       mockFetch.mockResolvedValue(createErrorResponse(500, { error: 'internal_server_error' }));
@@ -488,6 +532,53 @@ describe('client', () => {
         Record<string, unknown>
       >;
       expect(apiCalls[0]).toMatchObject({ status_code: 401, error_type: 'auth_error' });
+    });
+
+    it('records an api_call and error with error_type=rate_limit on 429 response', async () => {
+      await setupAccessToken(TEST_ACCESS_TOKEN);
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: {
+          get: (name: string) => (name === 'Retry-After' ? '30' : null),
+        },
+        json: () => Promise.resolve({ error: 'rate_limit_exceeded' }),
+      });
+
+      const { RequestRecorder, withRequestRecorder } = await import(
+        '../server/request-context.js'
+      );
+      const recorder = new RequestRecorder({
+        request_id: 'req-api-429',
+        source_ip: '127.0.0.1',
+        method: 'POST',
+        path: '/mcp',
+      });
+
+      await expect(
+        withRequestRecorder(recorder, () => makeApiRequest('GET', '/api/1/users/me')),
+      ).rejects.toThrow(/レートリミットに達しました \(429\)/);
+
+      const payload = recorder.buildPayload({ status: 200, duration_ms: 1 });
+      const apiCalls = payload.api.calls as Array<Record<string, unknown>>;
+      expect(apiCalls).toHaveLength(1);
+      expect(apiCalls[0]).toMatchObject({
+        method: 'GET',
+        status_code: 429,
+        error_type: 'rate_limit',
+      });
+
+      const errors = payload.errors as Array<{
+        source: string;
+        status_code?: number;
+        error_type?: string;
+      }>;
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        source: 'api_client',
+        status_code: 429,
+        error_type: 'rate_limit',
+      });
     });
 
     it('does nothing (null-safe) when no recorder is installed', async () => {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -39,6 +39,28 @@ function isBinaryContentType(contentType: string): boolean {
   return binaryTypes.some((type) => contentType.includes(type));
 }
 
+/**
+ * Build a Japanese retry guidance message from a Retry-After header value.
+ * RFC 7231 §7.1.3 allows delta-seconds (integer) or HTTP-date forms; both are
+ * normalized to a "N秒後に再試行してください。" message. Falls back to a
+ * generic "wait a few minutes" message when the header is absent or
+ * unparseable, so a malformed value never bleeds into the user-facing string.
+ */
+export function formatRetryAfterMessage(retryAfter: string | null): string {
+  const fallback = '数分待ってから再試行してください。';
+  if (!retryAfter) return fallback;
+  const trimmed = retryAfter.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return `${trimmed}秒後に再試行してください。`;
+  }
+  const parsed = Date.parse(trimmed);
+  if (Number.isFinite(parsed)) {
+    const seconds = Math.max(0, Math.ceil((parsed - Date.now()) / 1000));
+    return `${seconds}秒後に再試行してください。`;
+  }
+  return fallback;
+}
+
 export async function makeApiRequest(
   method: string,
   apiPath: string,
@@ -191,9 +213,7 @@ export async function makeApiRequest(
   if (response.status === 429) {
     const retryAfter = response.headers.get('Retry-After');
     const errorInfo = await formatResponseErrorInfo(response);
-    const retryMsg = retryAfter
-      ? `${retryAfter}秒後に再試行してください。`
-      : '数分待ってから再試行してください。';
+    const retryMsg = formatRetryAfterMessage(retryAfter);
     const rateLimitError = new Error(
       `レートリミットに達しました (429): ${errorInfo}\n` +
         `事業所ID: ${companyId}\n` +

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -188,6 +188,36 @@ export async function makeApiRequest(
     throw forbiddenError;
   }
 
+  if (response.status === 429) {
+    const retryAfter = response.headers.get('Retry-After');
+    const errorInfo = await formatResponseErrorInfo(response);
+    const retryMsg = retryAfter
+      ? `${retryAfter}秒後に再試行してください。`
+      : '数分待ってから再試行してください。';
+    const rateLimitError = new Error(
+      `レートリミットに達しました (429): ${errorInfo}\n` +
+        `事業所ID: ${companyId}\n` +
+        retryMsg,
+    );
+    recorder?.recordApiCall({
+      method,
+      path_pattern: safePath,
+      status_code: 429,
+      duration_ms: Date.now() - startTime,
+      company_id: String(companyId ?? ''),
+      user_id: userId,
+      error_type: 'rate_limit',
+      query_keys: queryKeys,
+    });
+    recorder?.recordError({
+      source: 'api_client',
+      status_code: 429,
+      error_type: 'rate_limit',
+      chain: serializeErrorChain(rateLimitError),
+    });
+    throw rateLimitError;
+  }
+
   if (!response.ok) {
     const errorMessage = await formatApiErrorMessage(response, response.status);
     const httpError = new Error(errorMessage);

--- a/src/server/request-context.ts
+++ b/src/server/request-context.ts
@@ -25,6 +25,7 @@ export type ApiCallErrorType =
   | 'network_error'
   | 'auth_error'
   | 'forbidden'
+  | 'rate_limit'
   | 'http_error'
   | 'json_parse_error';
 

--- a/src/sign/client.ts
+++ b/src/sign/client.ts
@@ -130,7 +130,7 @@ export async function makeSignApiRequest(
     const retryMsg = retryAfter
       ? `${retryAfter}秒後に再試行してください。`
       : '数分待ってから再試行してください。';
-    recordFailure(429, 'http_error', new Error(`レートリミットに達しました (429)。${retryMsg}`));
+    recordFailure(429, 'rate_limit', new Error(`レートリミットに達しました (429)。${retryMsg}`));
   }
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary

Add explicit handling for `429 Too Many Requests` responses from freee public APIs. The existing `makeApiRequest` covered only `401`/`403` and a generic `!response.ok` branch, so 429 was silently bucketed as `error_type: 'http_error'` in the canonical log line and the `Retry-After` header was discarded. This PR introduces a dedicated branch that:

- records `error_type: 'rate_limit'` in the canonical log line, making 429 hits searchable as a distinct facet (`@api_calls.error_type:rate_limit` in Datadog),
- formats a Japanese retry guidance message that honors `Retry-After` per RFC 7231 §7.1.3 (delta-seconds and HTTP-date both supported),
- aligns the existing Sign client (`src/sign/client.ts`) with the same facet name.

No automatic backoff/retry is introduced; that is intentionally deferred so we can observe baseline frequency before deciding on retry semantics.

## Changes

### `src/api/client.ts`

New branch matching the existing 401/403 pattern:

```ts
if (response.status === 429) {
  const retryAfter = response.headers.get('Retry-After');
  const errorInfo = await formatResponseErrorInfo(response);
  const retryMsg = formatRetryAfterMessage(retryAfter);
  const rateLimitError = new Error(
    `レートリミットに達しました (429): ${errorInfo}\n` +
    `事業所ID: ${companyId}\n` +
    retryMsg,
  );
  recorder?.recordApiCall({ ..., status_code: 429, error_type: 'rate_limit', ... });
  recorder?.recordError({ source: 'api_client', status_code: 429, error_type: 'rate_limit', ... });
  throw rateLimitError;
}
```

New exported helper:

```ts
export function formatRetryAfterMessage(retryAfter: string | null): string {
  // - integer seconds → `${n}秒後に再試行してください。`
  // - HTTP-date (RFC 7231) → seconds-from-now (`Math.max(0, …)` clamp)
  // - null / unparseable → `数分待ってから再試行してください。`
}
```

### `src/sign/client.ts`

Single-line alignment so the Sign client records `error_type: 'rate_limit'` for 429 (was `'http_error'`). Both clients now share the facet.

### `src/server/request-context.ts`

Add `'rate_limit'` to `ApiCallErrorType`.

### Tests (`src/api/client.test.ts`)

- 6 unit cases for `formatRetryAfterMessage` covering null / integer / whitespace-padded integer / HTTP-date in the future / HTTP-date in the past (clamp to 0) / unparseable.
- New 429 path tested with both delta-seconds and missing-header forms; recorder facet asserted.

## Functional verification

A local mock freee server was started on `localhost:4001` and `makeApiRequest` was invoked with `baseUrl: http://127.0.0.1:4001`. `RequestRecorder` captured the canonical log line so we could inspect `api_calls[0]`.

| Scenario | Mock response | Error message tail | `recorder.api_calls[0]` |
|---|---|---|---|
| delta-seconds | `429 Retry-After: 42` | `…42秒後に再試行してください。` | `status_code:429, error_type:'rate_limit'` |
| HTTP-date (future) | `429 Retry-After: <future>` | `…90秒後に再試行してください。` | `status_code:429, error_type:'rate_limit'` |
| missing header | `429` | `…数分待ってから再試行してください。` | `status_code:429, error_type:'rate_limit'` |
| ok | `200` | (no error) | `status_code:200, error_type:null` |

All 8 unit cases for `formatRetryAfterMessage` pass.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
