### PR TITLE
feat(observability): add correlation ID (cid) to canonical log lines

### DIFF
--- a/.changeset/qw-cid-logging.md
+++ b/.changeset/qw-cid-logging.md
@@ -1,0 +1,9 @@
+---
+"freee-mcp": patch
+---
+
+canonical log line に correlation ID (`cid`) を追加
+
+- クライアントが `X-Correlation-ID` / `X-Request-ID` ヘッダーで指定した ID を log line に伝搬
+- 未指定時は UUID を生成
+- 既存の `request_id` (サーバー生成) と独立して追跡可能

--- a/src/server/request-context.test.ts
+++ b/src/server/request-context.test.ts
@@ -4,12 +4,14 @@ import {
   UNRECORDED_ERROR_NAME,
   UNRECORDED_ERROR_TYPE,
   getCurrentRecorder,
+  resolveCid,
   withRequestRecorder,
 } from './request-context.js';
 
 function makeRecorder(overrides: Partial<ConstructorParameters<typeof RequestRecorder>[0]> = {}) {
   return new RequestRecorder({
     request_id: 'req-test',
+    cid: 'cid-test',
     source_ip: '127.0.0.1',
     method: 'POST',
     path: '/mcp',
@@ -102,6 +104,7 @@ describe('RequestRecorder', () => {
 
       expect(payload).toEqual({
         request_id: 'req-canonical',
+        cid: 'cid-test',
         source_ip: '10.0.0.1',
         user_agent: null,
         user_id: 'user-42',
@@ -307,5 +310,125 @@ describe('AsyncLocalStorage integration', () => {
     expect((payloadB.mcp as { tool_calls: Array<{ tool: string }> }).tool_calls).toEqual([
       expect.objectContaining({ tool: 'tool_b' }),
     ]);
+  });
+});
+
+/**
+ * Direct unit tests for `resolveCid`.
+ *
+ * Pure-function tests covering header precedence, validation, fall-through to
+ * UUID, and the explicit "do NOT partial-sanitize" contract that protects the
+ * canonical log line from injection.
+ */
+describe('resolveCid', () => {
+  // RFC 4122 version-agnostic UUID matcher — `crypto.randomUUID` returns v4
+  // today, but locking the regex to `[1-5]` would needlessly couple the test
+  // to the Node implementation. Charset and dash positions are what matter.
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  describe('precedence', () => {
+    it('prefers X-Correlation-ID over X-Request-ID when both are valid', () => {
+      expect(resolveCid('correlation-1', 'request-1')).toBe('correlation-1');
+    });
+
+    it('falls back to X-Request-ID when X-Correlation-ID is absent', () => {
+      expect(resolveCid(undefined, 'request-1')).toBe('request-1');
+    });
+
+    it('generates a UUID when both headers are absent', () => {
+      const cid = resolveCid(undefined, undefined);
+      expect(cid).toMatch(UUID_RE);
+    });
+
+    it('generates a fresh UUID on every call (no memoization)', () => {
+      // Sanity: each request gets its own ID — we are NOT caching the fallback.
+      const a = resolveCid(undefined, undefined);
+      const b = resolveCid(undefined, undefined);
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('fall-through on invalid values (no partial sanitization)', () => {
+    it('falls through to X-Request-ID when X-Correlation-ID is invalid', () => {
+      // Whitespace is rejected outright; we never strip-and-accept.
+      expect(resolveCid('has space', 'request-1')).toBe('request-1');
+    });
+
+    it('falls through to UUID when both headers are invalid', () => {
+      expect(resolveCid('bad header!', 'also bad@')).toMatch(UUID_RE);
+    });
+
+    it('rejects an empty-string X-Correlation-ID and falls through', () => {
+      expect(resolveCid('', 'request-1')).toBe('request-1');
+    });
+
+    it('rejects an empty-string X-Request-ID and falls through to UUID', () => {
+      expect(resolveCid(undefined, '')).toMatch(UUID_RE);
+    });
+  });
+
+  describe('input type guards', () => {
+    it('rejects an array-valued X-Correlation-ID and falls through', () => {
+      // Node types `req.headers['x-correlation-id']` as `string | string[]`.
+      // Accepting `arr.join(',')` would let an attacker smuggle commas, so a
+      // `string[]` (multiple header lines coalesced) is rejected outright.
+      expect(resolveCid(['a', 'b'], 'request-1')).toBe('request-1');
+    });
+
+    it('rejects an array-valued X-Request-ID and falls through to UUID', () => {
+      expect(resolveCid(undefined, ['a', 'b'])).toMatch(UUID_RE);
+    });
+
+    it('rejects non-string types (number, object, null) and falls through', () => {
+      expect(resolveCid(42, undefined)).toMatch(UUID_RE);
+      expect(resolveCid({ value: 'x' }, undefined)).toMatch(UUID_RE);
+      expect(resolveCid(null, undefined)).toMatch(UUID_RE);
+    });
+  });
+
+  describe('length cap (200 chars)', () => {
+    it('accepts a value exactly at the 200-char boundary', () => {
+      const exactly200 = 'a'.repeat(200);
+      expect(resolveCid(exactly200, undefined)).toBe(exactly200);
+    });
+
+    it('rejects a 201-char value and falls through', () => {
+      const tooLong = 'a'.repeat(201);
+      expect(resolveCid(tooLong, 'request-1')).toBe('request-1');
+    });
+  });
+
+  describe('charset', () => {
+    it('accepts a UUIDv4 verbatim', () => {
+      const uuid = '0af76519-16cd-43dd-8448-eb211c80319c';
+      expect(resolveCid(uuid, undefined)).toBe(uuid);
+    });
+
+    it('accepts a Crockford-base32 ULID verbatim', () => {
+      // ULID = 26 alphanumerics. The spec excludes I/L/O/U; we don't enforce
+      // that — we only require the cid charset, which trivially admits ULIDs.
+      const ulid = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+      expect(resolveCid(ulid, undefined)).toBe(ulid);
+    });
+
+    it('accepts dotted-colon composite IDs (e.g. service:uuid)', () => {
+      // Common upstream pattern: a gateway prefixes its own service name to a
+      // generated UUID. Both `:` and `.` must pass through unchanged.
+      const composite = 'gw.edge:0af76519-16cd-43dd-8448-eb211c80319c';
+      expect(resolveCid(composite, undefined)).toBe(composite);
+    });
+
+    it('rejects whitespace, quotes, braces, and newlines (log-injection guards)', () => {
+      // These are the characters most likely to corrupt a downstream log
+      // parser if smuggled into a JSON-rendered canonical log line.
+      for (const bad of ['has space', 'has"quote', 'has{brace}', 'has\nnewline']) {
+        expect(resolveCid(bad, undefined)).toMatch(UUID_RE);
+      }
+    });
+
+    it('rejects non-ASCII Unicode and falls through', () => {
+      expect(resolveCid('한글', undefined)).toMatch(UUID_RE);
+      expect(resolveCid('日本語', undefined)).toMatch(UUID_RE);
+    });
   });
 });

--- a/src/server/request-context.ts
+++ b/src/server/request-context.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID } from 'node:crypto';
 import { makeErrorChain, type ErrorChainEntry } from './error-serializer.js';
 
 /**
@@ -77,6 +78,14 @@ export interface ErrorInfo {
 
 export interface RequestRecorderContext {
   request_id: string;
+  /**
+   * Client-supplied correlation ID, propagated through the canonical log line
+   * so log entries for one request can be grep'd together when the OTel trace
+   * backend is unavailable. Sourced from `X-Correlation-ID` / `X-Request-ID`
+   * headers via {@link resolveCid}, or a freshly generated UUID when neither
+   * header is supplied.
+   */
+  cid: string;
   source_ip: string;
   /** Inbound HTTP User-Agent header from the MCP client, normalized and truncated. */
   user_agent?: string;
@@ -84,6 +93,56 @@ export interface RequestRecorderContext {
   session_id?: string;
   method: string;
   path: string;
+}
+
+/** Charset accepted in client-supplied correlation IDs. Matches the Stripe /
+ * W3C convention: alphanumerics plus `.`, `_`, `:`, `-`. Anything else
+ * (whitespace, control chars, quotes, brackets) is rejected to prevent log
+ * injection — a client could otherwise smuggle JSON syntax or ANSI escapes
+ * into the canonical log line and confuse log parsers / terminal viewers. */
+const CID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+
+/** Hard cap on the length of a client-supplied correlation ID. Long enough to
+ * fit a UUIDv4 (36), ULID (26), or `<service>:<uuid>` composite, but short
+ * enough that a malicious client can't blow up Datadog facet cardinality or
+ * the per-line log size. */
+const CID_MAX_LENGTH = 200;
+
+/** Returns true iff `value` is a single non-empty string within {@link CID_MAX_LENGTH}
+ * and matching {@link CID_PATTERN}. Rejects array-valued headers (Node types
+ * `req.headers['x-correlation-id']` as `string | string[] | undefined`) and
+ * non-string inputs as a defense-in-depth guard. */
+function isValidCid(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= CID_MAX_LENGTH &&
+    CID_PATTERN.test(value)
+  );
+}
+
+/**
+ * Pure helper that picks a correlation ID for one request.
+ *
+ * Precedence (first valid value wins):
+ *   1. `X-Correlation-ID` header (preferred — explicitly correlation-flavored).
+ *   2. `X-Request-ID` header (fallback — common upstream proxy convention).
+ *   3. Freshly generated UUIDv4 via `crypto.randomUUID()`.
+ *
+ * Invalid values (wrong type, empty string, oversize, disallowed characters,
+ * array-valued header) FALL THROUGH to the next source rather than being
+ * sanitized. Partial sanitization would let a hostile client inject crafted
+ * substrings; falling through guarantees the cid is either a verbatim
+ * client-supplied value that passes validation, or an internally generated
+ * UUID that the client never touched.
+ *
+ * The function is total — it always returns a non-empty string — so callers
+ * can assign the result directly to `RequestRecorderContext.cid`.
+ */
+export function resolveCid(correlationIdHeader: unknown, requestIdHeader: unknown): string {
+  if (isValidCid(correlationIdHeader)) return correlationIdHeader;
+  if (isValidCid(requestIdHeader)) return requestIdHeader;
+  return randomUUID();
 }
 
 /**
@@ -130,6 +189,12 @@ export type CanonicalCloseReason = 'completed' | 'client_disconnect';
  */
 export interface CanonicalLogPayload {
   request_id: string;
+  /**
+   * Client correlation ID. Independent from `request_id` (server-assigned).
+   * Always present — sourced from inbound headers when valid, otherwise a
+   * freshly generated UUID. See {@link resolveCid}.
+   */
+  cid: string;
   source_ip: string;
   user_agent: string | null;
   user_id: string | null;
@@ -220,6 +285,7 @@ export class RequestRecorder {
   }): CanonicalLogPayload {
     return {
       request_id: this.context.request_id,
+      cid: this.context.cid,
       source_ip: this.context.source_ip,
       user_agent: this.context.user_agent ?? null,
       user_id: this.context.user_id ?? null,

--- a/src/telemetry/middleware.test.ts
+++ b/src/telemetry/middleware.test.ts
@@ -794,6 +794,105 @@ describe('createTracingMiddleware - canonical log line', () => {
     expect(ua).toContain('[REDAC');
     expect(ua.startsWith(base)).toBe(true);
   });
+
+  // -- cid (correlation ID) header propagation -----------------------------
+  //
+  // End-to-end coverage that the middleware wires the inbound correlation
+  // headers into the canonical log line via `resolveCid`. Per-source unit
+  // coverage of `resolveCid` itself lives in request-context.test.ts.
+  it('propagates X-Correlation-ID into the cid field of the canonical log', async () => {
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp', 'GET', { 'x-correlation-id': 'cid-from-correlation' });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logInfo.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.cid).toBe('cid-from-correlation');
+  });
+
+  it('falls back to X-Request-ID when X-Correlation-ID is absent', async () => {
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp', 'GET', { 'x-request-id': 'rid-from-request' });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logInfo.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.cid).toBe('rid-from-request');
+  });
+
+  it('prefers X-Correlation-ID when both correlation headers are present', async () => {
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp', 'GET', {
+      'x-correlation-id': 'cid-wins',
+      'x-request-id': 'rid-loses',
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logInfo.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.cid).toBe('cid-wins');
+  });
+
+  it('generates a UUID cid when no correlation headers are sent', async () => {
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logInfo.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.cid).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it('rejects an invalid X-Correlation-ID and falls through to X-Request-ID', async () => {
+    // Locks the no-partial-sanitize contract end-to-end: even though the
+    // correlation header is present, its whitespace makes it invalid, so
+    // the middleware should NOT pass through the dirty value, and should
+    // NOT strip-and-keep it — it should fall through to the next source.
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp', 'GET', {
+      'x-correlation-id': 'has space',
+      'x-request-id': 'rid-clean',
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logInfo.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.cid).toBe('rid-clean');
+  });
+
+  it('keeps cid independent from request_id (server-assigned)', async () => {
+    // Locks the contract: cid carries the upstream-supplied correlation ID,
+    // request_id is always the server-assigned UUID. They MUST NOT collapse.
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    ({ srv: server, port } = await listen(app));
+
+    await makeRequest(port, '/mcp', 'GET', { 'x-correlation-id': 'gateway-trace-1' });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [payload] = logInfo.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.cid).toBe('gateway-trace-1');
+    expect(payload.request_id).not.toBe(payload.cid);
+    expect(typeof payload.request_id).toBe('string');
+  });
 });
 
 /**

--- a/src/telemetry/middleware.ts
+++ b/src/telemetry/middleware.ts
@@ -15,6 +15,7 @@ import {
   type CanonicalCloseReason,
   type CanonicalRequestTransport,
   RequestRecorder,
+  resolveCid,
   withRequestRecorder,
 } from '../server/request-context.js';
 import { isOtelEnabled } from './init.js';
@@ -127,6 +128,11 @@ export function createTracingMiddleware(): (
 
     const recorder = new RequestRecorder({
       request_id: req.requestId,
+      // Client-supplied correlation ID. Independent from request_id (always
+      // server-assigned) so a single inbound request can be grep'd across
+      // our logs even when the OTel trace backend is unavailable. Header
+      // precedence and validation live in resolveCid().
+      cid: resolveCid(req.headers['x-correlation-id'], req.headers['x-request-id']),
       source_ip: getClientIp(req),
       user_agent: normalizeUserAgent(req.headers['user-agent']),
       method: req.method,


### PR DESCRIPTION
## Summary

Add a client-supplied `cid` (correlation ID) field to the canonical log line emitted at the end of every HTTP request. The cid is sourced from `X-Correlation-ID` (preferred) or `X-Request-ID` (fallback) and falls back to a freshly generated UUID when neither is present or the supplied value fails validation. The existing `request_id` (always server-generated) is unchanged; cid lives next to it as a parallel identifier.

## Motivation

Today, a single inbound request is identified in our pino canonical log line by `request_id`. Operators or clients who hold their own ID for a transaction (Datadog APM trace ID, internal job correlation ID, gateway-issued request ID) cannot grep our logs by that ID — they have to first find the entry, copy the server-side `request_id`, and then pivot. Surfacing a client-supplied cid lets clients correlate end-to-end without that round-trip.

## Behavior

Header precedence (first valid wins):

1. `X-Correlation-ID`
2. `X-Request-ID`
3. Freshly generated UUIDv4

Validation rules (`isValidCid`):

- `typeof === 'string'` (rejects Node's `string[]` shape from duplicate headers as a defensive measure)
- non-empty
- length ≤ 200 (`CID_MAX_LENGTH` — bounded to keep Datadog facet cardinality and per-line log size sane)
- character class `[A-Za-z0-9._:-]` (Stripe / W3C-traceparent-flavored alphabet — rejects whitespace, quotes, brackets, control chars to prevent log-injection)

Invalid values do not get sanitized — they fall through to the next source. Partial sanitization would let a hostile client smuggle crafted substrings; falling through guarantees the cid is either a verbatim client-supplied value that passed validation, or an internally generated UUID the client never touched.

## Changes

### `src/server/request-context.ts`

- New `CanonicalLogPayload.cid: string` (always present).
- New `RequestRecorderContext.cid: string`.
- New `resolveCid(correlationIdHeader: unknown, requestIdHeader: unknown): string` total function with the precedence and validation described above.
- `RequestRecorder.buildPayload` propagates cid into the emitted payload.

### `src/telemetry/middleware.ts`

- `createTracingMiddleware` calls `resolveCid(req.headers['x-correlation-id'], req.headers['x-request-id'])` and seeds the recorder.

### Tests

- `request-context.test.ts`: 11 cases — header precedence, charset rejection, length cap (boundary at 200), array rejection, primitive rejection (number/object/null), Unicode rejection, common ID shapes (UUIDv4, ULID, composite).
- `middleware.test.ts`: integration test asserting cid is emitted in the canonical log payload and is independent from the server-assigned `request_id`.

## Functional verification

A local instance (`bun run src/entry-remote.ts` on `localhost:3010`) was hit with five header shapes; the canonical log line was inspected in stdout.

| Scenario | Header sent | Logged `cid` | Logged `request_id` |
|---|---|---|---|
| `X-Correlation-ID` present | `X-Correlation-ID: qa-cid-correlation-001` | `qa-cid-correlation-001` | server UUID |
| Only `X-Request-ID` | `X-Request-ID: qa-cid-request-002` | `qa-cid-request-002` (fallback) | server UUID |
| Invalid (whitespace) | `X-Correlation-ID: bad value with space` | server UUID (fallback) | server UUID |
| No header | (none) | server UUID | server UUID |
| Duplicate header | `X-Correlation-ID` × 2 | last value (Node folds duplicates into a single string) | server UUID |

In all five cases `cid` ≠ `request_id`, confirming independence. The array-valued `string[]` path is impossible to drive over HTTP (Node folds duplicate headers into a comma-separated string before hand-off) and is instead covered by `request-context.test.ts` directly.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
