### PR TITLE
feat(logging): add company_id to top-level canonical log payload

### DIFF
--- a/.changeset/qw-99-company-id-toplevel.md
+++ b/.changeset/qw-99-company-id-toplevel.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+canonical log line の top-level に `company_id` を追加。`tools/list` のように外向き API call を発火しないリクエストでも company コンテキストが残るようになり、Datadog の `@company_id:<id>` facet で 1 ログ行から検索可能になる。

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -215,14 +215,22 @@ export async function startHttpServer(options?: {
   async function handleMcpRequest(req: Request, res: Response): Promise<void> {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
 
-    // Patch the request recorder with user_id / session_id now that bearer
-    // auth has run. These are not known at middleware creation time.
+    // Patch the request recorder with identity fields now that bearer auth
+    // has run. company_id lookup is fail-soft: it is a diagnostic facet, not
+    // load-bearing for the request, so a Redis hiccup must not break /mcp.
     const authExtra = (req as unknown as Record<string, unknown>).auth as
       | { extra?: Record<string, unknown> }
       | undefined;
     const userId =
       typeof authExtra?.extra?.userId === 'string' ? authExtra.extra.userId : undefined;
-    getCurrentRecorder()?.updateContext({ user_id: userId, session_id: sessionId });
+    const companyId = userId
+      ? await tokenStore.getCurrentCompanyId(userId).catch(() => undefined)
+      : undefined;
+    getCurrentRecorder()?.updateContext({
+      user_id: userId,
+      company_id: companyId,
+      session_id: sessionId,
+    });
 
     // Unknown session ID: return 404 per MCP spec (stateless mode never issues session IDs)
     if (sessionId) {

--- a/src/server/request-context.test.ts
+++ b/src/server/request-context.test.ts
@@ -105,6 +105,7 @@ describe('RequestRecorder', () => {
         source_ip: '10.0.0.1',
         user_agent: null,
         user_id: 'user-42',
+        company_id: null,
         session_id: 'sess-xyz',
         http: {
           method: 'POST',
@@ -124,10 +125,11 @@ describe('RequestRecorder', () => {
       });
     });
 
-    it('defaults user_id and session_id to null when unset', () => {
+    it('defaults user_id, company_id, and session_id to null when unset', () => {
       const recorder = makeRecorder();
       const payload = recorder.buildPayload({ status: 200, duration_ms: 10 });
       expect(payload.user_id).toBeNull();
+      expect(payload.company_id).toBeNull();
       expect(payload.session_id).toBeNull();
     });
 
@@ -234,16 +236,29 @@ describe('RequestRecorder', () => {
       recorder.updateContext({ user_id: 'u-1' });
       const p1 = recorder.buildPayload({ status: 200, duration_ms: 1 });
       expect(p1.user_id).toBe('u-1');
+      expect(p1.company_id).toBeNull();
       expect(p1.session_id).toBeNull();
 
-      recorder.updateContext({ session_id: 's-1' });
+      recorder.updateContext({ company_id: 'c-1', session_id: 's-1' });
       const p2 = recorder.buildPayload({ status: 200, duration_ms: 1 });
       expect(p2.user_id).toBe('u-1');
+      expect(p2.company_id).toBe('c-1');
       expect(p2.session_id).toBe('s-1');
 
       // Request metadata from the constructor is preserved.
       expect(p2.request_id).toBe('req-1');
       expect((p2.http as { method: string }).method).toBe('GET');
+    });
+
+    it('lifts company_id to a top-level scalar even when api.calls[] is empty', () => {
+      // Requests with no outgoing API call (e.g. tools/list) must still
+      // expose company context as a top-level Datadog facet, not buried
+      // inside api.calls[].company_id where it would be unreachable.
+      const recorder = makeRecorder();
+      recorder.updateContext({ user_id: 'u-1', company_id: '12345' });
+      const payload = recorder.buildPayload({ status: 200, duration_ms: 1 });
+      expect(payload.company_id).toBe('12345');
+      expect(payload.api.calls).toHaveLength(0);
     });
   });
 });

--- a/src/server/request-context.ts
+++ b/src/server/request-context.ts
@@ -81,6 +81,7 @@ export interface RequestRecorderContext {
   /** Inbound HTTP User-Agent header from the MCP client, normalized and truncated. */
   user_agent?: string;
   user_id?: string;
+  company_id?: string;
   session_id?: string;
   method: string;
   path: string;
@@ -133,6 +134,7 @@ export interface CanonicalLogPayload {
   source_ip: string;
   user_agent: string | null;
   user_id: string | null;
+  company_id: string | null;
   session_id: string | null;
   http: {
     method: string;
@@ -169,8 +171,10 @@ export class RequestRecorder {
     this.context = initial;
   }
 
-  /** Patch fields available only after bearer auth runs (user_id, session_id). */
-  updateContext(patch: Partial<Pick<RequestRecorderContext, 'user_id' | 'session_id'>>): void {
+  /** Patch fields available only after bearer auth runs (user_id, company_id, session_id). */
+  updateContext(
+    patch: Partial<Pick<RequestRecorderContext, 'user_id' | 'company_id' | 'session_id'>>,
+  ): void {
     this.context = { ...this.context, ...patch };
   }
 
@@ -223,6 +227,7 @@ export class RequestRecorder {
       source_ip: this.context.source_ip,
       user_agent: this.context.user_agent ?? null,
       user_id: this.context.user_id ?? null,
+      company_id: this.context.company_id ?? null,
       session_id: this.context.session_id ?? null,
       http: {
         method: this.context.method,


### PR DESCRIPTION
## Summary

Adds `company_id` as a top-level scalar on the canonical log line emitted at `res.on('finish')`.

Previously, `company_id` only existed inside `api.calls[].company_id` (per outgoing freee API call). Requests that don't make any outbound freee API call — `tools/list`, OAuth discovery (`/.well-known/...`), failed-auth requests — lost company context entirely. Datadog facet search also required diving into the `api.calls` array.

## Changes

- `RequestRecorderContext` gains an optional `company_id?: string`
- `CanonicalLogPayload` gains a top-level `company_id: string | null`
- After bearer auth runs, the recorder is patched with the user's current company via `tokenStore.getCurrentCompanyId(userId)`
- The lookup is fail-soft (`.catch(() => undefined)`): a Redis hiccup must not break the `/mcp` request, since this field is diagnostic only
- Endpoints with no authenticated user (e.g. `/.well-known/oauth-authorization-server`) emit `company_id: null` — intentional

## Verification

- `bun run typecheck && bun run lint && bun run test:run && bun run build` — all green (681 tests)
- New tests in `src/server/request-context.test.ts` cover: default-null behavior, `updateContext({ company_id })` patching, top-level emission when `api.calls[]` is empty
- Manual: booted `bun run src/entry-remote.ts`, hit `/.well-known/oauth-authorization-server` with `curl`, confirmed canonical log shows `"company_id": null` at top-level alongside `user_id` / `session_id`

## Operational impact

- Datadog facet `@company_id:<id>` now works on a single log line
- Per-line size grows by ≤ 20 bytes (one nullable scalar)
- Hot-path adds one Redis `hget` after bearer auth on `/mcp`; sub-millisecond, fail-soft
