### PR TITLE
feat(config): secure-by-default env validation and rate limit default

### DIFF
--- a/.changeset/env-validation-secure-default.md
+++ b/.changeset/env-validation-secure-default.md
@@ -1,0 +1,9 @@
+---
+"freee-mcp": minor
+---
+
+serve モードの環境変数バリデーションを zod ベースで強化し、`RATE_LIMIT_ENABLED` をデフォルト `true`（secure-by-default）に変更
+
+- BREAKING: 明示的に `RATE_LIMIT_ENABLED=false` / `SIGN_RATE_LIMIT_ENABLED=false` を設定しない限り rate limit が有効化される
+- 必須環境変数 (ISSUER_URL / JWT_SECRET / FREEE_CLIENT_ID / FREEE_CLIENT_SECRET 等) が未設定・URL 形式不正・LOG_LEVEL 不正値の場合に起動時失敗
+- 起動時に解決済み設定をログ出力（jwtSecret / clientSecret はマスク）

--- a/src/config-remote.test.ts
+++ b/src/config-remote.test.ts
@@ -38,7 +38,7 @@ describe('loadRemoteServerConfig', () => {
       freeeApiUrl: 'https://api.freee.co.jp',
       redisUrl: 'redis://localhost:6379',
       corsAllowedOrigins: undefined,
-      rateLimitEnabled: false,
+      rateLimitEnabled: true,
       logLevel: 'info',
       allowInsecureLocalhostCimd: false,
     });
@@ -107,6 +107,58 @@ describe('loadRemoteServerConfig', () => {
     });
   });
 
+  it('should default RATE_LIMIT_ENABLED to true when unset (secure-by-default)', async () => {
+    delete process.env.RATE_LIMIT_ENABLED;
+    const { loadRemoteServerConfig } = await import('./config.js');
+    const config = loadRemoteServerConfig();
+
+    expect(config.rateLimitEnabled).toBe(true);
+  });
+
+  it('should allow opting out via RATE_LIMIT_ENABLED=false', async () => {
+    process.env.RATE_LIMIT_ENABLED = 'false';
+    const { loadRemoteServerConfig } = await import('./config.js');
+    const config = loadRemoteServerConfig();
+
+    expect(config.rateLimitEnabled).toBe(false);
+  });
+
+  it('should accept boolean aliases for RATE_LIMIT_ENABLED (NO/0/off)', async () => {
+    process.env.RATE_LIMIT_ENABLED = 'NO';
+    const { loadRemoteServerConfig } = await import('./config.js');
+    const config = loadRemoteServerConfig();
+
+    expect(config.rateLimitEnabled).toBe(false);
+  });
+
+  it('should throw when RATE_LIMIT_ENABLED has an invalid value', async () => {
+    process.env.RATE_LIMIT_ENABLED = 'maybe';
+    const { loadRemoteServerConfig } = await import('./config.js');
+
+    expect(() => loadRemoteServerConfig()).toThrow('RATE_LIMIT_ENABLED');
+  });
+
+  it('should throw when ISSUER_URL is not a valid URL', async () => {
+    process.env.ISSUER_URL = 'not-a-url';
+    const { loadRemoteServerConfig } = await import('./config.js');
+
+    expect(() => loadRemoteServerConfig()).toThrow('ISSUER_URL');
+  });
+
+  it('should throw when FREEE_API_BASE_URL is not a valid URL', async () => {
+    process.env.FREEE_API_BASE_URL = 'not-a-url';
+    const { loadRemoteServerConfig } = await import('./config.js');
+
+    expect(() => loadRemoteServerConfig()).toThrow('FREEE_API_BASE_URL');
+  });
+
+  it('should throw when LOG_LEVEL is not a recognised pino level', async () => {
+    process.env.LOG_LEVEL = 'verbose';
+    const { loadRemoteServerConfig } = await import('./config.js');
+
+    expect(() => loadRemoteServerConfig()).toThrow('LOG_LEVEL');
+  });
+
   it('should throw when ISSUER_URL is missing', async () => {
     delete process.env.ISSUER_URL;
     const { loadRemoteServerConfig } = await import('./config.js');
@@ -166,6 +218,65 @@ describe('loadRemoteServerConfig', () => {
     const config = loadRemoteServerConfig();
 
     expect(config.freeeApiUrl).toBe('https://staging.example.com');
+  });
+});
+
+describe('summarizeRemoteServerConfig', () => {
+  it('should mask jwtSecret and freeeClientSecret in the summary', async () => {
+    const { summarizeRemoteServerConfig } = await import('./config.js');
+    const summary = summarizeRemoteServerConfig({
+      port: 3000,
+      issuerUrl: 'https://mcp.example.com',
+      jwtSecret: 'a-test-secret-that-is-at-least-32-characters-long',
+      freeeClientId: 'cid',
+      freeeClientSecret: 'csec',
+      freeeAuthorizationEndpoint: 'https://accounts.secure.freee.co.jp/public_api/authorize',
+      freeeTokenEndpoint: 'https://accounts.secure.freee.co.jp/public_api/token',
+      freeeScope: 'read write',
+      freeeApiUrl: 'https://api.freee.co.jp',
+      redisUrl: 'redis://localhost:6379',
+      rateLimitEnabled: true,
+      logLevel: 'info',
+    });
+
+    expect(summary.jwtSecret).toBe('<redacted>');
+    expect(summary.freeeClientSecret).toBe('<redacted>');
+    expect(summary.freeeClientId).toBe('cid');
+    expect(summary.rateLimitEnabled).toBe(true);
+  });
+});
+
+describe('parseBooleanEnv', () => {
+  it.each([
+    ['true', true],
+    ['TRUE', true],
+    ['1', true],
+    ['yes', true],
+    ['on', true],
+    ['false', false],
+    ['FALSE', false],
+    ['0', false],
+    ['no', false],
+    ['off', false],
+  ])('parses %s as %s', async (input, expected) => {
+    const { parseBooleanEnv } = await import('./config.js');
+    expect(parseBooleanEnv('FOO', input, !expected)).toBe(expected);
+  });
+
+  it('returns the default when value is undefined', async () => {
+    const { parseBooleanEnv } = await import('./config.js');
+    expect(parseBooleanEnv('FOO', undefined, true)).toBe(true);
+    expect(parseBooleanEnv('FOO', undefined, false)).toBe(false);
+  });
+
+  it('returns the default when value is empty', async () => {
+    const { parseBooleanEnv } = await import('./config.js');
+    expect(parseBooleanEnv('FOO', '', true)).toBe(true);
+  });
+
+  it('throws on unrecognised values', async () => {
+    const { parseBooleanEnv } = await import('./config.js');
+    expect(() => parseBooleanEnv('FOO', 'maybe', false)).toThrow('FOO');
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { z } from 'zod';
 import { loadFullConfig } from './config/companies.js';
 import {
   AUTH_TIMEOUT_MS,
@@ -223,30 +224,103 @@ function isDevelopmentEnvironment(): boolean {
   return process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
 }
 
-export function loadRemoteServerConfig(): RemoteServerConfig {
-  const issuerUrl = process.env.ISSUER_URL;
-  if (!issuerUrl) {
-    throw new Error('ISSUER_URL environment variable is required for serve mode.');
+/**
+ * Parse a boolean environment variable.
+ * Accepts (case-insensitively): "true"/"false", "1"/"0", "yes"/"no", "on"/"off".
+ * Returns `defaultValue` when the variable is undefined or empty.
+ * Throws if the value is set but not one of the accepted forms.
+ */
+export function parseBooleanEnv(
+  name: string,
+  value: string | undefined,
+  defaultValue: boolean,
+): boolean {
+  if (value === undefined || value === '') {
+    return defaultValue;
   }
+  const normalized = value.trim().toLowerCase();
+  if (['true', '1', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['false', '0', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+  throw new Error(`${name} must be a boolean (true/false). Got: ${JSON.stringify(value)}`);
+}
 
-  const jwtSecret = process.env.JWT_SECRET;
-  if (!jwtSecret) {
-    throw new Error('JWT_SECRET environment variable is required for serve mode.');
-  }
-  if (jwtSecret.length < 32) {
-    throw new Error(
+const VALID_LOG_LEVELS = ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'] as const;
+
+/**
+ * Schema for validating remote server environment variables at startup.
+ * All required envs must be present and well-formed; invalid values fail loudly.
+ */
+const RemoteServerEnvSchema = z.object({
+  ISSUER_URL: z
+    .string({ required_error: 'ISSUER_URL is required for serve mode.' })
+    .min(1, 'ISSUER_URL is required for serve mode.')
+    .url('ISSUER_URL must be a valid URL.'),
+  JWT_SECRET: z
+    .string({ required_error: 'JWT_SECRET is required for serve mode.' })
+    .min(
+      32,
       'JWT_SECRET must be at least 32 characters. Use a cryptographically random value: openssl rand -hex 32',
-    );
-  }
+    ),
+  FREEE_CLIENT_ID: z
+    .string({ required_error: 'FREEE_CLIENT_ID is required for serve mode.' })
+    .min(1, 'FREEE_CLIENT_ID is required for serve mode.'),
+  FREEE_CLIENT_SECRET: z
+    .string({ required_error: 'FREEE_CLIENT_SECRET is required for serve mode.' })
+    .min(1, 'FREEE_CLIENT_SECRET is required for serve mode.'),
+  PORT: z.string().optional(),
+  FREEE_AUTHORIZATION_ENDPOINT: z
+    .string()
+    .url('FREEE_AUTHORIZATION_ENDPOINT must be a valid URL.')
+    .optional(),
+  FREEE_TOKEN_ENDPOINT: z.string().url('FREEE_TOKEN_ENDPOINT must be a valid URL.').optional(),
+  FREEE_SCOPE: z.string().optional(),
+  FREEE_API_BASE_URL: z.string().url('FREEE_API_BASE_URL must be a valid URL.').optional(),
+  REDIS_URL: z.string().min(1).optional(),
+  CORS_ALLOWED_ORIGINS: z.string().optional(),
+  RATE_LIMIT_ENABLED: z.string().optional(),
+  LOG_LEVEL: z.enum(VALID_LOG_LEVELS).optional(),
+});
 
-  const freeeClientId = process.env.FREEE_CLIENT_ID;
-  const freeeClientSecret = process.env.FREEE_CLIENT_SECRET;
+function formatZodIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const name = issue.path.join('.');
+      return name ? `${name}: ${issue.message}` : issue.message;
+    })
+    .join('; ');
+}
 
-  if (!freeeClientId || !freeeClientSecret) {
-    throw new Error(
-      'FREEE_CLIENT_ID and FREEE_CLIENT_SECRET environment variables are required for serve mode.',
-    );
+export function loadRemoteServerConfig(): RemoteServerConfig {
+  // Pick only the envs we care about so unrelated values don't trigger validation.
+  const rawEnv = {
+    ISSUER_URL: process.env.ISSUER_URL,
+    JWT_SECRET: process.env.JWT_SECRET,
+    FREEE_CLIENT_ID: process.env.FREEE_CLIENT_ID,
+    FREEE_CLIENT_SECRET: process.env.FREEE_CLIENT_SECRET,
+    PORT: process.env.PORT,
+    FREEE_AUTHORIZATION_ENDPOINT: process.env.FREEE_AUTHORIZATION_ENDPOINT,
+    FREEE_TOKEN_ENDPOINT: process.env.FREEE_TOKEN_ENDPOINT,
+    FREEE_SCOPE: process.env.FREEE_SCOPE,
+    FREEE_API_BASE_URL: process.env.FREEE_API_BASE_URL,
+    REDIS_URL: process.env.REDIS_URL,
+    CORS_ALLOWED_ORIGINS: process.env.CORS_ALLOWED_ORIGINS,
+    RATE_LIMIT_ENABLED: process.env.RATE_LIMIT_ENABLED,
+    LOG_LEVEL: process.env.LOG_LEVEL,
+  };
+
+  const parsed = RemoteServerEnvSchema.safeParse(rawEnv);
+  if (!parsed.success) {
+    throw new Error(`Invalid environment configuration: ${formatZodIssues(parsed.error)}`);
   }
+  const env = parsed.data;
+
+  // RATE_LIMIT_ENABLED defaults to true (secure-by-default).
+  // Operators must set RATE_LIMIT_ENABLED=false explicitly to disable.
+  const rateLimitEnabled = parseBooleanEnv('RATE_LIMIT_ENABLED', env.RATE_LIMIT_ENABLED, true);
 
   const allowInsecureLocalhostCimd = isDevelopmentEnvironment();
 
@@ -266,23 +340,60 @@ export function loadRemoteServerConfig(): RemoteServerConfig {
   }
 
   return {
-    port: parsePort(process.env.PORT, 3000),
-    issuerUrl,
-    jwtSecret,
+    port: parsePort(env.PORT, 3000),
+    issuerUrl: env.ISSUER_URL,
+    jwtSecret: env.JWT_SECRET,
     jwtAudience: resolveMcpJwtAudience(),
     jwtAudienceEnforce: resolveMcpJwtAudienceEnforce(),
-    freeeClientId,
-    freeeClientSecret,
-    freeeAuthorizationEndpoint:
-      process.env.FREEE_AUTHORIZATION_ENDPOINT || FREEE_AUTHORIZATION_ENDPOINT,
-    freeeTokenEndpoint: process.env.FREEE_TOKEN_ENDPOINT || FREEE_TOKEN_ENDPOINT,
-    freeeScope: process.env.FREEE_SCOPE || FREEE_OAUTH_SCOPE,
-    freeeApiUrl: process.env.FREEE_API_BASE_URL?.replace(/\/+$/, '') || FREEE_API_URL,
-    redisUrl: process.env.REDIS_URL || 'redis://localhost:6379',
-    corsAllowedOrigins: process.env.CORS_ALLOWED_ORIGINS,
-    rateLimitEnabled: process.env.RATE_LIMIT_ENABLED === 'true',
-    logLevel: process.env.LOG_LEVEL || 'info',
+    freeeClientId: env.FREEE_CLIENT_ID,
+    freeeClientSecret: env.FREEE_CLIENT_SECRET,
+    freeeAuthorizationEndpoint: env.FREEE_AUTHORIZATION_ENDPOINT || FREEE_AUTHORIZATION_ENDPOINT,
+    freeeTokenEndpoint: env.FREEE_TOKEN_ENDPOINT || FREEE_TOKEN_ENDPOINT,
+    freeeScope: env.FREEE_SCOPE || FREEE_OAUTH_SCOPE,
+    freeeApiUrl: env.FREEE_API_BASE_URL?.replace(/\/+$/, '') || FREEE_API_URL,
+    redisUrl: env.REDIS_URL || 'redis://localhost:6379',
+    corsAllowedOrigins: env.CORS_ALLOWED_ORIGINS,
+    rateLimitEnabled,
+    logLevel: env.LOG_LEVEL || 'info',
     allowInsecureLocalhostCimd,
+  };
+}
+
+/**
+ * Mask a secret value for safe logging.
+ * Returns a fixed-length placeholder so that the original length is not leaked.
+ */
+function maskSecret(value: string | undefined): string {
+  if (!value) {
+    return '<unset>';
+  }
+  return '<redacted>';
+}
+
+/**
+ * Build a log-safe summary of the resolved remote server config.
+ * Secrets (jwtSecret, freeeClientSecret) are masked.
+ */
+export function summarizeRemoteServerConfig(
+  config: RemoteServerConfig,
+): Record<string, string | number | boolean | undefined> {
+  return {
+    port: config.port,
+    issuerUrl: config.issuerUrl,
+    jwtSecret: maskSecret(config.jwtSecret),
+    jwtAudience: config.jwtAudience,
+    jwtAudienceEnforce: config.jwtAudienceEnforce,
+    freeeClientId: config.freeeClientId,
+    freeeClientSecret: maskSecret(config.freeeClientSecret),
+    freeeAuthorizationEndpoint: config.freeeAuthorizationEndpoint,
+    freeeTokenEndpoint: config.freeeTokenEndpoint,
+    freeeScope: config.freeeScope,
+    freeeApiUrl: config.freeeApiUrl,
+    redisUrl: config.redisUrl,
+    corsAllowedOrigins: config.corsAllowedOrigins,
+    rateLimitEnabled: config.rateLimitEnabled,
+    logLevel: config.logLevel,
+    allowInsecureLocalhostCimd: config.allowInsecureLocalhostCimd,
   };
 }
 

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -1,6 +1,11 @@
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { Request, Response } from 'express';
-import { getConfig, initRemoteConfig, loadRemoteServerConfig } from '../config.js';
+import {
+  getConfig,
+  initRemoteConfig,
+  loadRemoteServerConfig,
+  summarizeRemoteServerConfig,
+} from '../config.js';
 import { FREEE_CALLBACK_PATH } from '../constants.js';
 import { createMcpServer } from '../mcp/handlers.js';
 import type { Redis } from '../storage/redis-client.js';
@@ -36,6 +41,10 @@ export async function startHttpServer(options?: {
 
   const logger = initLogger({ level: remoteConfig.logLevel, transportMode: 'remote' });
   initUserAgentTransportMode('remote');
+
+  // Log the resolved configuration with secrets masked, so operators can verify
+  // what was loaded at startup without exposing credentials.
+  logger.info({ config: summarizeRemoteServerConfig(remoteConfig) }, 'Loaded remote server config');
 
   const redis = getRedisClient(remoteConfig.redisUrl);
 

--- a/src/sign/config.test.ts
+++ b/src/sign/config.test.ts
@@ -152,9 +152,46 @@ describe('loadSignRemoteServerConfig', () => {
       signScope: 'all',
       redisUrl: 'redis://localhost:6379',
       corsAllowedOrigins: undefined,
-      rateLimitEnabled: false,
+      rateLimitEnabled: true,
       logLevel: 'info',
     });
+  });
+
+  it('SIGN_RATE_LIMIT_ENABLED 未設定 → デフォルト true（secure-by-default）', async () => {
+    delete process.env.SIGN_RATE_LIMIT_ENABLED;
+    const { loadSignRemoteServerConfig } = await import('./config.js');
+    const config = loadSignRemoteServerConfig();
+
+    expect(config.rateLimitEnabled).toBe(true);
+  });
+
+  it('SIGN_RATE_LIMIT_ENABLED=false で明示的に無効化できる', async () => {
+    process.env.SIGN_RATE_LIMIT_ENABLED = 'false';
+    const { loadSignRemoteServerConfig } = await import('./config.js');
+    const config = loadSignRemoteServerConfig();
+
+    expect(config.rateLimitEnabled).toBe(false);
+  });
+
+  it('SIGN_RATE_LIMIT_ENABLED が不正値 → エラー', async () => {
+    process.env.SIGN_RATE_LIMIT_ENABLED = 'maybe';
+    const { loadSignRemoteServerConfig } = await import('./config.js');
+
+    expect(() => loadSignRemoteServerConfig()).toThrow('SIGN_RATE_LIMIT_ENABLED');
+  });
+
+  it('SIGN_LOG_LEVEL が pino で許容されない値 → エラー', async () => {
+    process.env.SIGN_LOG_LEVEL = 'verbose';
+    const { loadSignRemoteServerConfig } = await import('./config.js');
+
+    expect(() => loadSignRemoteServerConfig()).toThrow('SIGN_LOG_LEVEL');
+  });
+
+  it('SIGN_ISSUER_URL が URL 形式でない → エラー', async () => {
+    process.env.SIGN_ISSUER_URL = 'not-a-url';
+    const { loadSignRemoteServerConfig } = await import('./config.js');
+
+    expect(() => loadSignRemoteServerConfig()).toThrow('SIGN_ISSUER_URL');
   });
 
   it('SIGN_ISSUER_URL 未設定 → エラー', async () => {
@@ -184,5 +221,29 @@ describe('loadSignRemoteServerConfig', () => {
     const { loadSignRemoteServerConfig } = await import('./config.js');
 
     expect(() => loadSignRemoteServerConfig()).toThrow('FREEE_SIGN_CLIENT_ID');
+  });
+});
+
+describe('summarizeSignRemoteServerConfig', () => {
+  it('jwtSecret と signClientSecret はマスクされる', async () => {
+    const { summarizeSignRemoteServerConfig } = await import('./config.js');
+    const summary = summarizeSignRemoteServerConfig({
+      port: 3002,
+      issuerUrl: 'https://sign-mcp.example.com',
+      jwtSecret: 'a-sign-test-secret-that-is-at-least-32-characters-long',
+      signClientId: 'cid',
+      signClientSecret: 'csec',
+      signAuthorizationEndpoint: 'https://ninja-sign.com/oauth/authorize',
+      signTokenEndpoint: 'https://ninja-sign.com/oauth/token',
+      signScope: 'all',
+      redisUrl: 'redis://localhost:6379',
+      rateLimitEnabled: true,
+      logLevel: 'info',
+    });
+
+    expect(summary.jwtSecret).toBe('<redacted>');
+    expect(summary.signClientSecret).toBe('<redacted>');
+    expect(summary.signClientId).toBe('cid');
+    expect(summary.rateLimitEnabled).toBe(true);
   });
 });

--- a/src/sign/config.ts
+++ b/src/sign/config.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { z } from 'zod';
-import { parsePort } from '../config.js';
+import { parseBooleanEnv, parsePort } from '../config.js';
 import { CONFIG_FILE_PERMISSION, getConfigDir } from '../constants.js';
 
 /** サイン専用のデフォルトコールバックポート（freee 本体の 54321 と競合しないようにする） */
@@ -153,44 +153,127 @@ export interface SignRemoteServerConfig {
   logLevel: string;
 }
 
-export function loadSignRemoteServerConfig(): SignRemoteServerConfig {
-  const issuerUrl = process.env.SIGN_ISSUER_URL;
-  if (!issuerUrl) {
-    throw new Error('SIGN_ISSUER_URL environment variable is required for serve mode.');
-  }
+const SIGN_VALID_LOG_LEVELS = [
+  'fatal',
+  'error',
+  'warn',
+  'info',
+  'debug',
+  'trace',
+  'silent',
+] as const;
 
-  const jwtSecret = process.env.SIGN_JWT_SECRET;
-  if (!jwtSecret) {
-    throw new Error('SIGN_JWT_SECRET environment variable is required for serve mode.');
-  }
-  if (jwtSecret.length < 32) {
-    throw new Error(
+const SignRemoteServerEnvSchema = z.object({
+  SIGN_ISSUER_URL: z
+    .string({ required_error: 'SIGN_ISSUER_URL is required for serve mode.' })
+    .min(1, 'SIGN_ISSUER_URL is required for serve mode.')
+    .url('SIGN_ISSUER_URL must be a valid URL.'),
+  SIGN_JWT_SECRET: z
+    .string({ required_error: 'SIGN_JWT_SECRET is required for serve mode.' })
+    .min(
+      32,
       'SIGN_JWT_SECRET must be at least 32 characters. Use a cryptographically random value: openssl rand -hex 32',
-    );
-  }
+    ),
+  FREEE_SIGN_CLIENT_ID: z
+    .string({ required_error: 'FREEE_SIGN_CLIENT_ID is required for serve mode.' })
+    .min(1, 'FREEE_SIGN_CLIENT_ID is required for serve mode.'),
+  FREEE_SIGN_CLIENT_SECRET: z
+    .string({ required_error: 'FREEE_SIGN_CLIENT_SECRET is required for serve mode.' })
+    .min(1, 'FREEE_SIGN_CLIENT_SECRET is required for serve mode.'),
+  SIGN_PORT: z.string().optional(),
+  SIGN_AUTHORIZATION_ENDPOINT: z
+    .string()
+    .url('SIGN_AUTHORIZATION_ENDPOINT must be a valid URL.')
+    .optional(),
+  SIGN_TOKEN_ENDPOINT: z.string().url('SIGN_TOKEN_ENDPOINT must be a valid URL.').optional(),
+  SIGN_SCOPE: z.string().optional(),
+  SIGN_REDIS_URL: z.string().min(1).optional(),
+  SIGN_CORS_ALLOWED_ORIGINS: z.string().optional(),
+  SIGN_RATE_LIMIT_ENABLED: z.string().optional(),
+  SIGN_LOG_LEVEL: z.enum(SIGN_VALID_LOG_LEVELS).optional(),
+});
 
-  const signClientId = process.env.FREEE_SIGN_CLIENT_ID;
-  const signClientSecret = process.env.FREEE_SIGN_CLIENT_SECRET;
+function formatSignZodIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const name = issue.path.join('.');
+      return name ? `${name}: ${issue.message}` : issue.message;
+    })
+    .join('; ');
+}
 
-  if (!signClientId || !signClientSecret) {
-    throw new Error(
-      'FREEE_SIGN_CLIENT_ID and FREEE_SIGN_CLIENT_SECRET environment variables are required for serve mode.',
-    );
+export function loadSignRemoteServerConfig(): SignRemoteServerConfig {
+  const rawEnv = {
+    SIGN_ISSUER_URL: process.env.SIGN_ISSUER_URL,
+    SIGN_JWT_SECRET: process.env.SIGN_JWT_SECRET,
+    FREEE_SIGN_CLIENT_ID: process.env.FREEE_SIGN_CLIENT_ID,
+    FREEE_SIGN_CLIENT_SECRET: process.env.FREEE_SIGN_CLIENT_SECRET,
+    SIGN_PORT: process.env.SIGN_PORT,
+    SIGN_AUTHORIZATION_ENDPOINT: process.env.SIGN_AUTHORIZATION_ENDPOINT,
+    SIGN_TOKEN_ENDPOINT: process.env.SIGN_TOKEN_ENDPOINT,
+    SIGN_SCOPE: process.env.SIGN_SCOPE,
+    SIGN_REDIS_URL: process.env.SIGN_REDIS_URL,
+    SIGN_CORS_ALLOWED_ORIGINS: process.env.SIGN_CORS_ALLOWED_ORIGINS,
+    SIGN_RATE_LIMIT_ENABLED: process.env.SIGN_RATE_LIMIT_ENABLED,
+    SIGN_LOG_LEVEL: process.env.SIGN_LOG_LEVEL,
+  };
+
+  const parsed = SignRemoteServerEnvSchema.safeParse(rawEnv);
+  if (!parsed.success) {
+    throw new Error(`Invalid environment configuration: ${formatSignZodIssues(parsed.error)}`);
   }
+  const env = parsed.data;
+
+  // SIGN_RATE_LIMIT_ENABLED defaults to true (secure-by-default).
+  // Operators must set SIGN_RATE_LIMIT_ENABLED=false explicitly to disable.
+  const rateLimitEnabled = parseBooleanEnv(
+    'SIGN_RATE_LIMIT_ENABLED',
+    env.SIGN_RATE_LIMIT_ENABLED,
+    true,
+  );
 
   return {
-    port: parsePort(process.env.SIGN_PORT, 3002),
-    issuerUrl,
-    jwtSecret,
-    signClientId,
-    signClientSecret,
-    signAuthorizationEndpoint:
-      process.env.SIGN_AUTHORIZATION_ENDPOINT || SIGN_AUTHORIZATION_ENDPOINT,
-    signTokenEndpoint: process.env.SIGN_TOKEN_ENDPOINT || SIGN_TOKEN_ENDPOINT,
-    signScope: process.env.SIGN_SCOPE || SIGN_OAUTH_SCOPE,
-    redisUrl: process.env.SIGN_REDIS_URL || 'redis://localhost:6379',
-    corsAllowedOrigins: process.env.SIGN_CORS_ALLOWED_ORIGINS,
-    rateLimitEnabled: process.env.SIGN_RATE_LIMIT_ENABLED === 'true',
-    logLevel: process.env.SIGN_LOG_LEVEL || 'info',
+    port: parsePort(env.SIGN_PORT, 3002),
+    issuerUrl: env.SIGN_ISSUER_URL,
+    jwtSecret: env.SIGN_JWT_SECRET,
+    signClientId: env.FREEE_SIGN_CLIENT_ID,
+    signClientSecret: env.FREEE_SIGN_CLIENT_SECRET,
+    signAuthorizationEndpoint: env.SIGN_AUTHORIZATION_ENDPOINT || SIGN_AUTHORIZATION_ENDPOINT,
+    signTokenEndpoint: env.SIGN_TOKEN_ENDPOINT || SIGN_TOKEN_ENDPOINT,
+    signScope: env.SIGN_SCOPE || SIGN_OAUTH_SCOPE,
+    redisUrl: env.SIGN_REDIS_URL || 'redis://localhost:6379',
+    corsAllowedOrigins: env.SIGN_CORS_ALLOWED_ORIGINS,
+    rateLimitEnabled,
+    logLevel: env.SIGN_LOG_LEVEL || 'info',
+  };
+}
+
+function maskSignSecret(value: string | undefined): string {
+  if (!value) {
+    return '<unset>';
+  }
+  return '<redacted>';
+}
+
+/**
+ * Build a log-safe summary of the resolved sign remote server config.
+ * Secrets (jwtSecret, signClientSecret) are masked.
+ */
+export function summarizeSignRemoteServerConfig(
+  config: SignRemoteServerConfig,
+): Record<string, string | number | boolean | undefined> {
+  return {
+    port: config.port,
+    issuerUrl: config.issuerUrl,
+    jwtSecret: maskSignSecret(config.jwtSecret),
+    signClientId: config.signClientId,
+    signClientSecret: maskSignSecret(config.signClientSecret),
+    signAuthorizationEndpoint: config.signAuthorizationEndpoint,
+    signTokenEndpoint: config.signTokenEndpoint,
+    signScope: config.signScope,
+    redisUrl: config.redisUrl,
+    corsAllowedOrigins: config.corsAllowedOrigins,
+    rateLimitEnabled: config.rateLimitEnabled,
+    logLevel: config.logLevel,
   };
 }

--- a/src/sign/server/sign-http-server.ts
+++ b/src/sign/server/sign-http-server.ts
@@ -10,7 +10,12 @@ import { initUserAgentTransportMode } from '../../server/user-agent.js';
 import type { Redis } from '../../storage/redis-client.js';
 import { closeRedisClient, getRedisClient } from '../../storage/redis-client.js';
 import { createTracingMiddleware } from '../../telemetry/middleware.js';
-import { loadSignRemoteServerConfig, SIGN_API_URL, SIGN_CALLBACK_PATH } from '../config.js';
+import {
+  loadSignRemoteServerConfig,
+  SIGN_API_URL,
+  SIGN_CALLBACK_PATH,
+  summarizeSignRemoteServerConfig,
+} from '../config.js';
 import { createSignMcpServer } from '../handlers.js';
 import { createSignCallbackHandler } from './sign-callback.js';
 import { SignOAuthProvider } from './sign-oauth-provider.js';
@@ -37,6 +42,13 @@ export async function startSignHttpServer(options?: {
     serviceName: 'freee-sign-mcp',
   });
   initUserAgentTransportMode('remote');
+
+  // Log the resolved configuration with secrets masked, so operators can verify
+  // what was loaded at startup without exposing credentials.
+  logger.info(
+    { config: summarizeSignRemoteServerConfig(signRemoteConfig) },
+    'Loaded sign remote server config',
+  );
 
   const redis = getRedisClient(signRemoteConfig.redisUrl);
 


### PR DESCRIPTION
## Summary

Tightens startup environment validation for `serve` mode and flips `RATE_LIMIT_ENABLED` to a secure-by-default value.

Previously `loadRemoteServerConfig` (and its sign counterpart) only checked a handful of envs explicitly and silently fell back for the rest. Misconfiguration could go unnoticed in production. In addition, `RATE_LIMIT_ENABLED` defaulted to `false`, so an operator who forgot to set it shipped a server with rate limiting silently disabled.

This PR migrates both loaders to a zod schema:

- Required envs (`ISSUER_URL`, `JWT_SECRET`, `FREEE_CLIENT_ID`, `FREEE_CLIENT_SECRET`, and the sign equivalents) must be present.
- URL-shaped envs (`ISSUER_URL`, `FREEE_AUTHORIZATION_ENDPOINT`, `FREEE_TOKEN_ENDPOINT`, `FREEE_API_BASE_URL`, sign equivalents) must parse as valid URLs.
- `LOG_LEVEL` / `SIGN_LOG_LEVEL` must be one of pino's accepted levels.
- `JWT_SECRET` / `SIGN_JWT_SECRET` keep the existing 32-character minimum.

A new `parseBooleanEnv` helper accepts the common boolean spellings (`true`/`false`/`1`/`0`/`yes`/`no`/`on`/`off`, case-insensitive) and throws on unrecognised values, so a typo like `RATE_LIMIT_ENABLED=ture` now fails fast instead of being interpreted as "off".

Finally, `summarizeRemoteServerConfig` / `summarizeSignRemoteServerConfig` log the resolved configuration once at startup with `jwtSecret` and the client secret masked, so operators can verify what was actually loaded without exposing credentials.

## Behavior change (please read)

`RATE_LIMIT_ENABLED` and `SIGN_RATE_LIMIT_ENABLED` now default to `true`. Existing deployments that relied on the previous silent default of `false` and that need rate limiting disabled must set the variable to `false` explicitly. Any other unrecognised value will now cause the server to refuse to start, which is intentional — silently ignoring typos here is what the issue is asking us to fix.

This is the reason the changeset is bumped to `minor` rather than `patch`.

## Functional verification

- `bun run typecheck` — passes
- `bun run lint` — passes
- `bun run test:run` — 707 tests pass (54 files); new coverage in `src/config-remote.test.ts` and `src/sign/config.test.ts` exercises:
  - default `RATE_LIMIT_ENABLED` / `SIGN_RATE_LIMIT_ENABLED` is `true` when unset
  - explicit `RATE_LIMIT_ENABLED=false` opts out
  - boolean aliases (`NO`, `0`, `off`, `yes`, etc.) round-trip
  - unrecognised boolean values throw
  - non-URL `ISSUER_URL` / `FREEE_API_BASE_URL` throw
  - non-pino `LOG_LEVEL` throws
  - the summary helpers mask `jwtSecret` and the client secret
  - `parseBooleanEnv` covers each accepted form via a parameterised case
- `bun run build` — both stdio and remote bundles build cleanly.

I also walked through the diff against the canonical-log expectations: the new startup log line goes through the same pino logger that emits the per-request canonical lines, so the masked summary lands in the same sink as everything else.

## Migration notes for operators

If your deployment currently runs without `RATE_LIMIT_ENABLED` set and you want to keep rate limiting off, add `RATE_LIMIT_ENABLED=false` (and `SIGN_RATE_LIMIT_ENABLED=false` for the sign variant) to your environment before upgrading. Otherwise no action is required — the new default matches what most production deployments already opt into.
