### PR TITLE
feat(http): split health endpoint into /livez and /readyz

### DIFF
--- a/.changeset/livez-readyz-split.md
+++ b/.changeset/livez-readyz-split.md
@@ -1,0 +1,9 @@
+---
+"freee-mcp": minor
+---
+
+ヘルスチェックエンドポイントを `/livez` (liveness) と `/readyz` (readiness) に分離
+
+- `/livez`: プロセス生存のみを確認。外部依存 (Redis 等) をチェックしないため、Redis の一時的な不調で Pod が再起動されない
+- `/readyz`: Redis 到達性を確認し、未到達時は 503 を返してトラフィックを切り離す
+- `/health`: 後方互換のため残し、`/readyz` と同じ挙動

--- a/src/server/health-endpoints.test.ts
+++ b/src/server/health-endpoints.test.ts
@@ -1,0 +1,114 @@
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createLivenessHandler,
+  createReadinessHandler,
+  type RedisLike,
+} from './health-endpoints.js';
+
+function buildApp(redis: RedisLike, pingTimeoutMs?: number): Express {
+  const app = express();
+  app.get('/livez', createLivenessHandler());
+  app.get('/readyz', createReadinessHandler(redis, pingTimeoutMs ? { pingTimeoutMs } : undefined));
+  app.get('/health', createReadinessHandler(redis, pingTimeoutMs ? { pingTimeoutMs } : undefined));
+  return app;
+}
+
+describe('createLivenessHandler', () => {
+  it('returns 200 with status:ok regardless of dependency state', async () => {
+    // Use a Redis stub that always rejects to prove /livez does not depend on it.
+    const redis: RedisLike = {
+      ping: vi.fn().mockRejectedValue(new Error('Redis is down')),
+    };
+    const app = buildApp(redis);
+
+    const res = await request(app).get('/livez');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+    // The liveness handler MUST NOT touch Redis.
+    expect(redis.ping).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 even if Redis ping would hang indefinitely', async () => {
+    // A handler that touches Redis would never settle here. /livez must
+    // bypass the dependency entirely and respond synchronously.
+    const redis: RedisLike = {
+      ping: vi.fn(() => new Promise(() => {})),
+    };
+    const app = buildApp(redis);
+
+    const res = await request(app).get('/livez');
+
+    expect(res.status).toBe(200);
+    expect(redis.ping).not.toHaveBeenCalled();
+  });
+});
+
+describe('createReadinessHandler', () => {
+  it('returns 200 with redis:connected when Redis ping succeeds', async () => {
+    const redis: RedisLike = {
+      ping: vi.fn().mockResolvedValue('PONG'),
+    };
+    const app = buildApp(redis);
+
+    const res = await request(app).get('/readyz');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok', redis: 'connected' });
+    expect(redis.ping).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 503 with redis:disconnected when Redis ping rejects', async () => {
+    const redis: RedisLike = {
+      ping: vi.fn().mockRejectedValue(new Error('connection refused')),
+    };
+    const app = buildApp(redis);
+
+    const res = await request(app).get('/readyz');
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ status: 'degraded', redis: 'disconnected' });
+  });
+
+  it('returns 503 when Redis ping hangs beyond the timeout window', async () => {
+    // Simulate a half-open TCP socket by never resolving. Pass a 50 ms
+    // timeout so the test completes quickly without fake timers.
+    const redis: RedisLike = {
+      ping: vi.fn(() => new Promise(() => {})),
+    };
+    const app = buildApp(redis, 50);
+
+    const res = await request(app).get('/readyz');
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ status: 'degraded', redis: 'disconnected' });
+  });
+});
+
+describe('/health backward compatibility', () => {
+  it('mirrors /readyz on success', async () => {
+    const redis: RedisLike = {
+      ping: vi.fn().mockResolvedValue('PONG'),
+    };
+    const app = buildApp(redis);
+
+    const res = await request(app).get('/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok', redis: 'connected' });
+  });
+
+  it('mirrors /readyz on failure (returns 503 when Redis is unreachable)', async () => {
+    const redis: RedisLike = {
+      ping: vi.fn().mockRejectedValue(new Error('connection refused')),
+    };
+    const app = buildApp(redis);
+
+    const res = await request(app).get('/health');
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ status: 'degraded', redis: 'disconnected' });
+  });
+});

--- a/src/server/health-endpoints.ts
+++ b/src/server/health-endpoints.ts
@@ -1,0 +1,52 @@
+import type { Request, Response } from 'express';
+
+/**
+ * Minimal Redis surface required by the readiness probe. Kept narrow so
+ * tests can supply a stub without pulling in the real ioredis client.
+ */
+export interface RedisLike {
+  ping: () => Promise<unknown>;
+}
+
+// Default maximum time to wait for a Redis ping. Guards against half-open
+// TCP sockets that accept the connection but never reply.
+const READINESS_PING_TIMEOUT_MS = 3_000;
+
+/**
+ * Liveness probe handler.
+ *
+ * Returns 200 OK as long as the process is up. MUST NOT touch any external
+ * dependency (Redis, freee API, etc.) — a transient blip in those
+ * dependencies must not cause the orchestrator to restart this Pod.
+ */
+export function createLivenessHandler(): (req: Request, res: Response) => void {
+  return (_req: Request, res: Response): void => {
+    res.json({ status: 'ok' });
+  };
+}
+
+/**
+ * Readiness probe handler.
+ *
+ * Returns 200 only when Redis is reachable and responds within the timeout;
+ * otherwise 503 so the orchestrator stops sending traffic to this instance
+ * until it recovers.
+ *
+ * @param pingTimeoutMs - Override the default 3 s timeout (for testing).
+ */
+export function createReadinessHandler(
+  redis: RedisLike,
+  { pingTimeoutMs = READINESS_PING_TIMEOUT_MS }: { pingTimeoutMs?: number } = {},
+): (req: Request, res: Response) => Promise<void> {
+  return async (_req: Request, res: Response): Promise<void> => {
+    try {
+      const timeout = new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Redis ping timeout')), pingTimeoutMs),
+      );
+      await Promise.race([redis.ping(), timeout]);
+      res.json({ status: 'ok', redis: 'connected' });
+    } catch {
+      res.status(503).json({ status: 'degraded', redis: 'disconnected' });
+    }
+  };
+}

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -11,6 +11,7 @@ import { RedisClientStore } from './client-store.js';
 import { makeErrorChain, serializeErrorChain } from './error-serializer.js';
 import { RedisUnavailableError } from './errors.js';
 import { createFreeeCallbackHandler } from './freee-callback.js';
+import { createLivenessHandler, createReadinessHandler } from './health-endpoints.js';
 import { initLogger } from './logger.js';
 import { FreeeOAuthProvider } from './oauth-provider.js';
 import { OAuthStateStore } from './oauth-store.js';
@@ -148,21 +149,18 @@ export async function startHttpServer(options?: {
     await setupRateLimiting(app, redis, logger);
   }
 
-  // Health check endpoint (no auth required)
-  app.get('/health', async (_req: Request, res: Response) => {
-    try {
-      await redis.ping();
-      res.json({
-        status: 'ok',
-        redis: 'connected',
-      });
-    } catch {
-      res.status(503).json({
-        status: 'degraded',
-        redis: 'disconnected',
-      });
-    }
-  });
+  // Liveness probe (no auth required, no external dependencies).
+  app.get('/livez', createLivenessHandler());
+
+  // Readiness probe (no auth required).
+  // Returns 503 when Redis is unreachable so the orchestrator stops sending
+  // traffic to this instance.
+  const readinessHandler = createReadinessHandler(redis);
+  app.get('/readyz', readinessHandler);
+
+  // Backward-compatible alias for /readyz. Existing deployments may still
+  // probe /health; new deployments should migrate to /livez and /readyz.
+  app.get('/health', readinessHandler);
 
   // freee OAuth callback (browser redirect, no MCP auth required)
   app.get(FREEE_CALLBACK_PATH, freeeCallbackHandler);

--- a/src/sign/server/sign-http-server.ts
+++ b/src/sign/server/sign-http-server.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from 'express';
 import { RedisClientStore } from '../../server/client-store.js';
 import { makeErrorChain, serializeErrorChain } from '../../server/error-serializer.js';
 import { RedisUnavailableError } from '../../server/errors.js';
+import { createLivenessHandler, createReadinessHandler } from '../../server/health-endpoints.js';
 import { initLogger } from '../../server/logger.js';
 import { OAuthStateStore } from '../../server/oauth-store.js';
 import { getCurrentRecorder } from '../../server/request-context.js';
@@ -146,21 +147,18 @@ export async function startSignHttpServer(options?: {
     await setupRateLimiting(app, redis, logger);
   }
 
-  // Health check endpoint (no auth required)
-  app.get('/health', async (_req: Request, res: Response) => {
-    try {
-      await redis.ping();
-      res.json({
-        status: 'ok',
-        redis: 'connected',
-      });
-    } catch {
-      res.status(503).json({
-        status: 'degraded',
-        redis: 'disconnected',
-      });
-    }
-  });
+  // Liveness probe (no auth required, no external dependencies).
+  app.get('/livez', createLivenessHandler());
+
+  // Readiness probe (no auth required).
+  // Returns 503 when Redis is unreachable so the orchestrator stops sending
+  // traffic to this instance.
+  const readinessHandler = createReadinessHandler(redis);
+  app.get('/readyz', readinessHandler);
+
+  // Backward-compatible alias for /readyz. Existing deployments may still
+  // probe /health; new deployments should migrate to /livez and /readyz.
+  app.get('/health', readinessHandler);
 
   // Sign OAuth callback (browser redirect, no MCP auth required)
   app.get(SIGN_CALLBACK_PATH, signCallbackHandler);
@@ -172,9 +170,7 @@ export async function startSignHttpServer(options?: {
   // Override the SDK's authorization-server metadata to advertise
   // client_secret_basic (RFC 6749 §2.3.1). Mounted before mcpAuthRouter so
   // Express first-match-wins routes /.well-known here instead of into the SDK.
-  const { createOverrideMetadataHandler } = await import(
-    '../../server/oauth-metadata-override.js'
-  );
+  const { createOverrideMetadataHandler } = await import('../../server/oauth-metadata-override.js');
   app.get(
     '/.well-known/oauth-authorization-server',
     createOverrideMetadataHandler({

--- a/src/telemetry/middleware.test.ts
+++ b/src/telemetry/middleware.test.ts
@@ -18,18 +18,15 @@ function makeRequest(
   headers?: Record<string, string>,
 ): Promise<{ statusCode: number; body: string }> {
   return new Promise((resolve, reject) => {
-    const req = http.request(
-      { hostname: '127.0.0.1', port, path, method, headers },
-      (res) => {
-        let body = '';
-        res.on('data', (chunk) => {
-          body += chunk;
-        });
-        res.on('end', () => {
-          resolve({ statusCode: res.statusCode ?? 0, body });
-        });
-      },
-    );
+    const req = http.request({ hostname: '127.0.0.1', port, path, method, headers }, (res) => {
+      let body = '';
+      res.on('data', (chunk) => {
+        body += chunk;
+      });
+      res.on('end', () => {
+        resolve({ statusCode: res.statusCode ?? 0, body });
+      });
+    });
     req.on('error', reject);
     req.end();
   });
@@ -127,7 +124,11 @@ describe('createTracingMiddleware', () => {
     });
   });
 
-  it('skips /health endpoint', async () => {
+  it.each([
+    ['/health'],
+    ['/livez'],
+    ['/readyz'],
+  ])('skips %s endpoint (no OTel span emitted)', async (probePath) => {
     process.env.OTEL_ENABLED = 'true';
     const { exporter, provider } = setupInMemoryOtel();
 
@@ -135,7 +136,7 @@ describe('createTracingMiddleware', () => {
     const { createTracingMiddleware } = await import('./middleware.js');
     const app = express();
     app.use(createTracingMiddleware());
-    app.get('/health', (_req, res) => {
+    app.get(probePath, (_req, res) => {
       res.json({ status: 'ok' });
     });
 
@@ -143,7 +144,7 @@ describe('createTracingMiddleware', () => {
     const addr = server.address();
     port = typeof addr === 'object' && addr ? addr.port : 0;
 
-    const result = await makeRequest(port, '/health');
+    const result = await makeRequest(port, probePath);
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body)).toEqual({ status: 'ok' });
 
@@ -636,16 +637,17 @@ describe('createTracingMiddleware - canonical log line', () => {
     expect(logInfo).toHaveBeenCalledTimes(1);
   });
 
-  it('skips /health entirely — no canonical log emitted', async () => {
-    const { logInfo, app } = await setupAppWithLoggerSpy(
-      (_req, res) => {
-        res.status(200).json({ status: 'ok' });
-      },
-      '/health',
-    );
+  it.each([
+    ['/health'],
+    ['/livez'],
+    ['/readyz'],
+  ])('skips %s entirely — no canonical log emitted', async (probePath) => {
+    const { logInfo, app } = await setupAppWithLoggerSpy((_req, res) => {
+      res.status(200).json({ status: 'ok' });
+    }, probePath);
     ({ srv: server, port } = await listen(app));
 
-    await makeRequest(port, '/health');
+    await makeRequest(port, probePath);
     await new Promise((r) => setTimeout(r, 10));
 
     expect(logInfo).not.toHaveBeenCalled();

--- a/src/telemetry/middleware.ts
+++ b/src/telemetry/middleware.ts
@@ -113,8 +113,10 @@ export function createTracingMiddleware(): (
   next: NextFunction,
 ) => void {
   return (req: Request, res: Response, next: NextFunction): void => {
-    // Skip health checks entirely — no recorder, no span, no canonical log.
-    if (req.path === '/health') {
+    // Skip health/liveness/readiness probes entirely — no recorder, no span,
+    // no canonical log. These are polled at high frequency by orchestrators
+    // and would otherwise drown out useful telemetry.
+    if (req.path === '/health' || req.path === '/livez' || req.path === '/readyz') {
       next();
       return;
     }


### PR DESCRIPTION
## 概要

ヘルスチェックエンドポイントを用途別に分離する。

- `/livez` (liveness probe): プロセスが起動している限り常に 200 OK を返す。Redis 等の外部依存を一切確認しない。
- `/readyz` (readiness probe): Redis への接続が確認できた場合のみ 200 を返し、到達不能または応答タイムアウト（3 秒）の場合は 503 を返す。
- `/health`: 後方互換のために残し、`/readyz` と同じ挙動とする。

これにより、Redis の一時的な不調で liveness probe が失敗し Pod が不要に再起動されるという問題が解消される。

既存の `/health` エンドポイントの挙動（Redis 障害時に 503）は変わらないため、既存の監視設定への破壊的変更はない。

K8s マニフェストの probe 設定変更（`livenessProbe` を `/livez` へ、`readinessProbe` を `/readyz` へ）は別途 follow-up で行う。

## 変更種別

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他

## Functional verification

The Redis-down behavior was verified via automated tests:

- `/livez` は Redis スタブが reject してもステータス 200 を返すことをテストで確認（`redis.ping` が呼ばれないことも検証）
- `/livez` は Redis スタブが永続的にハングしても即時 200 を返すことを確認
- `/readyz` は Redis が正常時に 200、拒否時に 503 を返すことを確認
- `/readyz` は Redis ping が 3 秒タイムアウトを超えた場合（half-open TCP ソケット相当）に 503 を返すことを確認（50 ms の短縮タイムアウトをテスト用に注入）
- `/health` が `/readyz` と同一挙動を示すことを確認

テスト実行: `bun run test:run src/server/health-endpoints.test.ts` → 7 tests passed