### PR TITLE
chore(http): remove transitional /health alias in favour of /livez and /readyz

### DIFF
--- a/.changeset/remove-health-alias.md
+++ b/.changeset/remove-health-alias.md
@@ -1,0 +1,7 @@
+---
+"freee-mcp": minor
+---
+
+`/health` エンドポイント (transitional alias) を削除し、liveness は `/livez`、readiness は `/readyz` のみで提供。
+
+- BREAKING (operator-facing): アップグレード前に liveness / readiness probe を `/livez` / `/readyz` へ移行してください。`/health` への probe は 404 を返します。

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ COPY --from=builder /app/openapi/minimal ./openapi/minimal
 USER 65532:65532
 EXPOSE 3000
 HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \
-  CMD wget -q --spider http://localhost:3000/health || exit 1
+  CMD wget -q --spider http://localhost:3000/livez || exit 1
 CMD ["bun", "run", "bin/freee-remote-mcp.js"]

--- a/Dockerfile.sign
+++ b/Dockerfile.sign
@@ -16,5 +16,5 @@ COPY --from=builder /app/openapi/minimal ./openapi/minimal
 USER 65532:65532
 EXPOSE 3002
 HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \
-  CMD wget -q --spider http://localhost:3002/health || exit 1
+  CMD wget -q --spider http://localhost:3002/livez || exit 1
 CMD ["bun", "run", "bin/freee-sign-remote-mcp.js"]

--- a/src/server/health-endpoints.test.ts
+++ b/src/server/health-endpoints.test.ts
@@ -11,7 +11,6 @@ function buildApp(redis: RedisLike, pingTimeoutMs?: number): Express {
   const app = express();
   app.get('/livez', createLivenessHandler());
   app.get('/readyz', createReadinessHandler(redis, pingTimeoutMs ? { pingTimeoutMs } : undefined));
-  app.get('/health', createReadinessHandler(redis, pingTimeoutMs ? { pingTimeoutMs } : undefined));
   return app;
 }
 
@@ -81,32 +80,6 @@ describe('createReadinessHandler', () => {
     const app = buildApp(redis, 50);
 
     const res = await request(app).get('/readyz');
-
-    expect(res.status).toBe(503);
-    expect(res.body).toEqual({ status: 'degraded', redis: 'disconnected' });
-  });
-});
-
-describe('/health backward compatibility', () => {
-  it('mirrors /readyz on success', async () => {
-    const redis: RedisLike = {
-      ping: vi.fn().mockResolvedValue('PONG'),
-    };
-    const app = buildApp(redis);
-
-    const res = await request(app).get('/health');
-
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: 'ok', redis: 'connected' });
-  });
-
-  it('mirrors /readyz on failure (returns 503 when Redis is unreachable)', async () => {
-    const redis: RedisLike = {
-      ping: vi.fn().mockRejectedValue(new Error('connection refused')),
-    };
-    const app = buildApp(redis);
-
-    const res = await request(app).get('/health');
 
     expect(res.status).toBe(503);
     expect(res.body).toEqual({ status: 'degraded', redis: 'disconnected' });

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -170,10 +170,6 @@ export async function startHttpServer(options?: {
   const readinessHandler = createReadinessHandler(redis);
   app.get('/readyz', readinessHandler);
 
-  // Backward-compatible alias for /readyz. Existing deployments may still
-  // probe /health; new deployments should migrate to /livez and /readyz.
-  app.get('/health', readinessHandler);
-
   // freee OAuth callback (browser redirect, no MCP auth required)
   app.get(FREEE_CALLBACK_PATH, freeeCallbackHandler);
 

--- a/src/sign/server/sign-http-server.ts
+++ b/src/sign/server/sign-http-server.ts
@@ -168,10 +168,6 @@ export async function startSignHttpServer(options?: {
   const readinessHandler = createReadinessHandler(redis);
   app.get('/readyz', readinessHandler);
 
-  // Backward-compatible alias for /readyz. Existing deployments may still
-  // probe /health; new deployments should migrate to /livez and /readyz.
-  app.get('/health', readinessHandler);
-
   // Sign OAuth callback (browser redirect, no MCP auth required)
   app.get(SIGN_CALLBACK_PATH, signCallbackHandler);
 

--- a/src/telemetry/middleware.test.ts
+++ b/src/telemetry/middleware.test.ts
@@ -125,7 +125,6 @@ describe('createTracingMiddleware', () => {
   });
 
   it.each([
-    ['/health'],
     ['/livez'],
     ['/readyz'],
   ])('skips %s endpoint (no OTel span emitted)', async (probePath) => {
@@ -638,7 +637,6 @@ describe('createTracingMiddleware - canonical log line', () => {
   });
 
   it.each([
-    ['/health'],
     ['/livez'],
     ['/readyz'],
   ])('skips %s entirely — no canonical log emitted', async (probePath) => {

--- a/src/telemetry/middleware.ts
+++ b/src/telemetry/middleware.ts
@@ -113,10 +113,10 @@ export function createTracingMiddleware(): (
   next: NextFunction,
 ) => void {
   return (req: Request, res: Response, next: NextFunction): void => {
-    // Skip health/liveness/readiness probes entirely — no recorder, no span,
+    // Skip liveness/readiness probes entirely — no recorder, no span,
     // no canonical log. These are polled at high frequency by orchestrators
     // and would otherwise drown out useful telemetry.
-    if (req.path === '/health' || req.path === '/livez' || req.path === '/readyz') {
+    if (req.path === '/livez' || req.path === '/readyz') {
       next();
       return;
     }


### PR DESCRIPTION
## What

Removes the transitional `/health` alias introduced as a backward-compatibility shim in #427.

Diff summary:

- `src/server/http-server.ts`, `src/sign/server/sign-http-server.ts` — drop the `/health` route registration (and the now-stale "backward-compatible alias" comment).
- `src/telemetry/middleware.ts` — drop `/health` from the probe-skip predicate so only `/livez` and `/readyz` bypass the tracing middleware. (The skip set is reserved for orchestrator-frequency probes that would otherwise drown out telemetry; `/health` no longer exists, so it cannot be in this set.)
- `Dockerfile`, `Dockerfile.sign` — point `HEALTHCHECK` at `/livez` (port 3000 / 3002). Liveness must not depend on Redis, so `/livez` is the correct target — not `/readyz`.
- `src/server/health-endpoints.test.ts` — delete the `/health backward compatibility` describe block. Coverage for the underlying behaviour is preserved by the `/readyz` describe block (success and 503-on-Redis-down).
- `src/telemetry/middleware.test.ts` — drop the `['/health']` row from the two `it.each` skip-predicate tables; `/livez` and `/readyz` rows are kept.
- `.changeset/remove-health-alias.md` — `minor` bump (operator-visible behaviour change).

Untouched on purpose:

- `src/server/logger.test.ts` — uses the literal string `'/health'` as a fixture verifying that `sanitizePath` does not rewrite paths without numeric segments. It does not assert anything about the endpoint existing, and works equivalently for any non-numeric path. Left as-is to avoid unrelated churn.

## Why

`/health` was preserved as an alias of `/readyz` only to give operators a window to migrate. Keeping it around long-term has two costs:

1. The `/health` name is conventionally associated with liveness, but post-#427 it carried readiness semantics (it would 503 whenever Redis was unreachable). That mismatch can cause an orchestrator to restart a perfectly live pod whenever Redis hiccups.
2. It bloats the public API surface and the OTel skip list with a path nobody should be using going forward.

Removing the alias forces a single, unambiguous mapping: `/livez` for liveness, `/readyz` for readiness. The kubelet-style `/livez` and `/readyz` names are the right primitives for orchestrator probes.

## Operator migration

Operators must migrate liveness and readiness probes BEFORE upgrading to a release that contains this commit. After the upgrade, `/health` returns 404; if a probe still targets `/health` the orchestrator will see repeated probe failures.

- Liveness probe: `/livez` (200 OK, no external dependencies, never 503)
- Readiness probe: `/readyz` (200 OK when Redis reachable, 503 when Redis unreachable)

REDIS_URL behaviour, for completeness:

- When `REDIS_URL` is unset, the remote server defaults to `redis://localhost:6379` (see `src/storage/redis-client.ts`).
- The remote HTTP server fails fast at startup if it cannot reach Redis (the initial `redis.ping()` rejection triggers `process.exit(1)` in `src/server/http-server.ts`). So `/readyz` returning 503 in production indicates a transient outage after a successful boot, not a misconfigured `REDIS_URL`.

## Verification

Local pre-flight per the project checklist:

```
$ bun run typecheck
$ tsc --noEmit
(no output — clean)

$ bun run lint
$ biome lint src/
Checked 130 files in 39ms. No fixes applied.

$ bun run test:run
 Test Files  56 passed (56)
      Tests  756 passed (756)
   Duration  2.71s

$ bun run build
$ bun run build.ts
Built ./bin/freee-mcp.js
Built ./bin/freee-remote-mcp.js
Built ./bin/freee-sign-mcp.js
Built ./bin/freee-sign-remote-mcp.js
Copied 6 minimal schema files to dist/
```

## Functional verification

Started the remote HTTP server locally (`bun run src/entry-remote.ts` with a valid Redis on `redis://localhost:6379`) and exercised all three paths.

`/livez` — 200 OK, no Redis dependency:

```
$ curl -is http://localhost:3000/livez
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Content-Length: 15

{"status":"ok"}
```

`/readyz` — 200 OK with Redis reachable:

```
$ curl -is http://localhost:3000/readyz
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Content-Length: 35

{"status":"ok","redis":"connected"}
```

`/health` — 404 Not Found, confirming the alias is gone:

```
$ curl -is http://localhost:3000/health
HTTP/1.1 404 Not Found
Content-Type: text/html; charset=utf-8
Content-Length: 145

<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Cannot GET /health</pre>
</body>
</html>
```

The 404 on `/health` is the success criterion for this PR.

`/readyz` 503-on-Redis-down case: the remote server's startup ping fails fast (`process.exit(1)`), so this path is exercised only when Redis goes down mid-flight. That case is covered by the existing unit test `createReadinessHandler › returns 503 with redis:disconnected when Redis ping rejects` in `src/server/health-endpoints.test.ts`, which continues to pass after this PR.
