### PR TITLE
fix: 会社名キャッシュの損失バグを修正し display_name を追加

### DIFF
--- a/src/config/companies.ts
+++ b/src/config/companies.ts
@@ -168,7 +168,6 @@ export async function setCurrentCompany(
 ): Promise<void> {
   const config = await loadFullConfig();
 
-  // Add entry if missing; preserve fields that the caller did not supply.
   if (!config.companies[companyId]) {
     config.companies[companyId] = {
       id: companyId,

--- a/src/config/companies.ts
+++ b/src/config/companies.ts
@@ -7,6 +7,7 @@ import { CONFIG_FILE_PERMISSION, getConfigDir } from '../constants.js';
 export const CompanyConfigSchema = z.object({
   id: z.string(),
   name: z.string().optional(),
+  display_name: z.string().optional(),
   description: z.string().optional(),
   addedAt: z.number(),
   lastUsed: z.number().optional(),
@@ -15,6 +16,7 @@ export const CompanyConfigSchema = z.object({
 export interface CompanyConfig {
   id: string;
   name?: string;
+  display_name?: string;
   description?: string;
   addedAt: number;
   lastUsed?: number;
@@ -162,21 +164,23 @@ export async function setCurrentCompany(
   companyId: string,
   name?: string,
   description?: string,
+  display_name?: string,
 ): Promise<void> {
   const config = await loadFullConfig();
 
-  // Add or update company info
+  // Add entry if missing; preserve fields that the caller did not supply.
   if (!config.companies[companyId]) {
     config.companies[companyId] = {
       id: companyId,
-      name: name || `Company ${companyId}`,
-      description: description || undefined,
+      name,
+      display_name,
+      description,
       addedAt: Date.now(),
     };
-  } else if (name || description) {
-    // Update existing company info if provided
-    if (name) config.companies[companyId].name = name;
-    if (description) config.companies[companyId].description = description;
+  } else {
+    if (name !== undefined) config.companies[companyId].name = name;
+    if (display_name !== undefined) config.companies[companyId].display_name = display_name;
+    if (description !== undefined) config.companies[companyId].description = description;
   }
 
   // Update last used timestamp

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -361,8 +361,8 @@ describe('tools', () => {
         const mockMakeApiRequest = await import('../api/client.js');
         const validResponse = {
           companies: [
-            { id: 123, name: 'Company A' },
-            { id: 456, name: 'Company B' },
+            { id: 123, name: 'Company A', display_name: 'Co A' },
+            { id: 456, name: 'Company B', display_name: 'Co B' },
           ],
         };
         vi.mocked(mockMakeApiRequest.makeApiRequest).mockResolvedValue(validResponse);
@@ -374,7 +374,24 @@ describe('tools', () => {
 
         expect(result.content[0].text).toContain('事業所一覧:');
         expect(result.content[0].text).toContain('Company A');
+        expect(result.content[0].text).toContain('[display_name: Co A]');
         expect(result.content[0].text).toContain('Company B');
+        expect(result.content[0].text).toContain('[display_name: Co B]');
+      });
+
+      it('should label display_name as (未設定) when missing while keeping name visible', async () => {
+        const mockMakeApiRequest = await import('../api/client.js');
+        vi.mocked(mockMakeApiRequest.makeApiRequest).mockResolvedValue({
+          companies: [{ id: 789, name: null, display_name: 'Display Only' }],
+        });
+
+        addAuthenticationTools(mockServer);
+        const handler = mockTool.mock.calls.find((call) => call[0] === 'freee_list_companies')?.[2];
+
+        const result = await handler();
+
+        expect(result.content[0].text).toContain('(未設定) (789)');
+        expect(result.content[0].text).toContain('[display_name: Display Only]');
       });
 
       it('should return error message for invalid API response structure', async () => {
@@ -440,6 +457,83 @@ describe('tools', () => {
 
         expect(result.content[0].text).toContain('事業所一覧の取得に失敗');
         expect(result.content[0].text).toContain('API Error');
+      });
+    });
+
+    describe('freee_set_current_company lookup-on-miss', () => {
+      function createTokenStore(
+        initialEntry: {
+          name?: string;
+          display_name?: string;
+        } | null,
+      ) {
+        let entry = initialEntry;
+        return {
+          loadTokens: vi.fn().mockResolvedValue({
+            access_token: 'token',
+            refresh_token: 'refresh',
+            expires_at: Date.now() + 3600000,
+            scope: 'read write',
+            token_type: 'Bearer',
+          }),
+          saveTokens: vi.fn(),
+          clearTokens: vi.fn(),
+          getValidAccessToken: vi.fn().mockResolvedValue('token'),
+          getCurrentCompanyId: vi.fn().mockResolvedValue('12345'),
+          setCurrentCompany: vi.fn(async (_u, _id, name, _desc, display_name) => {
+            entry = {
+              ...(entry ?? {}),
+              ...(name !== undefined ? { name } : {}),
+              ...(display_name !== undefined ? { display_name } : {}),
+            };
+          }),
+          getCompanyInfo: vi.fn(async () => (entry ? { id: '12345', ...entry } : null)),
+        };
+      }
+
+      it('fetches /api/1/companies when neither name nor display_name is cached', async () => {
+        const tokenStore = createTokenStore(null);
+        const mockMakeApiRequest = await import('../api/client.js');
+        vi.mocked(mockMakeApiRequest.makeApiRequest).mockResolvedValue({
+          companies: [{ id: 12345, name: 'Resolved Name', display_name: 'Resolved DBA' }],
+        });
+
+        addAuthenticationTools(mockServer);
+        const handler = mockTool.mock.calls.find(
+          (call) => call[0] === 'freee_set_current_company',
+        )?.[2];
+        const extra = { authInfo: { extra: { tokenStore, userId: 'u1' } } };
+
+        const result = await handler({ company_id: '12345' }, extra);
+
+        expect(mockMakeApiRequest.makeApiRequest).toHaveBeenCalledWith(
+          'GET',
+          '/api/1/companies',
+          undefined,
+          undefined,
+          undefined,
+          expect.anything(),
+        );
+        expect(tokenStore.setCurrentCompany).toHaveBeenCalledTimes(2);
+        expect(result.content[0].text).toContain('Resolved Name');
+        expect(result.content[0].text).toContain('[display_name: Resolved DBA]');
+      });
+
+      it('skips lookup when the cache already has a name', async () => {
+        const tokenStore = createTokenStore({ name: 'Cached' });
+        const mockMakeApiRequest = await import('../api/client.js');
+        vi.mocked(mockMakeApiRequest.makeApiRequest).mockResolvedValue({ companies: [] });
+
+        addAuthenticationTools(mockServer);
+        const handler = mockTool.mock.calls.find(
+          (call) => call[0] === 'freee_set_current_company',
+        )?.[2];
+        const extra = { authInfo: { extra: { tokenStore, userId: 'u1' } } };
+
+        await handler({ company_id: '12345' }, extra);
+
+        expect(mockMakeApiRequest.makeApiRequest).not.toHaveBeenCalled();
+        expect(tokenStore.setCurrentCompany).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -425,7 +425,7 @@ describe('tools', () => {
 
         expect(result.content[0].text).toContain('事業所一覧:');
         expect(result.content[0].text).toContain('Company A');
-        expect(result.content[0].text).toContain('(名称未設定) (456)');
+        expect(result.content[0].text).toContain('(未設定) (456)');
         expect(result.content[0].text).toContain('Company C');
       });
 

--- a/src/mcp/tools.test.ts
+++ b/src/mcp/tools.test.ts
@@ -515,6 +515,10 @@ describe('tools', () => {
           expect.anything(),
         );
         expect(tokenStore.setCurrentCompany).toHaveBeenCalledTimes(2);
+        // Second call must pass resolved name as arg 3 and display_name as arg 5.
+        const secondCall = tokenStore.setCurrentCompany.mock.calls[1];
+        expect(secondCall[2]).toBe('Resolved Name');
+        expect(secondCall[4]).toBe('Resolved DBA');
         expect(result.content[0].text).toContain('Resolved Name');
         expect(result.content[0].text).toContain('[display_name: Resolved DBA]');
       });

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -16,6 +16,7 @@ import type { AuthExtra } from '../storage/context.js';
 import { registerTracedTool } from '../telemetry/tool-tracer.js';
 import { extractTokenContext, resolveCompanyId } from '../storage/context.js';
 import { createTextResponse, formatErrorMessage } from '../utils/error.js';
+import { formatCompanyName } from '../utils/format-company.js';
 
 export function addAuthenticationTools(server: McpServer, options?: { remote?: boolean }): void {
   registerTracedTool(server,
@@ -56,7 +57,7 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
         return createTextResponse(
           `現在のユーザー情報:\n` +
             `会社ID: ${companyId}\n` +
-            `会社名: ${companyInfo?.name || 'Unknown'}\n` +
+            `会社名: ${formatCompanyName(companyInfo?.name)}\n` +
             `ユーザー詳細:\n${JSON.stringify(userInfo, null, 2)}`,
         );
       } catch (error) {
@@ -251,7 +252,9 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
           status: 'success',
           duration_ms: Date.now() - toolStart,
         });
-        return createTextResponse(`事業所を設定: ${companyInfo?.name || company_id}`);
+        return createTextResponse(
+          `事業所を設定: ${formatCompanyName(companyInfo?.name)} (ID: ${company_id})`,
+        );
       } catch (error) {
         recorder?.recordToolCall({
           tool: 'freee_set_current_company',
@@ -288,7 +291,9 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
           return createTextResponse(`事業所ID: ${companyId} (詳細情報なし)`);
         }
 
-        return createTextResponse(`事業所: ${companyInfo.name} (ID: ${companyInfo.id})`);
+        return createTextResponse(
+          `事業所: ${formatCompanyName(companyInfo.name)} (ID: ${companyInfo.id})`,
+        );
       } catch (error) {
         recorder?.recordToolCall({
           tool: 'freee_get_current_company',
@@ -367,7 +372,7 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
         const companyList = apiCompanies.companies
           .map((company) => {
             const current = company.id === parseInt(currentCompanyId, 10) ? ' *' : '';
-            return `${company.name ?? '(名称未設定)'} (${company.id})${current}`;
+            return `${formatCompanyName(company.name)} (${company.id})${current}`;
           })
           .join('\n');
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -303,8 +303,6 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
           company_id,
         );
 
-        // Lookup-on-miss: if the cache has neither name nor display_name for
-        // this company, resolve them once from /api/1/companies and persist.
         if (!companyInfo?.name && !companyInfo?.display_name) {
           const resolved = await resolveCompanyNamesFromApi(company_id, tokenContext);
           if (resolved) {
@@ -315,10 +313,11 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
               undefined,
               resolved.display_name ?? undefined,
             );
-            companyInfo = await tokenContext.tokenStore.getCompanyInfo(
-              tokenContext.userId,
-              company_id,
-            );
+            companyInfo = {
+              ...(companyInfo ?? { id: company_id, addedAt: Date.now() }),
+              name: resolved.name ?? undefined,
+              display_name: resolved.display_name ?? undefined,
+            };
           }
         }
 
@@ -400,17 +399,6 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
       const toolStart = Date.now();
       try {
         const tokenContext = extractTokenContext(extra);
-        const CompanyResponseSchema = z.object({
-          companies: z
-            .array(
-              z.object({
-                id: z.number(),
-                name: z.string().nullable(),
-                display_name: z.string().nullable().optional(),
-              }),
-            )
-            .optional(),
-        });
         const rawResponse = await makeApiRequest(
           'GET',
           '/api/1/companies',
@@ -419,7 +407,7 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
           undefined,
           tokenContext,
         );
-        const parseResult = CompanyResponseSchema.safeParse(rawResponse);
+        const parseResult = CompaniesLookupSchema.safeParse(rawResponse);
         if (!parseResult.success) {
           recorder?.recordToolCall({
             tool: 'freee_list_companies',
@@ -454,7 +442,7 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
 
         const companyList = apiCompanies.companies
           .map((company) => {
-            const current = company.id === parseInt(currentCompanyId, 10) ? ' *' : '';
+            const current = company.id === Number.parseInt(currentCompanyId, 10) ? ' *' : '';
             return (
               `${formatCompanyName(company.name)} (${company.id})${current}` +
               ` [display_name: ${formatCompanyName(company.display_name)}]`

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -12,14 +12,57 @@ import { getConfig } from '../config.js';
 import { AUTH_TIMEOUT_MS, PACKAGE_VERSION } from '../constants.js';
 import { makeErrorChain, serializeErrorChain } from '../server/error-serializer.js';
 import { getCurrentRecorder } from '../server/request-context.js';
-import type { AuthExtra } from '../storage/context.js';
-import { registerTracedTool } from '../telemetry/tool-tracer.js';
+import type { AuthExtra, TokenContext } from '../storage/context.js';
 import { extractTokenContext, resolveCompanyId } from '../storage/context.js';
+import { registerTracedTool } from '../telemetry/tool-tracer.js';
 import { createTextResponse, formatErrorMessage } from '../utils/error.js';
 import { formatCompanyName } from '../utils/format-company.js';
 
+const CompaniesLookupSchema = z.object({
+  companies: z
+    .array(
+      z.object({
+        id: z.number(),
+        name: z.string().nullable().optional(),
+        display_name: z.string().nullable().optional(),
+      }),
+    )
+    .optional(),
+});
+
+/**
+ * Looks up name/display_name for the given company id from /api/1/companies.
+ * Returns null when the API call fails or the id is not in the response.
+ * Errors are swallowed because this is a best-effort cache fill.
+ */
+async function resolveCompanyNamesFromApi(
+  companyId: string,
+  tokenContext: TokenContext,
+): Promise<{ name?: string | null; display_name?: string | null } | null> {
+  try {
+    const raw = await makeApiRequest(
+      'GET',
+      '/api/1/companies',
+      undefined,
+      undefined,
+      undefined,
+      tokenContext,
+    );
+    const parsed = CompaniesLookupSchema.safeParse(raw);
+    if (!parsed.success) {
+      return null;
+    }
+    const numericId = Number.parseInt(companyId, 10);
+    const match = parsed.data.companies?.find((c) => c.id === numericId);
+    return match ? { name: match.name, display_name: match.display_name } : null;
+  } catch {
+    return null;
+  }
+}
+
 export function addAuthenticationTools(server: McpServer, options?: { remote?: boolean }): void {
-  registerTracedTool(server,
+  registerTracedTool(
+    server,
     'freee_current_user',
     {
       title: '現在のユーザー情報',
@@ -58,6 +101,7 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
           `現在のユーザー情報:\n` +
             `会社ID: ${companyId}\n` +
             `会社名: ${formatCompanyName(companyInfo?.name)}\n` +
+            `事業所表示名: ${formatCompanyName(companyInfo?.display_name)}\n` +
             `ユーザー詳細:\n${JSON.stringify(userInfo, null, 2)}`,
         );
       } catch (error) {
@@ -73,7 +117,8 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
   );
 
   if (!options?.remote) {
-    registerTracedTool(server,
+    registerTracedTool(
+      server,
       'freee_authenticate',
       {
         title: 'OAuth認証',
@@ -141,7 +186,8 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
     );
   }
 
-  registerTracedTool(server,
+  registerTracedTool(
+    server,
     'freee_auth_status',
     {
       title: '認証状態確認',
@@ -187,7 +233,8 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
     },
   );
 
-  registerTracedTool(server,
+  registerTracedTool(
+    server,
     'freee_clear_auth',
     {
       title: '認証情報クリア',
@@ -221,7 +268,8 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
   );
 
   // Company management tools
-  registerTracedTool(server,
+  registerTracedTool(
+    server,
     'freee_set_current_company',
     {
       title: '事業所設定',
@@ -243,9 +291,36 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
         const { company_id, name, description } = args;
         const tokenContext = extractTokenContext(extra);
 
-        await tokenContext.tokenStore.setCurrentCompany(tokenContext.userId, company_id, name, description);
+        await tokenContext.tokenStore.setCurrentCompany(
+          tokenContext.userId,
+          company_id,
+          name,
+          description,
+        );
 
-        const companyInfo = await tokenContext.tokenStore.getCompanyInfo(tokenContext.userId, company_id);
+        let companyInfo = await tokenContext.tokenStore.getCompanyInfo(
+          tokenContext.userId,
+          company_id,
+        );
+
+        // Lookup-on-miss: if the cache has neither name nor display_name for
+        // this company, resolve them once from /api/1/companies and persist.
+        if (!companyInfo?.name && !companyInfo?.display_name) {
+          const resolved = await resolveCompanyNamesFromApi(company_id, tokenContext);
+          if (resolved) {
+            await tokenContext.tokenStore.setCurrentCompany(
+              tokenContext.userId,
+              company_id,
+              resolved.name ?? undefined,
+              undefined,
+              resolved.display_name ?? undefined,
+            );
+            companyInfo = await tokenContext.tokenStore.getCompanyInfo(
+              tokenContext.userId,
+              company_id,
+            );
+          }
+        }
 
         recorder?.recordToolCall({
           tool: 'freee_set_current_company',
@@ -253,7 +328,8 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
           duration_ms: Date.now() - toolStart,
         });
         return createTextResponse(
-          `事業所を設定: ${formatCompanyName(companyInfo?.name)} (ID: ${company_id})`,
+          `事業所を設定: ${formatCompanyName(companyInfo?.name)} (ID: ${company_id})` +
+            ` [display_name: ${formatCompanyName(companyInfo?.display_name)}]`,
         );
       } catch (error) {
         recorder?.recordToolCall({
@@ -267,7 +343,8 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
     },
   );
 
-  registerTracedTool(server,
+  registerTracedTool(
+    server,
     'freee_get_current_company',
     {
       title: '現在の事業所情報',
@@ -280,7 +357,10 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
       try {
         const tokenContext = extractTokenContext(extra);
         const companyId = await resolveCompanyId(tokenContext);
-        const companyInfo = await tokenContext.tokenStore.getCompanyInfo(tokenContext.userId, companyId);
+        const companyInfo = await tokenContext.tokenStore.getCompanyInfo(
+          tokenContext.userId,
+          companyId,
+        );
 
         recorder?.recordToolCall({
           tool: 'freee_get_current_company',
@@ -292,7 +372,8 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
         }
 
         return createTextResponse(
-          `事業所: ${formatCompanyName(companyInfo.name)} (ID: ${companyInfo.id})`,
+          `事業所: ${formatCompanyName(companyInfo.name)} (ID: ${companyInfo.id})` +
+            ` [display_name: ${formatCompanyName(companyInfo.display_name)}]`,
         );
       } catch (error) {
         recorder?.recordToolCall({
@@ -306,7 +387,8 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
     },
   );
 
-  registerTracedTool(server,
+  registerTracedTool(
+    server,
     'freee_list_companies',
     {
       title: '事業所一覧',
@@ -324,6 +406,7 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
               z.object({
                 id: z.number(),
                 name: z.string().nullable(),
+                display_name: z.string().nullable().optional(),
               }),
             )
             .optional(),
@@ -372,7 +455,10 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
         const companyList = apiCompanies.companies
           .map((company) => {
             const current = company.id === parseInt(currentCompanyId, 10) ? ' *' : '';
-            return `${formatCompanyName(company.name)} (${company.id})${current}`;
+            return (
+              `${formatCompanyName(company.name)} (${company.id})${current}` +
+              ` [display_name: ${formatCompanyName(company.display_name)}]`
+            );
           })
           .join('\n');
 
@@ -394,7 +480,8 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
     },
   );
 
-  registerTracedTool(server,
+  registerTracedTool(
+    server,
     'freee_server_info',
     {
       title: 'サーバー情報',

--- a/src/server/freee-callback.test.ts
+++ b/src/server/freee-callback.test.ts
@@ -138,7 +138,13 @@ describe('createFreeeCallbackHandler', () => {
     );
 
     // Verify default company set to first company
-    expect(tokenStore.setCurrentCompany).toHaveBeenCalledWith('42', '12345', 'テスト事業所');
+    expect(tokenStore.setCurrentCompany).toHaveBeenCalledWith(
+      '42',
+      '12345',
+      'テスト事業所',
+      undefined,
+      undefined,
+    );
 
     // Verify MCP auth code saved
     expect(oauthStore.saveAuthCode).toHaveBeenCalledWith(
@@ -237,7 +243,60 @@ describe('createFreeeCallbackHandler', () => {
     });
 
     // Should fall back to HR API and set the HR company
-    expect(tokenStore.setCurrentCompany).toHaveBeenCalledWith('42', '11111', 'HR事業所');
+    expect(tokenStore.setCurrentCompany).toHaveBeenCalledWith(
+      '42',
+      '11111',
+      'HR事業所',
+      undefined,
+      undefined,
+    );
+  });
+
+  it('passes display_name through to setCurrentCompany when first company has only display_name', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => freeeTokenResponse,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => freeeUserResponse,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          companies: [{ id: 99999, name: null, display_name: '事業所名（未設定）' }],
+        }),
+      }) as unknown as typeof fetch;
+
+    const oauthStore = createMockOAuthStore();
+    const tokenStore = createMockTokenStore();
+
+    const handler = createFreeeCallbackHandler({
+      oauthStore,
+      tokenStore,
+      freeeClientId: 'freee-client-id',
+      freeeClientSecret: 'freee-client-secret',
+      freeeTokenEndpoint: 'https://accounts.secure.freee.co.jp/public_api/token',
+      freeeScope: 'read write',
+      callbackBaseUrl: 'https://mcp.example.com',
+    });
+
+    const { req, res } = createMockReqRes({ code: 'freee-auth-code', state: 'session-id' });
+    handler(req, res);
+
+    await vi.waitFor(() => {
+      expect(res.redirect).toHaveBeenCalled();
+    });
+
+    expect(tokenStore.setCurrentCompany).toHaveBeenCalledWith(
+      '42',
+      '99999',
+      undefined,
+      undefined,
+      '事業所名（未設定）',
+    );
   });
 
   it('continues OAuth flow even when both companies APIs fail', async () => {

--- a/src/server/freee-callback.ts
+++ b/src/server/freee-callback.ts
@@ -93,7 +93,7 @@ async function fetchFreeeUserId(accessToken: string, apiUrl: string): Promise<st
 async function fetchFirstCompany(
   accessToken: string,
   apiUrl: string,
-): Promise<{ id: number; name?: string | null } | null> {
+): Promise<{ id: number; name?: string | null; display_name?: string | null } | null> {
   // Try accounting API first
   try {
     const response = await fetch(`${apiUrl}/api/1/companies`, {
@@ -106,7 +106,7 @@ async function fetchFirstCompany(
 
     if (response.ok) {
       const data = (await response.json()) as {
-        companies?: Array<{ id: number; name?: string | null }>;
+        companies?: Array<{ id: number; name?: string | null; display_name?: string | null }>;
       };
       const first = data.companies?.[0];
       if (first) {
@@ -129,7 +129,7 @@ async function fetchFirstCompany(
 
     if (response.ok) {
       const data = (await response.json()) as {
-        companies?: Array<{ id: number; name?: string | null }>;
+        companies?: Array<{ id: number; name?: string | null; display_name?: string | null }>;
       };
       const first = data.companies?.[0];
       if (first) {
@@ -164,6 +164,8 @@ async function setDefaultCompanyIfNeeded(
       userId,
       String(firstCompany.id),
       firstCompany.name ?? undefined,
+      undefined,
+      firstCompany.display_name ?? undefined,
     );
     getLogger().info(
       { userId, companyId: firstCompany.id, companyName: firstCompany.name },

--- a/src/storage/file-token-store.test.ts
+++ b/src/storage/file-token-store.test.ts
@@ -94,9 +94,9 @@ describe('FileTokenStore', () => {
   it('setCurrentCompany delegates with all args except userId', async () => {
     vi.mocked(setCurrentCompany).mockResolvedValue(undefined);
 
-    await store.setCurrentCompany('ignored', '999', 'My Co', 'desc');
+    await store.setCurrentCompany('ignored', '999', 'My Co', 'desc', 'My Co DBA');
 
-    expect(setCurrentCompany).toHaveBeenCalledWith('999', 'My Co', 'desc');
+    expect(setCurrentCompany).toHaveBeenCalledWith('999', 'My Co', 'desc', 'My Co DBA');
   });
 
   it('getCompanyInfo delegates to file-based getCompanyInfo', async () => {

--- a/src/storage/file-token-store.ts
+++ b/src/storage/file-token-store.ts
@@ -43,8 +43,9 @@ export class FileTokenStore implements TokenStore {
     companyId: string,
     name?: string,
     description?: string,
+    display_name?: string,
   ): Promise<void> {
-    return fileSetCurrentCompany(companyId, name, description);
+    return fileSetCurrentCompany(companyId, name, description, display_name);
   }
 
   async getCompanyInfo(_userId: string, companyId: string): Promise<CompanyConfig | null> {

--- a/src/storage/redis-token-store.test.ts
+++ b/src/storage/redis-token-store.test.ts
@@ -125,10 +125,13 @@ describe('RedisTokenStore', () => {
   });
 
   describe('clearTokens', () => {
-    it('should delete tokens from Redis', async () => {
+    it('should delete tokens, current company, dict, and legacy keys', async () => {
       await tokenStore.clearTokens('user-1');
 
       expect(mockRedis.del).toHaveBeenCalledWith('freee-mcp:tokens:user-1');
+      expect(mockRedis.del).toHaveBeenCalledWith('freee-mcp:company:user-1');
+      expect(mockRedis.del).toHaveBeenCalledWith('freee-mcp:company:current:user-1');
+      expect(mockRedis.del).toHaveBeenCalledWith('freee-mcp:company:dict:user-1');
     });
   });
 
@@ -179,18 +182,25 @@ describe('RedisTokenStore', () => {
   });
 
   describe('getCurrentCompanyId', () => {
-    it('should return company ID from Redis', async () => {
-      mockRedis.hget.mockResolvedValue('12345');
+    it('should return company ID from the new dedicated key', async () => {
+      mockRedis._store.set('freee-mcp:company:current:user-1', '12345');
 
       const result = await tokenStore.getCurrentCompanyId('user-1');
 
       expect(result).toBe('12345');
+      expect(mockRedis.get).toHaveBeenCalledWith('freee-mcp:company:current:user-1');
+    });
+
+    it('should fall back to the legacy hash when the new key is missing', async () => {
+      mockRedis._hashStore.set('freee-mcp:company:user-1', { currentCompanyId: '67890' });
+
+      const result = await tokenStore.getCurrentCompanyId('user-1');
+
+      expect(result).toBe('67890');
       expect(mockRedis.hget).toHaveBeenCalledWith('freee-mcp:company:user-1', 'currentCompanyId');
     });
 
-    it('should return default "0" when not set', async () => {
-      mockRedis.hget.mockResolvedValue(null);
-
+    it('should return default "0" when neither new nor legacy keys exist', async () => {
       const result = await tokenStore.getCurrentCompanyId('user-1');
 
       expect(result).toBe('0');
@@ -198,23 +208,31 @@ describe('RedisTokenStore', () => {
   });
 
   describe('setCurrentCompany', () => {
-    it('should set company with all fields', async () => {
-      await tokenStore.setCurrentCompany('user-1', '12345', 'My Company', 'A description');
+    function getDictEntry(
+      userId: string,
+      companyId: string,
+    ): { name?: string; display_name?: string; description?: string; updatedAt?: number } | null {
+      const hash = mockRedis._hashStore.get(`freee-mcp:company:dict:${userId}`);
+      const raw = hash?.[companyId];
+      return raw ? JSON.parse(raw) : null;
+    }
 
-      expect(mockRedis.hset).toHaveBeenCalledWith('freee-mcp:company:user-1', {
-        currentCompanyId: '12345',
-        updatedAt: expect.any(String),
+    it('should write current company id and a dict entry with all fields', async () => {
+      await tokenStore.setCurrentCompany(
+        'user-1',
+        '12345',
+        'My Company',
+        'A description',
+        'My Company DBA',
+      );
+
+      expect(mockRedis._store.get('freee-mcp:company:current:user-1')).toBe('12345');
+      const entry = getDictEntry('user-1', '12345');
+      expect(entry).toEqual({
         name: 'My Company',
+        display_name: 'My Company DBA',
         description: 'A description',
-      });
-    });
-
-    it('should set company with only required fields, omitting name/description', async () => {
-      await tokenStore.setCurrentCompany('user-1', '12345');
-
-      expect(mockRedis.hset).toHaveBeenCalledWith('freee-mcp:company:user-1', {
-        currentCompanyId: '12345',
-        updatedAt: expect.any(String),
+        updatedAt: expect.any(Number),
       });
     });
 
@@ -222,27 +240,38 @@ describe('RedisTokenStore', () => {
       await tokenStore.setCurrentCompany('user-1', '12345', 'My Company', 'A description');
       await tokenStore.setCurrentCompany('user-1', '12345');
 
-      const stored = mockRedis._hashStore.get('freee-mcp:company:user-1');
-      expect(stored?.name).toBe('My Company');
-      expect(stored?.description).toBe('A description');
+      const entry = getDictEntry('user-1', '12345');
+      expect(entry?.name).toBe('My Company');
+      expect(entry?.description).toBe('A description');
     });
 
     it('should overwrite name only when an explicit value is provided', async () => {
       await tokenStore.setCurrentCompany('user-1', '12345', 'Old Name');
       await tokenStore.setCurrentCompany('user-1', '12345', 'New Name');
 
-      const stored = mockRedis._hashStore.get('freee-mcp:company:user-1');
-      expect(stored?.name).toBe('New Name');
+      expect(getDictEntry('user-1', '12345')?.name).toBe('New Name');
+    });
+
+    it('should keep per-company entries separate when switching companies', async () => {
+      await tokenStore.setCurrentCompany('user-1', 'A', 'Alpha');
+      await tokenStore.setCurrentCompany('user-1', 'B', 'Beta');
+      await tokenStore.setCurrentCompany('user-1', 'A');
+
+      expect(mockRedis._store.get('freee-mcp:company:current:user-1')).toBe('A');
+      expect(getDictEntry('user-1', 'A')?.name).toBe('Alpha');
+      expect(getDictEntry('user-1', 'B')?.name).toBe('Beta');
     });
   });
 
   describe('getCompanyInfo', () => {
-    it('should return company info when matching', async () => {
-      mockRedis.hgetall.mockResolvedValue({
-        currentCompanyId: '12345',
-        name: 'My Company',
-        description: 'desc',
-        updatedAt: '1700000000000',
+    it('should return the dict entry for a matching company id', async () => {
+      mockRedis._hashStore.set('freee-mcp:company:dict:user-1', {
+        '12345': JSON.stringify({
+          name: 'My Company',
+          display_name: 'My Co',
+          description: 'desc',
+          updatedAt: 1700000000000,
+        }),
       });
 
       const result = await tokenStore.getCompanyInfo('user-1', '12345');
@@ -250,13 +279,40 @@ describe('RedisTokenStore', () => {
       expect(result).toEqual({
         id: '12345',
         name: 'My Company',
+        display_name: 'My Co',
         description: 'desc',
         addedAt: 1700000000000,
       });
     });
 
-    it('should return null when company ID does not match', async () => {
-      mockRedis.hgetall.mockResolvedValue({
+    it('should fall back to legacy hash and lazily backfill the new dict', async () => {
+      mockRedis._hashStore.set('freee-mcp:company:user-1', {
+        currentCompanyId: '12345',
+        name: 'Legacy Co',
+        description: 'old desc',
+        updatedAt: '1699000000000',
+      });
+
+      const result = await tokenStore.getCompanyInfo('user-1', '12345');
+
+      expect(result).toEqual({
+        id: '12345',
+        name: 'Legacy Co',
+        description: 'old desc',
+        addedAt: 1699000000000,
+      });
+
+      const dict = mockRedis._hashStore.get('freee-mcp:company:dict:user-1');
+      expect(dict?.['12345']).toBeDefined();
+      const entry = JSON.parse(dict?.['12345'] ?? '{}');
+      expect(entry).toMatchObject({
+        name: 'Legacy Co',
+        description: 'old desc',
+      });
+    });
+
+    it('should return null when legacy entry exists for a different company', async () => {
+      mockRedis._hashStore.set('freee-mcp:company:user-1', {
         currentCompanyId: '99999',
         name: 'Other',
       });
@@ -266,9 +322,7 @@ describe('RedisTokenStore', () => {
       expect(result).toBeNull();
     });
 
-    it('should return null when no data exists', async () => {
-      mockRedis.hgetall.mockResolvedValue({});
-
+    it('should return null when no data exists in either store', async () => {
       const result = await tokenStore.getCompanyInfo('user-1', '12345');
 
       expect(result).toBeNull();

--- a/src/storage/redis-token-store.test.ts
+++ b/src/storage/redis-token-store.test.ts
@@ -209,15 +209,30 @@ describe('RedisTokenStore', () => {
       });
     });
 
-    it('should set company with only required fields', async () => {
+    it('should set company with only required fields, omitting name/description', async () => {
       await tokenStore.setCurrentCompany('user-1', '12345');
 
       expect(mockRedis.hset).toHaveBeenCalledWith('freee-mcp:company:user-1', {
         currentCompanyId: '12345',
         updatedAt: expect.any(String),
-        name: '',
-        description: '',
       });
+    });
+
+    it('should preserve existing name when subsequent call omits the name arg', async () => {
+      await tokenStore.setCurrentCompany('user-1', '12345', 'My Company', 'A description');
+      await tokenStore.setCurrentCompany('user-1', '12345');
+
+      const stored = mockRedis._hashStore.get('freee-mcp:company:user-1');
+      expect(stored?.name).toBe('My Company');
+      expect(stored?.description).toBe('A description');
+    });
+
+    it('should overwrite name only when an explicit value is provided', async () => {
+      await tokenStore.setCurrentCompany('user-1', '12345', 'Old Name');
+      await tokenStore.setCurrentCompany('user-1', '12345', 'New Name');
+
+      const stored = mockRedis._hashStore.get('freee-mcp:company:user-1');
+      expect(stored?.name).toBe('New Name');
     });
   });
 

--- a/src/storage/redis-token-store.ts
+++ b/src/storage/redis-token-store.ts
@@ -13,7 +13,19 @@ import type { Redis } from './redis-client.js';
 import type { TokenStore } from './token-store.js';
 
 const TOKEN_KEY_PREFIX = 'freee-mcp:tokens:';
+// Legacy single-slot hash. Read-only fallback; new writes go to the keys below.
 const COMPANY_KEY_PREFIX = 'freee-mcp:company:';
+// Current company id, one value per user.
+const COMPANY_CURRENT_KEY_PREFIX = 'freee-mcp:company:current:';
+// Per-company dictionary: hash field=companyId, value=JSON({ name?, display_name?, description?, updatedAt }).
+const COMPANY_DICT_KEY_PREFIX = 'freee-mcp:company:dict:';
+
+interface DictEntry {
+  name?: string;
+  display_name?: string;
+  description?: string;
+  updatedAt?: number;
+}
 
 export class RedisTokenStore implements TokenStore {
   private redis: Redis;
@@ -56,7 +68,14 @@ export class RedisTokenStore implements TokenStore {
   }
 
   async clearTokens(userId: string): Promise<void> {
-    await withRedis('clearTokens', () => this.redis.del(this.tokenKey(userId)));
+    await withRedis('clearTokens', async () => {
+      await Promise.all([
+        this.redis.del(this.tokenKey(userId)),
+        this.redis.del(this.companyKey(userId)),
+        this.redis.del(this.companyCurrentKey(userId)),
+        this.redis.del(this.companyDictKey(userId)),
+      ]);
+    });
   }
 
   async getValidAccessToken(userId: string): Promise<string | null> {
@@ -77,10 +96,17 @@ export class RedisTokenStore implements TokenStore {
   }
 
   async getCurrentCompanyId(userId: string): Promise<string> {
-    const companyId = await withRedis('getCurrentCompanyId', () =>
+    // Prefer the new dedicated key; fall back to the legacy single-slot hash.
+    const fromNew = await withRedis('getCurrentCompanyId', () =>
+      this.redis.get(this.companyCurrentKey(userId)),
+    );
+    if (fromNew) {
+      return fromNew;
+    }
+    const fromLegacy = await withRedis('getCurrentCompanyId', () =>
       this.redis.hget(this.companyKey(userId), 'currentCompanyId'),
     );
-    return companyId || '0';
+    return fromLegacy || '0';
   }
 
   async setCurrentCompany(
@@ -88,36 +114,76 @@ export class RedisTokenStore implements TokenStore {
     companyId: string,
     name?: string,
     description?: string,
+    display_name?: string,
   ): Promise<void> {
-    const fields: Record<string, string> = {
-      currentCompanyId: companyId,
-      updatedAt: String(Date.now()),
+    await withRedis('setCurrentCompany', () =>
+      this.redis.set(this.companyCurrentKey(userId), companyId),
+    );
+    // Merge into the per-company dict, preserving fields the caller omitted.
+    const existing = (await this.readDictEntry(userId, companyId)) ?? {};
+    const merged: DictEntry = {
+      ...existing,
+      updatedAt: Date.now(),
     };
-    // Only overwrite name/description when an explicit value is provided.
-    // Omitted args preserve any existing cached value (HSET merges fields).
-    if (name !== undefined) {
-      fields.name = name;
-    }
-    if (description !== undefined) {
-      fields.description = description;
-    }
-    await withRedis('setCurrentCompany', () => this.redis.hset(this.companyKey(userId), fields));
+    if (name !== undefined) merged.name = name;
+    if (display_name !== undefined) merged.display_name = display_name;
+    if (description !== undefined) merged.description = description;
+    await withRedis('setCurrentCompany', () =>
+      this.redis.hset(this.companyDictKey(userId), {
+        [companyId]: JSON.stringify(merged),
+      }),
+    );
   }
 
   async getCompanyInfo(userId: string, companyId: string): Promise<CompanyConfig | null> {
-    const data = await withRedis('getCompanyInfo', () =>
+    const fromDict = await this.readDictEntry(userId, companyId);
+    if (fromDict) {
+      return {
+        id: companyId,
+        name: fromDict.name,
+        display_name: fromDict.display_name,
+        description: fromDict.description,
+        addedAt: fromDict.updatedAt ?? Date.now(),
+      };
+    }
+    // Legacy single-slot fallback. Returns null when the legacy entry is for
+    // a different company or absent.
+    const legacy = await withRedis('getCompanyInfo', () =>
       this.redis.hgetall(this.companyKey(userId)),
     );
-    if (!data || data.currentCompanyId !== companyId) {
+    if (!legacy || legacy.currentCompanyId !== companyId) {
       return null;
     }
-
-    return {
+    const result: CompanyConfig = {
       id: companyId,
-      name: data.name,
-      description: data.description,
-      addedAt: data.updatedAt ? Number(data.updatedAt) : Date.now(),
+      name: legacy.name || undefined,
+      description: legacy.description || undefined,
+      addedAt: legacy.updatedAt ? Number(legacy.updatedAt) : Date.now(),
     };
+    // Best-effort lazy backfill into the new dict.
+    try {
+      const entry: DictEntry = { updatedAt: result.addedAt };
+      if (result.name) entry.name = result.name;
+      if (result.description) entry.description = result.description;
+      await this.redis.hset(this.companyDictKey(userId), {
+        [companyId]: JSON.stringify(entry),
+      });
+    } catch (err) {
+      getLogger().warn({ err, userId, companyId }, 'company dict backfill failed (non-fatal)');
+    }
+    return result;
+  }
+
+  private async readDictEntry(userId: string, companyId: string): Promise<DictEntry | null> {
+    const raw = await withRedis('getCompanyInfo', () =>
+      this.redis.hget(this.companyDictKey(userId), companyId),
+    );
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as DictEntry;
+    } catch {
+      return null;
+    }
   }
 
   private tokenKey(userId: string): string {
@@ -126,5 +192,13 @@ export class RedisTokenStore implements TokenStore {
 
   private companyKey(userId: string): string {
     return `${COMPANY_KEY_PREFIX}${userId}`;
+  }
+
+  private companyCurrentKey(userId: string): string {
+    return `${COMPANY_CURRENT_KEY_PREFIX}${userId}`;
+  }
+
+  private companyDictKey(userId: string): string {
+    return `${COMPANY_DICT_KEY_PREFIX}${userId}`;
   }
 }

--- a/src/storage/redis-token-store.ts
+++ b/src/storage/redis-token-store.ts
@@ -116,13 +116,14 @@ export class RedisTokenStore implements TokenStore {
     description?: string,
     display_name?: string,
   ): Promise<void> {
-    await withRedis('setCurrentCompany', () =>
-      this.redis.set(this.companyCurrentKey(userId), companyId),
-    );
-    // Merge into the per-company dict, preserving fields the caller omitted.
-    const existing = (await this.readDictEntry(userId, companyId)) ?? {};
+    const [, existingOrNull] = await Promise.all([
+      withRedis('setCurrentCompany', () =>
+        this.redis.set(this.companyCurrentKey(userId), companyId),
+      ),
+      this.readDictEntry(userId, companyId),
+    ]);
     const merged: DictEntry = {
-      ...existing,
+      ...(existingOrNull ?? {}),
       updatedAt: Date.now(),
     };
     if (name !== undefined) merged.name = name;
@@ -175,7 +176,7 @@ export class RedisTokenStore implements TokenStore {
   }
 
   private async readDictEntry(userId: string, companyId: string): Promise<DictEntry | null> {
-    const raw = await withRedis('getCompanyInfo', () =>
+    const raw = await withRedis('readDictEntry', () =>
       this.redis.hget(this.companyDictKey(userId), companyId),
     );
     if (!raw) return null;

--- a/src/storage/redis-token-store.ts
+++ b/src/storage/redis-token-store.ts
@@ -92,9 +92,15 @@ export class RedisTokenStore implements TokenStore {
     const fields: Record<string, string> = {
       currentCompanyId: companyId,
       updatedAt: String(Date.now()),
-      name: name ?? '',
-      description: description ?? '',
     };
+    // Only overwrite name/description when an explicit value is provided.
+    // Omitted args preserve any existing cached value (HSET merges fields).
+    if (name !== undefined) {
+      fields.name = name;
+    }
+    if (description !== undefined) {
+      fields.description = description;
+    }
     await withRedis('setCurrentCompany', () => this.redis.hset(this.companyKey(userId), fields));
   }
 

--- a/src/storage/token-store.ts
+++ b/src/storage/token-store.ts
@@ -12,6 +12,7 @@ export interface TokenStore {
     companyId: string,
     name?: string,
     description?: string,
+    display_name?: string,
   ): Promise<void>;
   getCompanyInfo(userId: string, companyId: string): Promise<CompanyConfig | null>;
 }

--- a/src/utils/format-company.test.ts
+++ b/src/utils/format-company.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { formatCompanyName } from './format-company.js';
+
+describe('formatCompanyName', () => {
+  it('returns the trimmed name when present', () => {
+    expect(formatCompanyName('Acme Co.')).toBe('Acme Co.');
+    expect(formatCompanyName('  Acme Co.  ')).toBe('Acme Co.');
+  });
+
+  it('returns the unified label for missing values', () => {
+    expect(formatCompanyName(undefined)).toBe('(未設定)');
+    expect(formatCompanyName(null)).toBe('(未設定)');
+  });
+
+  it('returns the unified label for empty or whitespace-only values', () => {
+    expect(formatCompanyName('')).toBe('(未設定)');
+    expect(formatCompanyName('   ')).toBe('(未設定)');
+  });
+});

--- a/src/utils/format-company.ts
+++ b/src/utils/format-company.ts
@@ -1,0 +1,11 @@
+const UNSET_LABEL = '(未設定)';
+
+/**
+ * Returns the company name for display, normalizing missing or whitespace-only
+ * values to the unified UNSET_LABEL. Does not fall back to other fields —
+ * `name` and `display_name` are distinct in the freee API.
+ */
+export function formatCompanyName(name: string | null | undefined): string {
+  const value = name?.trim();
+  return value ? value : UNSET_LABEL;
+}


### PR DESCRIPTION
## 概要

`freee_get_current_company` / `freee_current_user` / `freee_list_companies` の 3 ツールで会社名が空欄・Unknown になる問題を修正します。stg / prod 両環境で再現を確認済み（v0.26.0 / v0.25.5）。

### 根本原因

1. **`RedisTokenStore.setCurrentCompany` のデータ損失**: 毎呼び出しで `name: name ?? ''` を無条件に上書き。`freee_set_current_company` を `name` 引数なしで呼ぶ（通常フロー）と、キャッシュ済みの会社名が空文字列に消える。
2. **単一スロット型キャッシュ**: `getCompanyInfo(userId, companyId)` のシグネチャは事業所別辞書を示唆するが、実態は単一スロットで `currentCompanyId !== companyId` なら常に null。事業所切替のたびに会社名が消える。
3. **ハンドラが会社名を自己解決しない**: `freee_set_current_company` ハンドラがユーザー args の `name` をそのまま storage に渡すだけで、未指定時に API から補完しない。
4. **表示 fallback が各ツールでバラバラ**: `""` / `'Unknown'` / `(名称未設定)` の 3 種類が混在。

### 変更内容（5 コミット構成）

| コミット | 内容 |
|---|---|
| refactor(display) | 空会社名表記を `(未設定)` に統一する `formatCompanyName` ヘルパー追加 |
| fix(token-store) | `setCurrentCompany` で引数が未指定のとき既存 dict 値を保存（コアバグ修正） |
| refactor(token-store) | Redis キーを `company:current:<userId>` + `company:dict:<userId>` に分離。旧シングルスロットキーはホットパス後に lazy backfill。`clearTokens` は 4 キー全削除 |
| feat(tools) | `freee_list_companies` に `display_name` ラベル追加。`freee_set_current_company` にキャッシュミス時の `/api/1/companies` 1 回照会を追加。コールバックも `display_name` を渡すよう修正 |
| refactor: apply code-review-trio feedback | 重複 Zod スキーマ削除・余分な Redis round-trip 削除・withRedis タグ修正・Promise.all 最適化 |

### 機能検証

stg 環境に配備後、以下のシーケンスで回帰確認を予定:

1. `freee_clear_auth` → 再認証
2. `freee_get_current_company` — 会社名 + display_name が両方表示されること
3. `freee_list_companies` — name / display_name ラベルが分離表示されること
4. `freee_set_current_company(company_id=<other>)` ※name 引数なし — 応答に会社名が表示されること（Unknown / 空欄にならないこと）
5. `freee_get_current_company` — 切替後も会社名が保持されていること
6. `freee_current_user` — `会社名:` が Unknown でないこと
7. 元の事業所に戻す — 元の会社名が保持されていること

## 変更種別

- [x] バグ修正
- [x] リファクタリング
