### PR TITLE
feat(server): HTTP server timeout を明示設定 (long-lived MCP 接続向け)

### DIFF
--- a/.changeset/explicit-http-server-timeouts.md
+++ b/.changeset/explicit-http-server-timeouts.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+serve モードの HTTP server タイムアウトを明示設定。long-lived な MCP Streamable-HTTP / SSE 接続に合わせて Node.js の `requestTimeout` / `headersTimeout` / `keepAliveTimeout` をデフォルト 10m / 65s / 60s に固定し、それぞれ `HTTP_REQUEST_TIMEOUT_MS` / `HTTP_HEADERS_TIMEOUT_MS` / `HTTP_KEEP_ALIVE_TIMEOUT_MS` 環境変数で上書き可能にした。Node デフォルト (5m / 60s / 5s) では中間プロキシのストリームアイドルタイムアウトと衝突して MCP セッション中の長時間接続が切れるケースがあったため。

--- a/src/config-remote.test.ts
+++ b/src/config-remote.test.ts
@@ -85,6 +85,26 @@ describe('loadRemoteServerConfig', () => {
 
       expect(() => loadRemoteServerConfig()).toThrow(/HTTP_KEEP_ALIVE_TIMEOUT_MS/);
     });
+
+    it('rejects headers timeout that is not greater than keep-alive timeout', async () => {
+      // Node requires headersTimeout > keepAliveTimeout. Validate against resolved
+      // values so an operator overriding only one of the two still gets caught.
+      process.env.HTTP_HEADERS_TIMEOUT_MS = '60000';
+      process.env.HTTP_KEEP_ALIVE_TIMEOUT_MS = '60000';
+      const { loadRemoteServerConfig } = await import('./config.js');
+
+      expect(() => loadRemoteServerConfig()).toThrow(
+        /HTTP_HEADERS_TIMEOUT_MS .* must be greater than HTTP_KEEP_ALIVE_TIMEOUT_MS/,
+      );
+    });
+
+    it('catches invariant violation when only keep-alive is overridden upward', async () => {
+      // Default headersTimeout=65s; bumping only keepAlive to 70s violates the invariant.
+      process.env.HTTP_KEEP_ALIVE_TIMEOUT_MS = '70000';
+      const { loadRemoteServerConfig } = await import('./config.js');
+
+      expect(() => loadRemoteServerConfig()).toThrow(/must be greater than/);
+    });
   });
 
   describe('allowInsecureLocalhostCimd environment detection', () => {

--- a/src/config-remote.test.ts
+++ b/src/config-remote.test.ts
@@ -40,7 +40,50 @@ describe('loadRemoteServerConfig', () => {
       corsAllowedOrigins: undefined,
       rateLimitEnabled: true,
       logLevel: 'info',
+      httpRequestTimeoutMs: 10 * 60 * 1000,
+      httpHeadersTimeoutMs: 65 * 1000,
+      httpKeepAliveTimeoutMs: 60 * 1000,
       allowInsecureLocalhostCimd: false,
+    });
+  });
+
+  describe('HTTP server timeouts', () => {
+    it('falls back to constants when env is unset', async () => {
+      delete process.env.HTTP_REQUEST_TIMEOUT_MS;
+      delete process.env.HTTP_HEADERS_TIMEOUT_MS;
+      delete process.env.HTTP_KEEP_ALIVE_TIMEOUT_MS;
+      const { loadRemoteServerConfig } = await import('./config.js');
+      const config = loadRemoteServerConfig();
+
+      expect(config.httpRequestTimeoutMs).toBe(10 * 60 * 1000);
+      expect(config.httpHeadersTimeoutMs).toBe(65 * 1000);
+      expect(config.httpKeepAliveTimeoutMs).toBe(60 * 1000);
+    });
+
+    it('honors env overrides when set', async () => {
+      process.env.HTTP_REQUEST_TIMEOUT_MS = '900000';
+      process.env.HTTP_HEADERS_TIMEOUT_MS = '70000';
+      process.env.HTTP_KEEP_ALIVE_TIMEOUT_MS = '65000';
+      const { loadRemoteServerConfig } = await import('./config.js');
+      const config = loadRemoteServerConfig();
+
+      expect(config.httpRequestTimeoutMs).toBe(900_000);
+      expect(config.httpHeadersTimeoutMs).toBe(70_000);
+      expect(config.httpKeepAliveTimeoutMs).toBe(65_000);
+    });
+
+    it('rejects non-numeric values with a clear error', async () => {
+      process.env.HTTP_REQUEST_TIMEOUT_MS = 'forever';
+      const { loadRemoteServerConfig } = await import('./config.js');
+
+      expect(() => loadRemoteServerConfig()).toThrow(/HTTP_REQUEST_TIMEOUT_MS/);
+    });
+
+    it('rejects zero or negative values', async () => {
+      process.env.HTTP_KEEP_ALIVE_TIMEOUT_MS = '0';
+      const { loadRemoteServerConfig } = await import('./config.js');
+
+      expect(() => loadRemoteServerConfig()).toThrow(/HTTP_KEEP_ALIVE_TIMEOUT_MS/);
     });
   });
 
@@ -237,12 +280,18 @@ describe('summarizeRemoteServerConfig', () => {
       redisUrl: 'redis://localhost:6379',
       rateLimitEnabled: true,
       logLevel: 'info',
+      httpRequestTimeoutMs: 600_000,
+      httpHeadersTimeoutMs: 65_000,
+      httpKeepAliveTimeoutMs: 60_000,
     });
 
     expect(summary.jwtSecret).toBe('<redacted>');
     expect(summary.freeeClientSecret).toBe('<redacted>');
     expect(summary.freeeClientId).toBe('cid');
     expect(summary.rateLimitEnabled).toBe(true);
+    expect(summary.httpRequestTimeoutMs).toBe(600_000);
+    expect(summary.httpHeadersTimeoutMs).toBe(65_000);
+    expect(summary.httpKeepAliveTimeoutMs).toBe(60_000);
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,9 @@ import {
   FREEE_AUTHORIZATION_ENDPOINT,
   FREEE_OAUTH_SCOPE,
   FREEE_TOKEN_ENDPOINT,
+  HTTP_HEADERS_TIMEOUT_MS,
+  HTTP_KEEP_ALIVE_TIMEOUT_MS,
+  HTTP_REQUEST_TIMEOUT_MS,
   SERVER_INSTRUCTIONS,
 } from './constants.js';
 
@@ -211,6 +214,10 @@ export interface RemoteServerConfig {
   corsAllowedOrigins?: string;
   rateLimitEnabled: boolean;
   logLevel: string;
+  // HTTP server timeouts for long-lived MCP Streamable-HTTP / SSE connections.
+  httpRequestTimeoutMs: number;
+  httpHeadersTimeoutMs: number;
+  httpKeepAliveTimeoutMs: number;
   // Dev-only: accept http://localhost CIMD URLs. Determined by environment, not by an env var.
   allowInsecureLocalhostCimd: boolean;
 }
@@ -250,6 +257,16 @@ export function parseBooleanEnv(
 
 const VALID_LOG_LEVELS = ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'] as const;
 
+/** Optional env var that, when set, must coerce to a positive integer. */
+function positiveIntEnv(name: string) {
+  const message = `${name} must be a positive integer.`;
+  return z.coerce
+    .number({ invalid_type_error: message })
+    .int(message)
+    .positive(message)
+    .optional();
+}
+
 /**
  * Schema for validating remote server environment variables at startup.
  * All required envs must be present and well-formed; invalid values fail loudly.
@@ -283,6 +300,9 @@ const RemoteServerEnvSchema = z.object({
   CORS_ALLOWED_ORIGINS: z.string().optional(),
   RATE_LIMIT_ENABLED: z.string().optional(),
   LOG_LEVEL: z.enum(VALID_LOG_LEVELS).optional(),
+  HTTP_REQUEST_TIMEOUT_MS: positiveIntEnv('HTTP_REQUEST_TIMEOUT_MS'),
+  HTTP_HEADERS_TIMEOUT_MS: positiveIntEnv('HTTP_HEADERS_TIMEOUT_MS'),
+  HTTP_KEEP_ALIVE_TIMEOUT_MS: positiveIntEnv('HTTP_KEEP_ALIVE_TIMEOUT_MS'),
 });
 
 function formatZodIssues(error: z.ZodError): string {
@@ -310,6 +330,9 @@ export function loadRemoteServerConfig(): RemoteServerConfig {
     CORS_ALLOWED_ORIGINS: process.env.CORS_ALLOWED_ORIGINS,
     RATE_LIMIT_ENABLED: process.env.RATE_LIMIT_ENABLED,
     LOG_LEVEL: process.env.LOG_LEVEL,
+    HTTP_REQUEST_TIMEOUT_MS: process.env.HTTP_REQUEST_TIMEOUT_MS,
+    HTTP_HEADERS_TIMEOUT_MS: process.env.HTTP_HEADERS_TIMEOUT_MS,
+    HTTP_KEEP_ALIVE_TIMEOUT_MS: process.env.HTTP_KEEP_ALIVE_TIMEOUT_MS,
   };
 
   const parsed = RemoteServerEnvSchema.safeParse(rawEnv);
@@ -355,6 +378,9 @@ export function loadRemoteServerConfig(): RemoteServerConfig {
     corsAllowedOrigins: env.CORS_ALLOWED_ORIGINS,
     rateLimitEnabled,
     logLevel: env.LOG_LEVEL || 'info',
+    httpRequestTimeoutMs: env.HTTP_REQUEST_TIMEOUT_MS ?? HTTP_REQUEST_TIMEOUT_MS,
+    httpHeadersTimeoutMs: env.HTTP_HEADERS_TIMEOUT_MS ?? HTTP_HEADERS_TIMEOUT_MS,
+    httpKeepAliveTimeoutMs: env.HTTP_KEEP_ALIVE_TIMEOUT_MS ?? HTTP_KEEP_ALIVE_TIMEOUT_MS,
     allowInsecureLocalhostCimd,
   };
 }
@@ -393,6 +419,9 @@ export function summarizeRemoteServerConfig(
     corsAllowedOrigins: config.corsAllowedOrigins,
     rateLimitEnabled: config.rateLimitEnabled,
     logLevel: config.logLevel,
+    httpRequestTimeoutMs: config.httpRequestTimeoutMs,
+    httpHeadersTimeoutMs: config.httpHeadersTimeoutMs,
+    httpKeepAliveTimeoutMs: config.httpKeepAliveTimeoutMs,
     allowInsecureLocalhostCimd: config.allowInsecureLocalhostCimd,
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -362,6 +362,20 @@ export function loadRemoteServerConfig(): RemoteServerConfig {
     );
   }
 
+  // Resolve HTTP timeouts (env override -> constant fallback) and enforce the
+  // Node.js invariant headersTimeout > keepAliveTimeout. Otherwise idle keep-alive
+  // sockets get killed by the headers timer, producing flaky disconnects that are
+  // hard to attribute. Validating against resolved values catches mixed cases where
+  // only one of the two envs is overridden.
+  const httpRequestTimeoutMs = env.HTTP_REQUEST_TIMEOUT_MS ?? HTTP_REQUEST_TIMEOUT_MS;
+  const httpHeadersTimeoutMs = env.HTTP_HEADERS_TIMEOUT_MS ?? HTTP_HEADERS_TIMEOUT_MS;
+  const httpKeepAliveTimeoutMs = env.HTTP_KEEP_ALIVE_TIMEOUT_MS ?? HTTP_KEEP_ALIVE_TIMEOUT_MS;
+  if (httpHeadersTimeoutMs <= httpKeepAliveTimeoutMs) {
+    throw new Error(
+      `Invalid environment configuration: HTTP_HEADERS_TIMEOUT_MS (${httpHeadersTimeoutMs}) must be greater than HTTP_KEEP_ALIVE_TIMEOUT_MS (${httpKeepAliveTimeoutMs}).`,
+    );
+  }
+
   return {
     port: parsePort(env.PORT, 3000),
     issuerUrl: env.ISSUER_URL,
@@ -378,9 +392,9 @@ export function loadRemoteServerConfig(): RemoteServerConfig {
     corsAllowedOrigins: env.CORS_ALLOWED_ORIGINS,
     rateLimitEnabled,
     logLevel: env.LOG_LEVEL || 'info',
-    httpRequestTimeoutMs: env.HTTP_REQUEST_TIMEOUT_MS ?? HTTP_REQUEST_TIMEOUT_MS,
-    httpHeadersTimeoutMs: env.HTTP_HEADERS_TIMEOUT_MS ?? HTTP_HEADERS_TIMEOUT_MS,
-    httpKeepAliveTimeoutMs: env.HTTP_KEEP_ALIVE_TIMEOUT_MS ?? HTTP_KEEP_ALIVE_TIMEOUT_MS,
+    httpRequestTimeoutMs,
+    httpHeadersTimeoutMs,
+    httpKeepAliveTimeoutMs,
     allowInsecureLocalhostCimd,
   };
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,3 +74,10 @@ export const OAUTH_KEY_PREFIX = 'freee-mcp:oauth';
 export const FETCH_TIMEOUT_TOKEN_MS = 10_000; // Token exchange / refresh
 export const FETCH_TIMEOUT_USERINFO_MS = 10_000; // User info fetch
 export const FETCH_TIMEOUT_API_MS = 30_000; // freee API calls (MCP tools)
+
+// HTTP server timeouts for serve mode (Streamable-HTTP / SSE long-lived connections).
+// Defaults; per-environment override via HTTP_REQUEST_TIMEOUT_MS / HTTP_HEADERS_TIMEOUT_MS / HTTP_KEEP_ALIVE_TIMEOUT_MS.
+// Node requires headersTimeout > keepAliveTimeout, otherwise idle keep-alive sockets get killed by the headers timer.
+export const HTTP_REQUEST_TIMEOUT_MS = 10 * 60 * 1000; // 10m
+export const HTTP_HEADERS_TIMEOUT_MS = 65 * 1000; // 65s
+export const HTTP_KEEP_ALIVE_TIMEOUT_MS = 60 * 1000; // 60s

--- a/src/server/http-server.test.ts
+++ b/src/server/http-server.test.ts
@@ -12,6 +12,9 @@ const mockRemoteConfig = {
   scope: 'read write',
   freeeApiUrl: 'https://api.freee.co.jp',
   redisUrl: 'redis://localhost:6379',
+  httpRequestTimeoutMs: 600_000,
+  httpHeadersTimeoutMs: 65_000,
+  httpKeepAliveTimeoutMs: 60_000,
 };
 
 vi.mock('../config.js', () => ({
@@ -293,5 +296,15 @@ describe('HTTP Server - config integration', () => {
     expect(mockRemoteConfig.issuerUrl).toBe('https://mcp.example.com');
     expect(mockRemoteConfig.jwtSecret).toBeDefined();
     expect(mockRemoteConfig.jwtSecret.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it('should expose HTTP server timeouts so app.listen() can pin them', () => {
+    expect(mockRemoteConfig.httpRequestTimeoutMs).toBe(600_000);
+    expect(mockRemoteConfig.httpHeadersTimeoutMs).toBe(65_000);
+    expect(mockRemoteConfig.httpKeepAliveTimeoutMs).toBe(60_000);
+    // Node requires headersTimeout > keepAliveTimeout to avoid killing idle keep-alive sockets.
+    expect(mockRemoteConfig.httpHeadersTimeoutMs).toBeGreaterThan(
+      mockRemoteConfig.httpKeepAliveTimeoutMs,
+    );
   });
 });

--- a/src/server/http-server.ts
+++ b/src/server/http-server.ts
@@ -324,6 +324,13 @@ export async function startHttpServer(options?: {
     logger.info({ port: remoteConfig.port }, 'freee MCP HTTP server listening');
   });
 
+  // Pin Node-side HTTP server timeouts for long-lived MCP Streamable-HTTP / SSE connections.
+  // Node defaults: requestTimeout=300_000, headersTimeout=60_000, keepAliveTimeout=5_000.
+  // Node requires headersTimeout > keepAliveTimeout; values are configurable via env.
+  server.requestTimeout = remoteConfig.httpRequestTimeoutMs;
+  server.headersTimeout = remoteConfig.httpHeadersTimeoutMs;
+  server.keepAliveTimeout = remoteConfig.httpKeepAliveTimeoutMs;
+
   // Graceful shutdown
   let shuttingDown = false;
   async function shutdown(signal: string): Promise<void> {

--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -30,8 +30,8 @@ export function getHttpRequestDuration(): Histogram {
  * SSE (Streamable-HTTP) connection lifetime histogram (seconds).
  *
  * Recorded only for `transport=sse` requests at connection close. The expected
- * distribution clusters near the route's `streamIdleTimeout` (e.g. ~600s on
- * Istio's default HTTPRoute), so the p99 reveals whether SSE clients are
+ * distribution clusters near the route's per-request timeout (e.g. ~1200s on
+ * the configured HTTPRoute), so the p99 reveals whether SSE clients are
  * disconnecting early or running until the platform max — useful when
  * triaging `envoy.cluster.upstream_rq_timeout` alerts which alone cannot
  * distinguish "long but normal SSE" from "slow JSON-RPC".


### PR DESCRIPTION
## 概要

freee-mcp の serve モード HTTP server に Node.js タイムアウトを明示設定し、long-lived な MCP Streamable-HTTP / SSE 接続を考慮した値 (10m / 65s / 60s) をデフォルトに採用します。各値は環境変数で上書き可能。

これは現在 production で発火している P2 alarm `envoy upstream request timeout` (cluster `outbound_3000_freee-mcp-web`) の **first move** であり、同時に **5m timeout の発火 layer (Node `requestTimeout` か Envoy `stream_idle_timeout` か)** を staging で識別する診断ツールも兼ねます。

## 変更種別

- [x] その他 (タイムアウト・運用設定の明示化、診断目的を兼ねる)

## 変更内容

| 領域 | 変更 |
|---|---|
| `src/constants.ts` | `HTTP_REQUEST_TIMEOUT_MS` (10m) / `HTTP_HEADERS_TIMEOUT_MS` (65s) / `HTTP_KEEP_ALIVE_TIMEOUT_MS` (60s) を新規定義 |
| `src/config.ts` | `RemoteServerConfig` に 3 フィールド追加。zod schema (`positiveIntEnv()` ヘルパー経由、正の整数バリデーション)、`loadRemoteServerConfig` の env パース、`summarizeRemoteServerConfig` のログ出力に反映 |
| `src/server/http-server.ts` | `app.listen()` 直後に `server.requestTimeout` / `headersTimeout` / `keepAliveTimeout` を `remoteConfig` から代入 |
| `src/telemetry/metrics.ts` | `getMcpSseConnectionDuration` の docstring を実 HTTPRoute 設定値 (~1200s) に合わせて訂正 |
| tests | `src/server/http-server.test.ts` / `src/config-remote.test.ts` に 3 フィールドのデフォルト・env オーバーライド・不正値拒否のアサーションを追加 (765 tests, all pass) |
| `.changeset/explicit-http-server-timeouts.md` | patch レベル changeset を追加 |

## 設計判断

- **Node 推奨制約**: `headersTimeout > keepAliveTimeout` を満たす値 (65s > 60s) を採用。この制約はテストでも明示的に検証
- **Keep-alive layer**: HTTP-level (`server.keepAliveTimeout`) のみ採用。TCP-level (`socket.setKeepAlive`) は requestTimeout=10m が half-open 寿命をキャップするため初回 PR では追加せず、staging 観測で half-open 累積が見えれば follow-up
- **env 上書き**: `positiveIntEnv` ヘルパーで 3 種を一括バリデーション (z.coerce.number().int().positive().optional())。零・負数・非数値は明示エラーで起動時失敗

## 検証 (Verification)

### Local

```sh
bun run typecheck   # ✅ clean
bun run lint        # ✅ clean (biome)
bun run test:run    # ✅ 56 files, 765 tests passed
bun run build       # ✅ 4 binaries built
```

ローカル code-review-trio (simplify + security-review + naguru-chan + CodeRabbit) も並列実行済み。Critical / High / Medium 共に新規発見なし。simplify の Medium 1 件 (zod schema 重複) は本 PR 内で `positiveIntEnv()` ヘルパー抽出により解消済み。

### Staging 検証手順 (rollout 後)

1. staging に本 PR を反映
2. `mcp.sse.connection.duration` (histogram, `src/telemetry/metrics.ts:41`) の p99 と Envoy アクセスログを観察
3. **判定分岐**:
   - **timeout 分布が ~600s 付近に移動** → 原因は **Node `server.requestTimeout`** で確定。production 展開で alarm 解消
   - **依然 ~300s 付近で打ち切られている** → 原因は **Envoy HCM `stream_idle_timeout` (default 300s)** で確定。`chart-libs/apps/istio-gateway` / `istio-waypoint` どちらか (freee-mcp traffic が通る側) に override を入れる SRE 相談 PR を別建て (cross-repo, 本 PR スコープ外)

つまりアプリ側を先に直すこと自体が **診断ツールとしても機能** します。Node が原因でも Envoy が原因でも、Node 側の明示は衛生作業として必要なので、どちらに転んでも無駄になりません。

## 参考

- 詳細な調査ログ (clusterops + datadog-infra 側現状, monitor 仕様, Step1/2/3 分岐) は #133 issue コメントを参照

Closes #133
