### PR TITLE
skillsが間違ってたので修正

### DIFF
--- a/skills/freee-api-skill/recipes/hr-attendance-operations.md
+++ b/skills/freee-api-skill/recipes/hr-attendance-operations.md
@@ -78,8 +78,7 @@ freee_api_put {
 ```
 freee_api_get {
   "service": "hr",
-  "path": "/api/v1/users/me",
-  "query": { "company_id": 123456 }
+  "path": "/api/v1/users/me"
 }
 ```
 

--- a/skills/freee-api-skill/recipes/pm-workload-registration.md
+++ b/skills/freee-api-skill/recipes/pm-workload-registration.md
@@ -58,10 +58,7 @@ freee_api_get {
 ```
 freee_api_get {
   "service": "hr",
-  "path": "/api/v1/users/me",
-  "query": {
-    "company_id": 123456
-  }
+  "path": "/api/v1/users/me"
 }
 ```
 


### PR DESCRIPTION
## 概要

https://developer.freee.co.jp/reference/hr/reference#/%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC/get_users_me
の `/api/v1/users/me` を叩く時に `company_id` のパラメータがあると 403 になることが判明したので skills から削除。↑の API リファレンスにも parameters は無しで良いと記載されている。