### PR TITLE
chore: #443 の changeset を追加

### DIFF
--- a/.changeset/fix-hr-skill-users-me-company-id.md
+++ b/.changeset/fix-hr-skill-users-me-company-id.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+skill レシピを修正: `/api/v1/users/me` 呼び出し時に `company_id` を付与すると 403 になる問題を反映し、人事労務・工数管理レシピのサンプルから `company_id` パラメータを削除


### PR DESCRIPTION
## 概要

#443 で changeset の追加が漏れていたので追加する。

#443 はskillレシピの修正（`/api/v1/users/me` 呼び出し時に `company_id` を付けると 403 になる問題に対応してサンプルから `company_id` を削除）なので、bump type は `patch` とした。