### PR TITLE
fix(security): prevent prototype pollution in setCurrentCompany

### DIFF
--- a/.changeset/fix-prototype-pollution-set-current-company.md
+++ b/.changeset/fix-prototype-pollution-set-current-company.md
@@ -1,0 +1,9 @@
+---
+'freee-mcp': patch
+---
+
+freee_set_current_company の company_id にプロトタイプ汚染を引き起こす予約キーを渡せる脆弱性を修正
+
+- `__proto__` / `constructor` / `prototype` を弾くガードを追加
+- companies レコードのルックアップを `Object.hasOwn` ベースに変更
+- MCP ツールの入力スキーマに数字のみを受け付ける regex 検証を追加

--- a/src/config/companies.test.ts
+++ b/src/config/companies.test.ts
@@ -191,6 +191,22 @@ describe('companies', () => {
 
       expect(mockFs.writeFile).toHaveBeenCalled();
     });
+
+    it.each(['__proto__', 'constructor', 'prototype'])(
+      'should reject reserved key %s to prevent prototype pollution',
+      async (reserved) => {
+        mockFs.readFile.mockResolvedValue(JSON.stringify(validConfig));
+        mockFs.mkdir.mockResolvedValue(undefined);
+        mockFs.writeFile.mockResolvedValue(undefined);
+
+        await expect(setCurrentCompany(reserved, 'polluted', 'polluted')).rejects.toThrow(
+          /Invalid company ID/,
+        );
+        expect(mockFs.writeFile).not.toHaveBeenCalled();
+        // biome-ignore lint/suspicious/noPrototypeBuiltins: verifying no pollution occurred
+        expect(({}).hasOwnProperty('name')).toBe(false);
+      },
+    );
   });
 
   describe('getCompanyInfo', () => {
@@ -210,5 +226,14 @@ describe('companies', () => {
 
       expect(result).toBeNull();
     });
+
+    it.each(['__proto__', 'constructor', 'prototype'])(
+      'should reject reserved key %s instead of leaking prototype values',
+      async (reserved) => {
+        mockFs.readFile.mockResolvedValue(JSON.stringify(validConfig));
+
+        await expect(getCompanyInfo(reserved)).rejects.toThrow(/Invalid company ID/);
+      },
+    );
   });
 });

--- a/src/config/companies.ts
+++ b/src/config/companies.ts
@@ -157,6 +157,17 @@ export async function getCurrentCompanyId(): Promise<string> {
   return config.currentCompanyId;
 }
 
+// Reserved property keys that must never be used as bracket-access keys on a
+// plain object — assigning to them would mutate Object.prototype (prototype
+// pollution).
+const RESERVED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function assertSafeCompanyId(companyId: string): void {
+  if (RESERVED_KEYS.has(companyId)) {
+    throw new Error(`Invalid company ID: ${companyId}`);
+  }
+}
+
 /**
  * Set current company
  */
@@ -166,9 +177,10 @@ export async function setCurrentCompany(
   description?: string,
   display_name?: string,
 ): Promise<void> {
+  assertSafeCompanyId(companyId);
   const config = await loadFullConfig();
 
-  if (!config.companies[companyId]) {
+  if (!Object.hasOwn(config.companies, companyId)) {
     config.companies[companyId] = {
       id: companyId,
       name,
@@ -177,9 +189,10 @@ export async function setCurrentCompany(
       addedAt: Date.now(),
     };
   } else {
-    if (name !== undefined) config.companies[companyId].name = name;
-    if (display_name !== undefined) config.companies[companyId].display_name = display_name;
-    if (description !== undefined) config.companies[companyId].description = description;
+    const entry = config.companies[companyId];
+    if (name !== undefined) entry.name = name;
+    if (display_name !== undefined) entry.display_name = display_name;
+    if (description !== undefined) entry.description = description;
   }
 
   // Update last used timestamp
@@ -195,8 +208,10 @@ export async function setCurrentCompany(
  * Get company info by ID
  */
 export async function getCompanyInfo(companyId: string): Promise<CompanyConfig | null> {
+  assertSafeCompanyId(companyId);
   const config = await loadFullConfig();
-  return config.companies[companyId] || null;
+  if (!Object.hasOwn(config.companies, companyId)) return null;
+  return config.companies[companyId] ?? null;
 }
 
 /**

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -275,7 +275,10 @@ export function addAuthenticationTools(server: McpServer, options?: { remote?: b
       title: '事業所設定',
       description: '事業所を設定・切り替え (詳細ガイドはfreee-api-skill skillを参照)',
       inputSchema: {
-        company_id: z.string().describe('事業所ID'),
+        company_id: z
+          .string()
+          .regex(/^[0-9]+$/, '事業所IDは数字のみ指定してください')
+          .describe('事業所ID'),
         name: z.string().optional().describe('事業所名'),
         description: z.string().optional().describe('説明'),
       },


### PR DESCRIPTION
## 概要

`freee_set_current_company` MCP ツールの `company_id` 入力にプロトタイプ汚染（Prototype Pollution）を引き起こす予約キーを渡せる脆弱性を修正します。

`__proto__` / `constructor` / `prototype` を `company_id` として渡すと、`src/config/companies.ts` の `setCurrentCompany` が `Object.prototype` のプロパティ（`name` / `description` / `lastUsed`）に書き込みを行い、同一プロセス内のすべてのオブジェクトに副作用が及びます。stdio モード（`FileTokenStore`）が影響を受け、Redis ストアは `{ [companyId]: ... }` の computed-property 構文と HSET を使うため影響を受けません。

## 変更内容

多層防御で塞ぎます。

- `src/config/companies.ts`
  - 予約キー (`__proto__` / `constructor` / `prototype`) を早期に弾く `assertSafeCompanyId()` を追加し、`setCurrentCompany` / `getCompanyInfo` の入口で呼び出す
  - 既存判定 `if (!config.companies[companyId])` を `Object.hasOwn(config.companies, companyId)` に変更し、プロトタイプチェーン経由の真値読みを排除
  - `getCompanyInfo` も `Object.hasOwn` ガード経由でアクセス
- `src/mcp/tools.ts`
  - `freee_set_current_company` の `company_id` に `regex(/^[0-9]+$/)` を追加し、MCP 境界で数字以外の文字列を弾く
- `src/config/companies.test.ts`
  - 3 つの予約キーで `setCurrentCompany` / `getCompanyInfo` が throw すること、書き込みが発生しないこと、`Object.prototype` が汚染されないことを検証するリグレッションテストを追加
- `.changeset/fix-prototype-pollution-set-current-company.md`
  - patch バージョンの changeset

## 変更種別

- [ ] 新機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他

## 動作確認

- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run test:run src/config/companies.test.ts src/mcp/tools.test.ts src/storage/file-token-store.test.ts` 全件 pass
