### PR TITLE
fix(auth): CLI コールバックページの reflected XSS を修正

### DIFF
--- a/.changeset/fix-cli-callback-xss.md
+++ b/.changeset/fix-cli-callback-xss.md
@@ -1,0 +1,8 @@
+---
+"freee-mcp": patch
+---
+
+CLI 認証コールバックページの reflected XSS を修正
+
+- `error_description` 等の OAuth エラーパラメータを HTML エスケープしてから埋め込むように変更
+- 127.0.0.1 上で返す HTML レスポンスに CSP / `X-Content-Type-Options` / `Referrer-Policy` を付与

--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -1,0 +1,120 @@
+import http from 'node:http';
+import net from 'node:net';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config.js', () => ({
+  getConfig: (): {
+    auth: { timeoutMs: number };
+    oauth: { callbackPort: number };
+  } => ({
+    auth: { timeoutMs: 60_000 },
+    oauth: { callbackPort: 0 },
+  }),
+}));
+
+vi.mock('./oauth.js', () => ({
+  exchangeCodeForTokens: vi.fn(),
+}));
+
+import { getDefaultAuthManager, startCallbackServer, stopCallbackServer } from './server.js';
+
+async function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (typeof address === 'object' && address) {
+        const port = address.port;
+        server.close(() => resolve(port));
+      } else {
+        reject(new Error('Failed to obtain free port'));
+      }
+    });
+  });
+}
+
+interface RawResponse {
+  statusCode: number;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}
+
+async function getRaw(url: string): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => {
+        resolve({
+          statusCode: res.statusCode ?? 0,
+          headers: res.headers,
+          body: Buffer.concat(chunks).toString('utf8'),
+        });
+      });
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+  });
+}
+
+describe('CallbackServer HTML response safety', () => {
+  let port: number;
+
+  beforeEach(async () => {
+    port = await findFreePort();
+    await startCallbackServer(port);
+  });
+
+  afterEach(() => {
+    stopCallbackServer();
+    getDefaultAuthManager().clearAllPending();
+  });
+
+  it('escapes HTML in error_description to prevent reflected XSS', async () => {
+    const payload = '<img src=x onerror=alert(1)>';
+    const url = `http://127.0.0.1:${port}/callback?error=access_denied&error_description=${encodeURIComponent(payload)}`;
+
+    const response = await getRaw(url);
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).not.toContain('<img src=x onerror=alert(1)>');
+    expect(response.body).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  it('falls back to escaped error code when error_description is missing', async () => {
+    const payload = '<svg/onload=alert(1)>';
+    const url = `http://127.0.0.1:${port}/callback?error=${encodeURIComponent(payload)}`;
+
+    const response = await getRaw(url);
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).not.toContain(payload);
+    expect(response.body).toContain('&lt;svg/onload=alert(1)&gt;');
+  });
+
+  it('returns hardening headers (CSP, nosniff) on HTML responses', async () => {
+    const response = await getRaw(`http://127.0.0.1:${port}/callback?error=foo`);
+
+    expect(response.headers['content-type']).toBe('text/html; charset=utf-8');
+    expect(response.headers['content-security-policy']).toContain("default-src 'none'");
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+    expect(response.headers['referrer-policy']).toBe('no-referrer');
+  });
+
+  it('applies the same hardening headers to the index page', async () => {
+    const response = await getRaw(`http://127.0.0.1:${port}/`);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-security-policy']).toContain("default-src 'none'");
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('applies the same hardening headers to the 404 page', async () => {
+    const response = await getRaw(`http://127.0.0.1:${port}/does-not-exist`);
+
+    expect(response.statusCode).toBe(404);
+    expect(response.headers['content-security-policy']).toContain("default-src 'none'");
+  });
+});

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -12,6 +12,22 @@ interface PendingAuthentication {
   timeout: NodeJS.Timeout;
 }
 
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const HTML_RESPONSE_HEADERS = {
+  'Content-Type': 'text/html; charset=utf-8',
+  'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'",
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'no-referrer',
+} as const;
+
 interface CliAuthHandler {
   resolve: (code: string) => void;
   reject: (error: Error) => void;
@@ -171,10 +187,10 @@ class CallbackServer {
         if (url.pathname === '/callback') {
           this.handleCallback(url, res);
         } else if (url.pathname === '/') {
-          res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+          res.writeHead(200, HTML_RESPONSE_HEADERS);
           res.end('<h1>freee MCP OAuth Server</h1><p>コールバックサーバーが稼働中です。</p>');
         } else {
-          res.writeHead(404, { 'Content-Type': 'text/html; charset=utf-8' });
+          res.writeHead(404, HTML_RESPONSE_HEADERS);
           res.end('<h1>404 Not Found</h1><p>このパスは存在しません。</p>');
         }
       });
@@ -246,8 +262,8 @@ class CallbackServer {
     if (error) {
       const errorMsg = errorDescription || error;
       console.error(`OAuth error: ${error} - ${errorDescription}`);
-      res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
-      res.end(`<h1>認証エラー</h1><p>認証に失敗しました: ${errorMsg}</p>`);
+      res.writeHead(400, HTML_RESPONSE_HEADERS);
+      res.end(`<h1>認証エラー</h1><p>認証に失敗しました: ${escapeHtml(errorMsg)}</p>`);
 
       if (cliHandler) {
         cliHandler.reject(new Error(`OAuth error: ${error} - ${errorDescription}`));
@@ -264,7 +280,7 @@ class CallbackServer {
 
     if (!code || !state) {
       console.error(`Missing code or state`);
-      res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.writeHead(400, HTML_RESPONSE_HEADERS);
       res.end('<h1>認証エラー</h1><p>認証コードまたは状態パラメータが不足しています。</p>');
       return;
     }
@@ -272,7 +288,7 @@ class CallbackServer {
     // Handle CLI authentication
     if (cliHandler) {
       console.error(`Valid CLI callback received`);
-      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.writeHead(200, HTML_RESPONSE_HEADERS);
       res.end(
         '<h1>認証完了</h1><p>認証が完了しました。このページを閉じてターミナルに戻ってください。</p>',
       );
@@ -284,7 +300,7 @@ class CallbackServer {
     const pendingAuth = this.authManager.getPendingAuthentication(state);
     if (!pendingAuth) {
       console.error(`Unknown state: ${state}`);
-      res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.writeHead(400, HTML_RESPONSE_HEADERS);
       res.end('<h1>認証エラー</h1><p>不明な認証状態です。認証を再開してください。</p>');
       return;
     }
@@ -302,7 +318,7 @@ class CallbackServer {
       pendingAuth.resolve(tokens);
 
       // 成功時のみ「認証完了」を表示
-      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.writeHead(200, HTML_RESPONSE_HEADERS);
       res.end('<h1>認証完了</h1><p>認証が完了しました。このページを閉じてください。</p>');
     } catch (exchangeError) {
       console.error(`Token exchange failed:`, exchangeError);
@@ -311,8 +327,8 @@ class CallbackServer {
       // エラー時は「認証エラー」を表示
       const errorMessage =
         exchangeError instanceof Error ? exchangeError.message : String(exchangeError);
-      res.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });
-      res.end(`<h1>認証エラー</h1><p>トークン交換に失敗しました: ${errorMessage}</p>`);
+      res.writeHead(500, HTML_RESPONSE_HEADERS);
+      res.end(`<h1>認証エラー</h1><p>トークン交換に失敗しました: ${escapeHtml(errorMessage)}</p>`);
     } finally {
       this.authManager.removePendingAuthentication(state);
     }
@@ -332,7 +348,10 @@ export async function startCallbackServer(port?: number): Promise<void> {
   return defaultCallbackServer.start(port);
 }
 
-export async function startCallbackServerWithAutoStop(timeoutMs: number, port?: number): Promise<void> {
+export async function startCallbackServerWithAutoStop(
+  timeoutMs: number,
+  port?: number,
+): Promise<void> {
   await defaultCallbackServer.start(port);
   defaultCallbackServer.scheduleAutoStop(timeoutMs);
 }


### PR DESCRIPTION
## 概要

CLI 認証コールバックサーバー (`http://127.0.0.1:54321/callback` / sign は 54322) で発生していた reflected XSS を修正。

OAuth プロバイダから返ってくる `error_description` などのクエリパラメータを HTML エスケープせず `text/html` レスポンスに埋め込んでいたため、攻撃者が制御する HTML/JS が `127.0.0.1` オリジンで実行可能だった。ループバックオリジンは特権的に扱われるブラウザが多く、他のローカルサービスへのプロービング・Private Network Access 試行・偽の認証完了ページによるフィッシングなどに悪用される懸念があった。

## 変更種別

- [x] バグ修正

## 変更内容

- `escapeHtml()` を追加し、`errorDescription` / `error` / トークン交換エラーメッセージを全てエスケープ
- HTML レスポンスに `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'`、`X-Content-Type-Options: nosniff`、`Referrer-Policy: no-referrer` を付与（多層防御）
- 各 `res.writeHead()` の `Content-Type` 直書きを `HTML_RESPONSE_HEADERS` 定数に統一して、ヘッダ漏れの再発を防止
- 回帰テスト `src/auth/server.test.ts` を新規追加（実 HTTP で `<img onerror>` / `<svg onload>` が中立化されることと、各エンドポイントでハードニングヘッダが返ることを検証）

## 動作確認

- `bun run typecheck`
- `bun run test:run`（58 ファイル / 776 テスト全通過、新規 5 テスト含む）
- `bun run build`
