### PR TITLE
fix(client-mode): publish coercibleRecord as anyOf[object|string] for client-side validators (#410)

### DIFF
--- a/.changeset/coercible-record-anyof-jsonschema.md
+++ b/.changeset/coercible-record-anyof-jsonschema.md
@@ -1,0 +1,5 @@
+---
+"freee-mcp": patch
+---
+
+`freee_api_*` の body/query が JSON 文字列で届くケースで、一部の MCP クライアントによる送信前バリデーションで弾かれていた問題を修正した。

--- a/src/openapi/client-mode.test.ts
+++ b/src/openapi/client-mode.test.ts
@@ -1,5 +1,14 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ZodIssue } from 'zod';
+
+function collectIssueMessages(issues: ZodIssue[]): string[] {
+  return issues.flatMap((issue) =>
+    issue.code === 'invalid_union'
+      ? issue.unionErrors.flatMap((err) => collectIssueMessages(err.issues))
+      : [issue.message],
+  );
+}
 
 // Privacy regression tests: query values and request bodies must never appear
 // in the canonical log payload emitted by RequestRecorder.
@@ -195,7 +204,8 @@ describe('coercibleRecord', () => {
     const result = schema.safeParse(`${bom}{"a":1}`);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0].message).toMatch(/UTF-8 BOM/);
+      const messages = collectIssueMessages(result.error.issues);
+      expect(messages.some((m) => m.includes('UTF-8 BOM'))).toBe(true);
     }
   });
 
@@ -214,11 +224,47 @@ describe('coercibleRecord', () => {
     const result = schema.safeParse(SECRET);
     expect(result.success).toBe(false);
     if (!result.success) {
-      const message = result.error.issues[0].message;
-      expect(message).toMatch(/length \d+/);
-      expect(message).not.toContain('Acme');
-      expect(message).not.toContain('SECRET');
-      expect(message).not.toContain('partner_name');
+      const messages = collectIssueMessages(result.error.issues);
+      expect(messages.some((m) => /length \d+/.test(m))).toBe(true);
+      for (const message of messages) {
+        expect(message).not.toContain('Acme');
+        expect(message).not.toContain('SECRET');
+        expect(message).not.toContain('partner_name');
+      }
     }
+  });
+
+  it('publishes anyOf JSON Schema so MCP clients accept both object and string bodies', async () => {
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+    const { InMemoryTransport } = await import('@modelcontextprotocol/sdk/inMemory.js');
+    const { coercibleRecord } = await import('./client-mode.js');
+
+    const server = new McpServer({ name: 'test', version: '1.0.0' });
+    server.registerTool(
+      'with_body',
+      { inputSchema: { body: coercibleRecord('body') } },
+      async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }),
+    );
+
+    const [serverT, clientT] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'tester', version: '1.0.0' });
+    await Promise.all([server.connect(serverT), client.connect(clientT)]);
+
+    const tools = await client.listTools();
+    const tool = tools.tools.find((t) => t.name === 'with_body');
+    if (!tool) throw new Error('tool not registered');
+
+    type ToolInputSchema = { properties: { body: { anyOf?: Array<{ type?: string }> } }; required?: string[] };
+    const inputSchema = tool.inputSchema as ToolInputSchema;
+    expect(inputSchema.properties.body.anyOf).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'object' }),
+        expect.objectContaining({ type: 'string' }),
+      ]),
+    );
+    expect(inputSchema.required).toContain('body');
+
+    await client.close();
   });
 });

--- a/src/openapi/client-mode.ts
+++ b/src/openapi/client-mode.ts
@@ -21,46 +21,44 @@ const serviceSchema = z
 
 const UTF8_BOM = String.fromCharCode(0xfeff);
 
-/**
- * Some MCP clients send object parameters as JSON strings. This wrapper
- * accepts both a plain object and a JSON string, coercing the latter.
- *
- * A leading UTF-8 BOM (U+FEFF) is rejected with a dedicated error rather than
- * silently stripped: silent normalization would make the same payload behave
- * differently across operating systems and hide upstream encoding bugs. The
- * generic parse-failure message intentionally carries only the string length —
- * never any portion of the raw string — so customer payload data cannot leak
- * into error responses or downstream logs.
- */
+// Top-level union (record | string-decoding-to-record) rather than
+// `z.preprocess(..., z.record(...))` so the JSON Schema published via
+// tools/list becomes `anyOf: [{type: "object"}, {type: "string"}]`. Some MCP
+// clients validate arguments against the published JSON Schema before
+// forwarding the call, and `{type: "object"}` alone causes them to reject
+// string-shaped bodies before the server-side coercion can run (issue #410).
+const recordSchema = z.record(z.string(), z.unknown());
+const jsonStringToRecord = z
+  .string()
+  .transform((val, ctx) => {
+    if (val.startsWith(UTF8_BOM)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          `string starts with a UTF-8 BOM (U+FEFF), which is not valid JSON. ` +
+          `The MCP client likely transcoded the payload through a transport ` +
+          `that prepended a BOM (commonly seen on Windows). ` +
+          `Send the JSON without a BOM.`,
+      });
+      return z.NEVER;
+    }
+    try {
+      return JSON.parse(val);
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          `expected object or JSON-encoded object string; received string ` +
+          `of length ${val.length} that could not be parsed as JSON`,
+      });
+      return z.NEVER;
+    }
+  })
+  .pipe(recordSchema);
+const coercibleRecordSchema = z.union([recordSchema, jsonStringToRecord]);
+
 export function coercibleRecord(description: string) {
-  return z.preprocess(
-    (val, ctx) => {
-      if (typeof val !== 'string') return val;
-      if (val.startsWith(UTF8_BOM)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message:
-            `string starts with a UTF-8 BOM (U+FEFF), which is not valid JSON. ` +
-            `The MCP client likely transcoded the payload through a transport ` +
-            `that prepended a BOM (commonly seen on Windows). ` +
-            `Send the JSON without a BOM.`,
-        });
-        return z.NEVER;
-      }
-      try {
-        return JSON.parse(val);
-      } catch {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message:
-            `expected object or JSON-encoded object string; received string ` +
-            `of length ${val.length} that could not be parsed as JSON`,
-        });
-        return z.NEVER;
-      }
-    },
-    z.record(z.string(), z.unknown()),
-  ).describe(description);
+  return coercibleRecordSchema.describe(description);
 }
 
 /**


### PR DESCRIPTION
## 概要

issue #410 の追加対応。PR #414 でサーバ側の `coercibleRecord` に preprocess を入れたが、報告者の v0.25.4 環境でも依然 `Expected object, received string` という旧フォーマットのエラーが返り、preprocess に到達していないことが確認できた。

調査の結果、`z.preprocess(..., z.record(...))` で構築した zod スキーマは tools/list で公開される JSON Schema 上は単なる `{type: "object"}` となり、送信前にクライアント側で JSON Schema バリデーションを行う MCP クライアント（Claude Code 等）では JSON 文字列の body を server に届く前に弾かれていた。報告されたエラーフォーマット (`expected: "object"`, `Expected object, received string`) は server 側 zod 3.25 の生メッセージ (`expected: "record"`, `Invalid input: expected record, received string`) とフォーマットが異なり、クライアント側バリデーターが返した形と整合する。

`coercibleRecord` を `record | string-that-decodes-to-record` の union に書き換え、公開 JSON Schema を `anyOf: [{type: "object"}, {type: "string"}]` にすることでクライアント側バリデーションを通過させ、サーバ側で従来どおり BOM 検出・length-only 失敗メッセージを返せるようにした。実機の stdio 経由で `freee_api_put.inputSchema.properties.body.anyOf` が想定通り出力されること、`required: ["body"]` が維持されることを確認。

スキーマ構築は module scope に hoist し、`coercibleRecord` 呼び出しごとに再構築しないようにしてある。テストは `InMemoryTransport` 経由で MCP SDK が実際に publish する JSON Schema を検証しており、`zod-to-json-schema` を直接呼ぶ簡略案は SDK 側の `pipeStrategy: 'input'` 等のオプションを再現できず罠になるため採らなかった。

なお preprocess ベースのまま inner schema を union に変える案も試したが、SDK が ZodEffects を optional 扱いして `required` から body が外れたため不採用とした。

## 変更種別

- [ ] 新機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] その他

Closes #410
