### PR TITLE
Fix for Comparison between inconvertible types

### DIFF
--- a/src/server/error-serializer.ts
+++ b/src/server/error-serializer.ts
@@ -93,7 +93,7 @@ export function serializeErrorChain(
 
     depth += 1;
     current =
-      typeof current === 'object' && current !== null
+      typeof current === 'object'
         ? (current as { cause?: unknown }).cause
         : undefined;
   }


### PR DESCRIPTION
To fix this without changing behavior, simplify the conditional expression that computes `current` at the end of the loop.

Best fix:
- In `src/server/error-serializer.ts`, update the ternary condition on lines 96–98.
- Replace:
  - `typeof current === 'object' && current !== null`
- With:
  - `typeof current === 'object'`

This preserves existing functionality because:
- The `while` guard already excludes `null` before entering the body.
- In this location, `current` is already checked for object-ness.
- The reassignment to `cause` remains unchanged.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._