### PR TITLE
chore: エラースクラブとツール annotation を改善

### DIFF
--- a/.changeset/tidy-ai-quality-findings.md
+++ b/.changeset/tidy-ai-quality-findings.md
@@ -1,0 +1,5 @@
+---
+'freee-mcp': patch
+---
+
+エラーメッセージのプライバシースクラブ強化、POST/PUT/PATCH/DELETE ツールへの destructiveHint 付与、その他コード品質改善。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 
 ### Patch Changes
 
-- [`70a7dae`](https://github.com/freee/freee-mcp/commit/70a7dae2f8cef8bad9afd617e200562dc678d722): ローカル開発用途で loopback の CIMD URL を受け入れるオプションを追加。 ([#429](https://github.com/freee/freee-mcp/pull/429))
+- [`70a7dae`](https://github.com/freee/freee-mcp/commit/70a7dae2f8cef8bad9afd617e200562dc678d722): ローカル開発用途で loopback の OIDC URL を受け入れるオプションを追加。 ([#429](https://github.com/freee/freee-mcp/pull/429))
 
   - dev/test 環境かつ Kubernetes Pod 外でのみ、`http://localhost` / `127.0.0.1` / `[::1]` の `client_id` を許可
   - 同条件で loopback の `https://` self-signed cert も受け入れ（mkcert 等のローカル検証向け）

--- a/src/auth/server.test.ts
+++ b/src/auth/server.test.ts
@@ -16,7 +16,13 @@ vi.mock('./oauth.js', () => ({
   exchangeCodeForTokens: vi.fn(),
 }));
 
-import { getDefaultAuthManager, startCallbackServer, stopCallbackServer } from './server.js';
+import {
+  AuthenticationManager,
+  getDefaultAuthManager,
+  startCallbackServer,
+  stopCallbackServer,
+} from './server.js';
+import type { TokenData } from './tokens.js';
 
 async function findFreePort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -116,5 +122,31 @@ describe('CallbackServer HTML response safety', () => {
 
     expect(response.statusCode).toBe(404);
     expect(response.headers['content-security-policy']).toContain("default-src 'none'");
+  });
+});
+
+describe('AuthenticationManager', () => {
+  it('stores caller-provided completion handlers for the callback server', () => {
+    const manager = new AuthenticationManager();
+    const resolve = vi.fn();
+    const reject = vi.fn();
+    const tokens: TokenData = {
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expires_at: Date.now() + 60_000,
+      token_type: 'Bearer',
+      scope: 'read write',
+    };
+
+    manager.registerAuthentication('state-1', 'verifier-1', resolve, reject);
+
+    const pending = manager.getPendingAuthentication('state-1');
+    expect(pending?.codeVerifier).toBe('verifier-1');
+
+    pending?.resolve(tokens);
+    expect(resolve).toHaveBeenCalledWith(tokens);
+    expect(reject).not.toHaveBeenCalled();
+
+    manager.removePendingAuthentication('state-1');
   });
 });

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -42,7 +42,20 @@ export class AuthenticationManager {
   private pendingAuthentications = new Map<string, PendingAuthentication>();
   private cliAuthHandlers = new Map<string, CliAuthHandler>();
 
-  registerAuthentication(state: string, codeVerifier: string): void {
+  /**
+   * Register a browser OAuth flow that will be completed by the callback server.
+   *
+   * The callback server owns code exchange and invokes these handlers once it has
+   * either exchanged the authorization code for tokens or hit an OAuth/exchange
+   * error. Keeping the handlers injectable prevents this manager from hiding a
+   * fixed no-op promise contract behind pending authentication state.
+   */
+  registerAuthentication(
+    state: string,
+    codeVerifier: string,
+    resolve: (tokens: TokenData) => void,
+    reject: (error: Error) => void,
+  ): void {
     console.error(`Registering authentication request with state: ${state.substring(0, 10)}...`);
     console.error(`Code verifier: ${codeVerifier.substring(0, 10)}...`);
 
@@ -53,12 +66,8 @@ export class AuthenticationManager {
 
     this.pendingAuthentications.set(state, {
       codeVerifier,
-      resolve: (_tokens: TokenData) => {
-        console.error('Authentication completed successfully!');
-      },
-      reject: (error: Error) => {
-        console.error('Authentication failed:', error);
-      },
+      resolve,
+      reject,
       timeout,
     });
 
@@ -150,7 +159,12 @@ class CallbackServer {
     return this.server !== null;
   }
 
-  // portOverride: サインなど freee の loadConfig() に依存しないモジュールが独自のポートを指定するため
+  /**
+   * Starts the OAuth callback server.
+   *
+   * `portOverride` allows modules (for example, sign-in flows) that do not
+   * depend on `loadConfig()` to specify a custom callback port explicitly.
+   */
   async start(portOverride?: number): Promise<void> {
     if (this.server) {
       console.error(
@@ -261,17 +275,18 @@ class CallbackServer {
 
     if (error) {
       const errorMsg = errorDescription || error;
-      console.error(`OAuth error: ${error} - ${errorDescription}`);
+      const oauthErrorMessage = `OAuth error: ${error} - ${errorDescription}`;
+      console.error(oauthErrorMessage);
       res.writeHead(400, HTML_RESPONSE_HEADERS);
       res.end(`<h1>認証エラー</h1><p>認証に失敗しました: ${escapeHtml(errorMsg)}</p>`);
 
       if (cliHandler) {
-        cliHandler.reject(new Error(`OAuth error: ${error} - ${errorDescription}`));
+        cliHandler.reject(new Error(oauthErrorMessage));
       } else if (state) {
         const pendingAuth = this.authManager.getPendingAuthentication(state);
         if (pendingAuth) {
           clearTimeout(pendingAuth.timeout);
-          pendingAuth.reject(new Error(`OAuth error: ${error} - ${errorDescription}`));
+          pendingAuth.reject(new Error(oauthErrorMessage));
           this.authManager.removePendingAuthentication(state);
         }
       }
@@ -357,7 +372,16 @@ export async function startCallbackServerWithAutoStop(
 }
 
 export function registerAuthenticationRequest(state: string, codeVerifier: string): void {
-  defaultAuthManager.registerAuthentication(state, codeVerifier);
+  defaultAuthManager.registerAuthentication(
+    state,
+    codeVerifier,
+    (_tokens: TokenData) => {
+      console.error('Authentication completed successfully!');
+    },
+    (error: Error) => {
+      console.error('Authentication failed:', error);
+    },
+  );
 }
 
 export function stopCallbackServer(): void {

--- a/src/openapi/client-mode.ts
+++ b/src/openapi/client-mode.ts
@@ -83,7 +83,11 @@ function createMethodTool(method: string) {
 
     try {
       const { service, path, query, body } = args;
-      setToolAttributes({ 'mcp.tool.service': service, 'mcp.tool.path': safePath, 'mcp.tool.method': method });
+      setToolAttributes({
+        'mcp.tool.service': service,
+        'mcp.tool.path': safePath,
+        'mcp.tool.method': method,
+      });
 
       const validation = validatePathForService(method, path, service);
       if (!validation.isValid) {
@@ -96,7 +100,10 @@ function createMethodTool(method: string) {
         recorder?.recordError({
           source: 'validation',
           error_type: 'path_validation_failed',
-          chain: makeErrorChain('ValidationError', validation.message ?? 'unknown validation error'),
+          chain: makeErrorChain(
+            'ValidationError',
+            validation.message ?? 'unknown validation error',
+          ),
         });
         return createTextResponse(
           `パス検証エラー: ${validation.message}\n\n` +
@@ -105,7 +112,14 @@ function createMethodTool(method: string) {
       }
 
       const actualPath = validation.actualPath ?? path;
-      const result = await makeApiRequest(method, actualPath, query, body, validation.baseUrl, tokenContext);
+      const result = await makeApiRequest(
+        method,
+        actualPath,
+        query,
+        body,
+        validation.baseUrl,
+        tokenContext,
+      );
 
       recorder?.recordToolCall({
         tool: toolName,
@@ -175,7 +189,8 @@ function createMethodTool(method: string) {
  */
 export function generateClientModeTool(server: McpServer): void {
   // GET tool
-  registerTracedTool(server,
+  registerTracedTool(
+    server,
     'freee_api_get',
     {
       title: 'freee API GET リクエスト',
@@ -191,7 +206,8 @@ export function generateClientModeTool(server: McpServer): void {
   );
 
   // POST tool
-  registerTracedTool(server,
+  registerTracedTool(
+    server,
     'freee_api_post',
     {
       title: 'freee API POST リクエスト',
@@ -202,13 +218,14 @@ export function generateClientModeTool(server: McpServer): void {
         body: coercibleRecord('リクエストボディ'),
         query: coercibleRecord('クエリパラメータ (オプション)').optional(),
       },
-      annotations: { destructiveHint: false },
+      annotations: { destructiveHint: true },
     },
     createMethodTool('POST'),
   );
 
   // PUT tool
-  registerTracedTool(server,
+  registerTracedTool(
+    server,
     'freee_api_put',
     {
       title: 'freee API PUT リクエスト',
@@ -219,13 +236,14 @@ export function generateClientModeTool(server: McpServer): void {
         body: coercibleRecord('リクエストボディ'),
         query: coercibleRecord('クエリパラメータ (オプション)').optional(),
       },
-      annotations: { destructiveHint: false, idempotentHint: true },
+      annotations: { destructiveHint: true, idempotentHint: true },
     },
     createMethodTool('PUT'),
   );
 
   // DELETE tool
-  registerTracedTool(server,
+  registerTracedTool(
+    server,
     'freee_api_delete',
     {
       title: 'freee API DELETE リクエスト',
@@ -235,13 +253,14 @@ export function generateClientModeTool(server: McpServer): void {
         path: z.string().describe('APIパス (例: /api/1/deals/123)'),
         query: coercibleRecord('クエリパラメータ (オプション)').optional(),
       },
-      annotations: { idempotentHint: true },
+      annotations: { destructiveHint: true, idempotentHint: true },
     },
     createMethodTool('DELETE'),
   );
 
   // PATCH tool
-  registerTracedTool(server,
+  registerTracedTool(
+    server,
     'freee_api_patch',
     {
       title: 'freee API PATCH リクエスト',
@@ -252,13 +271,14 @@ export function generateClientModeTool(server: McpServer): void {
         body: coercibleRecord('リクエストボディ'),
         query: coercibleRecord('クエリパラメータ (オプション)').optional(),
       },
-      annotations: { destructiveHint: false },
+      annotations: { destructiveHint: true },
     },
     createMethodTool('PATCH'),
   );
 
   // Add helper tool to list available paths
-  registerTracedTool(server,
+  registerTracedTool(
+    server,
     'freee_api_list_paths',
     {
       title: 'API エンドポイント一覧',

--- a/src/openapi/schema-loader.ts
+++ b/src/openapi/schema-loader.ts
@@ -102,12 +102,28 @@ const _loadedConfigs: Partial<Record<ApiType, ApiConfig>> = {};
 // Cached compiled regex patterns for path matching (per schema path)
 const _pathRegexCache = new Map<string, RegExp>();
 
+/**
+ * Build (and cache) a strict regex for matching concrete request paths to schema paths.
+ *
+ * Security assumption:
+ * Path parameters are treated as a single URL path segment and MUST NOT contain URL
+ * metacharacters such as `?`, `#`, `&`, or `=`.
+ *
+ * Rationale:
+ * Using `[^/?#&=]+` for `{param}` placeholders prevents query/fragment smuggling
+ * through path arguments (for example, `/resource/{id}` must not match
+ * `/resource/123?company_id=...`).
+ *
+ * This is a defense-in-depth control and complements request validation in
+ * `makeApiRequest`. Do not relax this to `[^/]+` without introducing equivalent
+ * canonicalization/validation guarantees.
+ */
 function getPathRegex(schemaPath: string): RegExp {
   let regex = _pathRegexCache.get(schemaPath);
   if (!regex) {
-    // URL メタ文字 (?, #, &, =) を placeholder にマッチさせない。
-    // `[^/]+` だと '/api/1/deals/{id}' が '/api/1/deals/123?company_id=B' を valid と扱い
-    // path argument 経由でクエリを smuggle されるため、明示的に除外する。
+    // Do not allow URL metacharacters (?, #, &, =) to match placeholders.
+    // Using `[^/]+` would treat '/api/1/deals/{id}' as matching
+    // '/api/1/deals/123?company_id=B', enabling query smuggling via a path argument.
     const pattern = schemaPath.replace(/\{[^}]+\}/g, '[^/?#&=]+');
     regex = new RegExp(`^${pattern}$`);
     _pathRegexCache.set(schemaPath, regex);
@@ -288,7 +304,7 @@ export function listAllAvailablePaths(): string {
 
   const sections: string[] = [];
 
-  for (const [, config] of Object.entries(API_CONFIGS) as [ApiType, ApiConfig][]) {
+  for (const config of Object.values(API_CONFIGS) as ApiConfig[]) {
     const paths = config.schema.paths;
     const pathList: string[] = [];
 

--- a/src/server/error-serializer.test.ts
+++ b/src/server/error-serializer.test.ts
@@ -3,9 +3,7 @@ import { makeErrorChain, scrubErrorMessage, serializeErrorChain } from './error-
 
 describe('scrubErrorMessage', () => {
   it('masks 6+ digit numeric IDs', () => {
-    expect(scrubErrorMessage('company_id=12345678 failed')).toBe(
-      'company_id=[REDACTED_ID] failed',
-    );
+    expect(scrubErrorMessage('company_id=12345678 failed')).toBe('company_id=[REDACTED_ID] failed');
   });
 
   it('leaves short integers (status codes, line numbers) alone', () => {
@@ -15,25 +13,28 @@ describe('scrubErrorMessage', () => {
   });
 
   it('masks email addresses', () => {
-    expect(scrubErrorMessage('User user@example.com failed')).toBe(
-      'User [REDACTED_EMAIL] failed',
-    );
+    expect(scrubErrorMessage('User user@example.com failed')).toBe('User [REDACTED_EMAIL] failed');
+  });
+
+  it('preserves punctuation around masked email addresses', () => {
+    expect(scrubErrorMessage('(user@example.com), owner')).toBe('([REDACTED_EMAIL]), owner');
   });
 
   it('masks both emails and numeric IDs in one pass', () => {
-    expect(scrubErrorMessage('user@x.io id=99999999')).toBe(
-      '[REDACTED_EMAIL] id=[REDACTED_ID]',
-    );
+    expect(scrubErrorMessage('user@x.io id=99999999')).toBe('[REDACTED_EMAIL] id=[REDACTED_ID]');
   });
 
   it('returns empty string unchanged', () => {
     expect(scrubErrorMessage('')).toBe('');
   });
 
+  it('stringifies non-string inputs before scrubbing', () => {
+    expect(scrubErrorMessage(12345678)).toBe('[REDACTED_ID]');
+    expect(scrubErrorMessage(null)).toBe('');
+  });
+
   it('returns plain messages unchanged', () => {
-    expect(scrubErrorMessage('timeout waiting for upstream')).toBe(
-      'timeout waiting for upstream',
-    );
+    expect(scrubErrorMessage('timeout waiting for upstream')).toBe('timeout waiting for upstream');
   });
 });
 

--- a/src/server/error-serializer.ts
+++ b/src/server/error-serializer.ts
@@ -37,9 +37,9 @@ const EMAIL_PATTERN =
  * - Email addresses.
  */
 export function scrubErrorMessage(input: unknown): string {
-  if (typeof input !== 'string') return scrubErrorMessage(String(input ?? ''));
-  if (input.length === 0) return input;
-  return input
+  const str = typeof input === 'string' ? input : String(input ?? '');
+  if (str.length === 0) return str;
+  return str
     .replace(EMAIL_PATTERN, '$1[REDACTED_EMAIL]')
     .replace(NUMERIC_ID_PATTERN, '[REDACTED_ID]');
 }

--- a/src/server/error-serializer.ts
+++ b/src/server/error-serializer.ts
@@ -19,8 +19,13 @@ const DEFAULT_MAX_CHAIN_DEPTH = 10;
 /** Match standalone numeric identifiers (6+ digits): company_id, user_id, timestamps. */
 const NUMERIC_ID_PATTERN = /\b\d{6,}\b/g;
 
-/** Simple email regex — intentionally permissive, prefer over-masking. */
-const EMAIL_PATTERN = /[\w.+-]+@[\w-]+\.[\w.-]+/g;
+/**
+ * Email-like token matcher for log redaction (not full RFC validation).
+ * Uses boundaries to reduce matching inside larger tokens while still
+ * preferring over-masking over under-masking.
+ */
+const EMAIL_PATTERN =
+  /(^|[^A-Za-z0-9._%+-])([A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,63})(?=$|[^A-Za-z0-9._%+-])/g;
 
 /**
  * Mask sensitive identifiers from a free-form error message.
@@ -31,9 +36,12 @@ const EMAIL_PATTERN = /[\w.+-]+@[\w-]+\.[\w.-]+/g;
  *   are intentionally left alone so stack traces stay readable.
  * - Email addresses.
  */
-export function scrubErrorMessage(input: string): string {
-  if (typeof input !== 'string' || input.length === 0) return input;
-  return input.replace(EMAIL_PATTERN, '[REDACTED_EMAIL]').replace(NUMERIC_ID_PATTERN, '[REDACTED_ID]');
+export function scrubErrorMessage(input: unknown): string {
+  if (typeof input !== 'string') return scrubErrorMessage(String(input ?? ''));
+  if (input.length === 0) return input;
+  return input
+    .replace(EMAIL_PATTERN, '$1[REDACTED_EMAIL]')
+    .replace(NUMERIC_ID_PATTERN, '[REDACTED_ID]');
 }
 
 /**
@@ -71,8 +79,8 @@ export function serializeErrorChain(
 
   while (current !== undefined && current !== null && depth < maxDepth) {
     if (typeof current === 'object') {
-      if (seen.has(current as object)) break;
-      seen.add(current as object);
+      if (seen.has(current)) break;
+      seen.add(current);
     }
 
     // serialize-error safely handles non-Error values, toJSON methods,
@@ -92,10 +100,7 @@ export function serializeErrorChain(
     });
 
     depth += 1;
-    current =
-      typeof current === 'object'
-        ? (current as { cause?: unknown }).cause
-        : undefined;
+    current = typeof current === 'object' ? (current as { cause?: unknown }).cause : undefined;
   }
 
   return chain;

--- a/src/sign/handlers.test.ts
+++ b/src/sign/handlers.test.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createSignMcpServer } from './handlers.js';
-import { addSignAuthenticationTools } from './tools.js';
+import { addSignApiTools, addSignAuthenticationTools } from './tools.js';
 
 vi.mock('./config.js', () => ({
   SIGN_SERVER_INSTRUCTIONS: 'freee サイン（電子契約）APIと連携するMCPサーバー。',
@@ -108,6 +108,29 @@ describe('sign/handlers', () => {
       const result = await handler();
 
       expect(result.content[0].text).toContain('transport: remote');
+    });
+
+    it('sign API mutating methods are marked destructive', () => {
+      addSignApiTools(mockServer);
+
+      const configs = new Map(
+        mockTool.mock.calls.map((call: unknown[]) => [
+          call[0] as string,
+          call[1] as { annotations?: Record<string, boolean> },
+        ]),
+      );
+
+      expect(configs.get('sign_api_get')?.annotations).toEqual({ readOnlyHint: true });
+      expect(configs.get('sign_api_post')?.annotations).toEqual({ destructiveHint: true });
+      expect(configs.get('sign_api_put')?.annotations).toEqual({
+        destructiveHint: true,
+        idempotentHint: true,
+      });
+      expect(configs.get('sign_api_patch')?.annotations).toEqual({ destructiveHint: true });
+      expect(configs.get('sign_api_delete')?.annotations).toEqual({
+        destructiveHint: true,
+        idempotentHint: true,
+      });
     });
   });
 });

--- a/src/sign/tools.ts
+++ b/src/sign/tools.ts
@@ -199,7 +199,7 @@ export function addSignApiTools(server: McpServer, options?: { remote?: boolean 
         .describe('APIパス (例: /v1/documents)'),
       query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ'),
     };
-    const inputSchema: Record<string, z.ZodTypeAny> = hasBody
+    const inputSchema = hasBody
       ? {
           ...baseSchema,
           body: z.record(z.string(), z.unknown()).optional().describe('リクエストボディ'),

--- a/src/sign/tools.ts
+++ b/src/sign/tools.ts
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { getDefaultAuthManager, startCallbackServerWithAutoStop } from '../auth/server.js';
 import { AUTH_TIMEOUT_MS, PACKAGE_VERSION } from '../constants.js';
@@ -12,6 +13,7 @@ import type { SignTokenStore } from './server/sign-redis-token-store.js';
 import { clearSignTokens, isSignTokenValid, loadSignTokens } from './tokens.js';
 
 type SignAuthExtra = { authInfo?: { extra?: Record<string, unknown> } };
+type SignApiMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
 function extractSignTokenContext(extra?: SignAuthExtra): SignTokenContext | undefined {
   const authExtra = extra?.authInfo?.extra;
@@ -37,6 +39,18 @@ function resolveTokenContext(
     );
   }
   return ctx;
+}
+
+function getSignApiToolAnnotations(method: SignApiMethod): ToolAnnotations {
+  if (method === 'GET') {
+    return { readOnlyHint: true };
+  }
+
+  if (method === 'PUT' || method === 'DELETE') {
+    return { destructiveHint: true, idempotentHint: true };
+  }
+
+  return { destructiveHint: true };
 }
 
 function addSignAuthTools(server: McpServer, options?: { remote?: boolean }): void {
@@ -185,7 +199,7 @@ export function addSignApiTools(server: McpServer, options?: { remote?: boolean 
         .describe('APIパス (例: /v1/documents)'),
       query: z.record(z.string(), z.unknown()).optional().describe('クエリパラメータ'),
     };
-    const inputSchema = hasBody
+    const inputSchema: Record<string, z.ZodTypeAny> = hasBody
       ? {
           ...baseSchema,
           body: z.record(z.string(), z.unknown()).optional().describe('リクエストボディ'),
@@ -198,7 +212,7 @@ export function addSignApiTools(server: McpServer, options?: { remote?: boolean 
         title: desc,
         description: desc,
         inputSchema,
-        annotations: { readOnlyHint: method === 'GET' },
+        annotations: getSignApiToolAnnotations(method),
       },
       async (
         args: { path: string; query?: Record<string, unknown>; body?: Record<string, unknown> },


### PR DESCRIPTION
## 概要
- AI 品質指摘への対応として patch changeset を追加
- freee API / freee Sign API の状態変更系メソッドに `destructiveHint` を付与し、PUT/DELETE は `idempotentHint` も維持
- `AuthenticationManager` の完了ハンドラ注入の意図を JSDoc で明記し、契約を単体テストでカバー
- エラーメッセージの scrub を強化し、非文字列入力も文字列化してから redact するよう変更
- CHANGELOG の `CIMD` → `OIDC` タイポ修正と、schema path regex の security rationale を明文化

## 検証
- `bun run typecheck`
- `bunx biome check .changeset/tidy-ai-quality-findings.md CHANGELOG.md src/auth/server.ts src/auth/server.test.ts src/openapi/client-mode.ts src/openapi/schema-loader.ts src/sign/tools.ts src/sign/handlers.test.ts src/server/error-serializer.ts src/server/error-serializer.test.ts`
- `bun run test:run src/server/error-serializer.test.ts src/auth/server.test.ts src/openapi/client-mode.test.ts src/openapi/schema-loader.test.ts src/sign/handlers.test.ts`

補足: `bun run check` 全体は、この PR で触っていない既存ファイルの formatting/import-order 指摘で失敗します。