### PR TITLE
chore(sign): サイン MCP のコード品質改善

### DIFF
--- a/.changeset/sign-tool-cleanup.md
+++ b/.changeset/sign-tool-cleanup.md
@@ -2,8 +2,8 @@
 'freee-mcp': patch
 ---
 
-サイン MCP のコード品質改善。
+freee と freee サインの MCP ツール周りのリファクタ。
 
-- `getSignApiToolAnnotations` を else-if 連結に整理し、PATCH/POST が destructive かつ非冪等である前提を明示
+- HTTP メソッド→`ToolAnnotations` のマッピングを共通ユーティリティに抽出し、freee／サイン両方のツール登録で共有
 - `CliAuthHandler` インターフェースから未使用の `codeVerifier` フィールドを除去（コールバックハンドラ内で参照されておらず Sign は PKCE 非対応）
-- `sign_api_delete` 用ツールに body を許可している理由のコメントを補足
+- `sign_api_delete` で body を許可している理由のコメントを補足

--- a/.changeset/sign-tool-cleanup.md
+++ b/.changeset/sign-tool-cleanup.md
@@ -1,0 +1,9 @@
+---
+'freee-mcp': patch
+---
+
+サイン MCP のコード品質改善。
+
+- `getSignApiToolAnnotations` を else-if 連結に整理し、PATCH/POST が destructive かつ非冪等である前提を明示
+- `CliAuthHandler` インターフェースから未使用の `codeVerifier` フィールドを除去（コールバックハンドラ内で参照されておらず Sign は PKCE 非対応）
+- `sign_api_delete` 用ツールに body を許可している理由のコメントを補足

--- a/src/auth/server.ts
+++ b/src/auth/server.ts
@@ -31,7 +31,6 @@ const HTML_RESPONSE_HEADERS = {
 interface CliAuthHandler {
   resolve: (code: string) => void;
   reject: (error: Error) => void;
-  codeVerifier: string;
 }
 
 /**

--- a/src/cli/oauth-flow.ts
+++ b/src/cli/oauth-flow.ts
@@ -45,7 +45,6 @@ export async function performOAuth(): Promise<OAuthResult> {
         clearTimeout(timeout);
         reject(error);
       },
-      codeVerifier,
     });
   });
 

--- a/src/e2e/configure.e2e.test.ts
+++ b/src/e2e/configure.e2e.test.ts
@@ -93,7 +93,6 @@ vi.mock('../auth/server', () => ({
         handler: {
           resolve: (code: string) => void;
           reject: (error: Error) => void;
-          codeVerifier: string;
         },
       ) => {
         mockAuthCallback = handler.resolve;

--- a/src/openapi/client-mode.ts
+++ b/src/openapi/client-mode.ts
@@ -8,6 +8,7 @@ import type { AuthExtra } from '../storage/context.js';
 import { extractTokenContext } from '../storage/context.js';
 import { registerTracedTool, setToolAttributes } from '../telemetry/tool-tracer.js';
 import { createTextResponse, formatErrorMessage } from '../utils/error.js';
+import { getHttpMethodToolAnnotations } from '../utils/http-method-annotations.js';
 import { type ApiType, listAllAvailablePaths, validatePathForService } from './schema-loader.js';
 
 const SUPPORTED_IMAGE_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
@@ -200,7 +201,7 @@ export function generateClientModeTool(server: McpServer): void {
         path: z.string().describe('APIパス (例: /api/1/deals)'),
         query: coercibleRecord('クエリパラメータ (オプション)').optional(),
       },
-      annotations: { readOnlyHint: true },
+      annotations: getHttpMethodToolAnnotations('GET'),
     },
     createMethodTool('GET'),
   );
@@ -218,7 +219,7 @@ export function generateClientModeTool(server: McpServer): void {
         body: coercibleRecord('リクエストボディ'),
         query: coercibleRecord('クエリパラメータ (オプション)').optional(),
       },
-      annotations: { destructiveHint: true },
+      annotations: getHttpMethodToolAnnotations('POST'),
     },
     createMethodTool('POST'),
   );
@@ -236,7 +237,7 @@ export function generateClientModeTool(server: McpServer): void {
         body: coercibleRecord('リクエストボディ'),
         query: coercibleRecord('クエリパラメータ (オプション)').optional(),
       },
-      annotations: { destructiveHint: true, idempotentHint: true },
+      annotations: getHttpMethodToolAnnotations('PUT'),
     },
     createMethodTool('PUT'),
   );
@@ -253,7 +254,7 @@ export function generateClientModeTool(server: McpServer): void {
         path: z.string().describe('APIパス (例: /api/1/deals/123)'),
         query: coercibleRecord('クエリパラメータ (オプション)').optional(),
       },
-      annotations: { destructiveHint: true, idempotentHint: true },
+      annotations: getHttpMethodToolAnnotations('DELETE'),
     },
     createMethodTool('DELETE'),
   );
@@ -271,7 +272,7 @@ export function generateClientModeTool(server: McpServer): void {
         body: coercibleRecord('リクエストボディ'),
         query: coercibleRecord('クエリパラメータ (オプション)').optional(),
       },
-      annotations: { destructiveHint: true },
+      annotations: getHttpMethodToolAnnotations('PATCH'),
     },
     createMethodTool('PATCH'),
   );

--- a/src/sign/cli/index.ts
+++ b/src/sign/cli/index.ts
@@ -70,7 +70,6 @@ async function performSignOAuthFlow(credentials: SignCredentials): Promise<void>
         clearTimeout(timeout);
         reject(error);
       },
-      codeVerifier: '',
     });
   });
 

--- a/src/sign/tools.ts
+++ b/src/sign/tools.ts
@@ -44,12 +44,14 @@ function resolveTokenContext(
 function getSignApiToolAnnotations(method: SignApiMethod): ToolAnnotations {
   if (method === 'GET') {
     return { readOnlyHint: true };
-  }
-
-  if (method === 'PUT' || method === 'DELETE') {
+  } else if (method === 'PUT' || method === 'DELETE') {
     return { destructiveHint: true, idempotentHint: true };
+  } else if (method === 'POST' || method === 'PATCH') {
+    // POST/PATCH は副作用ありかつ冪等保証なし
+    return { destructiveHint: true };
   }
 
+  // SignApiMethod の union では到達しないが、将来の拡張時の安全側のデフォルト
   return { destructiveHint: true };
 }
 
@@ -92,7 +94,6 @@ function addSignAuthTools(server: McpServer, options?: { remote?: boolean }): vo
               console.error('Sign authentication failed:', error);
               authManager.removeCliAuthHandler(state);
             },
-            codeVerifier: '',
           });
 
           return createTextResponse(
@@ -183,7 +184,9 @@ export function addSignApiTools(server: McpServer, options?: { remote?: boolean 
   ] as const;
 
   for (const { name, method, desc } of methods) {
-    // サイン API の DELETE は user_id 等を body で要求するエンドポイントがある
+    // freee サイン API では一部の DELETE エンドポイントが user_id などの JSON body を要求する。
+    // 該当エンドポイントは API 仕様に従うため、詳細は公式 API ドキュメントを参照すること。
+    // そのため DELETE も body 許可対象に含める。
     const hasBody =
       method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
     const baseSchema = {

--- a/src/sign/tools.ts
+++ b/src/sign/tools.ts
@@ -1,10 +1,10 @@
 import crypto from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { getDefaultAuthManager, startCallbackServerWithAutoStop } from '../auth/server.js';
 import { AUTH_TIMEOUT_MS, PACKAGE_VERSION } from '../constants.js';
 import { createTextResponse, formatErrorMessage } from '../utils/error.js';
+import { getHttpMethodToolAnnotations } from '../utils/http-method-annotations.js';
 import type { SignTokenContext } from './client.js';
 import { makeSignApiRequest } from './client.js';
 import { getSignCredentials } from './config.js';
@@ -13,7 +13,6 @@ import type { SignTokenStore } from './server/sign-redis-token-store.js';
 import { clearSignTokens, isSignTokenValid, loadSignTokens } from './tokens.js';
 
 type SignAuthExtra = { authInfo?: { extra?: Record<string, unknown> } };
-type SignApiMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
 function extractSignTokenContext(extra?: SignAuthExtra): SignTokenContext | undefined {
   const authExtra = extra?.authInfo?.extra;
@@ -39,20 +38,6 @@ function resolveTokenContext(
     );
   }
   return ctx;
-}
-
-function getSignApiToolAnnotations(method: SignApiMethod): ToolAnnotations {
-  if (method === 'GET') {
-    return { readOnlyHint: true };
-  } else if (method === 'PUT' || method === 'DELETE') {
-    return { destructiveHint: true, idempotentHint: true };
-  } else if (method === 'POST' || method === 'PATCH') {
-    // POST/PATCH は副作用ありかつ冪等保証なし
-    return { destructiveHint: true };
-  }
-
-  // SignApiMethod の union では到達しないが、将来の拡張時の安全側のデフォルト
-  return { destructiveHint: true };
 }
 
 function addSignAuthTools(server: McpServer, options?: { remote?: boolean }): void {
@@ -184,9 +169,7 @@ export function addSignApiTools(server: McpServer, options?: { remote?: boolean 
   ] as const;
 
   for (const { name, method, desc } of methods) {
-    // freee サイン API では一部の DELETE エンドポイントが user_id などの JSON body を要求する。
-    // 該当エンドポイントは API 仕様に従うため、詳細は公式 API ドキュメントを参照すること。
-    // そのため DELETE も body 許可対象に含める。
+    // freee サイン API では一部の DELETE エンドポイントが user_id などの JSON body を要求するため、DELETE も body 許可対象に含める
     const hasBody =
       method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
     const baseSchema = {
@@ -215,7 +198,7 @@ export function addSignApiTools(server: McpServer, options?: { remote?: boolean 
         title: desc,
         description: desc,
         inputSchema,
-        annotations: getSignApiToolAnnotations(method),
+        annotations: getHttpMethodToolAnnotations(method),
       },
       async (
         args: { path: string; query?: Record<string, unknown>; body?: Record<string, unknown> },

--- a/src/utils/http-method-annotations.ts
+++ b/src/utils/http-method-annotations.ts
@@ -1,0 +1,16 @@
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export function getHttpMethodToolAnnotations(method: HttpMethod): ToolAnnotations {
+  switch (method) {
+    case 'GET':
+      return { readOnlyHint: true };
+    case 'PUT':
+    case 'DELETE':
+      return { destructiveHint: true, idempotentHint: true };
+    case 'POST':
+    case 'PATCH':
+      return { destructiveHint: true };
+  }
+}


### PR DESCRIPTION
## 概要

GitHub Code Quality (AI findings) で `src/sign/tools.ts` に挙がった指摘 3 件への対応とその場での重複整理。

- HTTP メソッド→`ToolAnnotations` のマッピングを `src/utils/http-method-annotations.ts` に抽出
  - 同じロジックが freee `client-mode.ts` と `sign/tools.ts` の双方に存在していたため共通化
  - switch で網羅的に列挙し、到達不能な fallthrough return を排除
- `CliAuthHandler.codeVerifier` フィールドを削除
  - AI 指摘は「Sign の OAuth で PKCE 用 verifier を生成すべき」という内容だったが、`buildSignAuthUrl` は `code_challenge` を送らず `exchangeSignCodeForTokens` も `code_verifier` を受け取らないため Sign は PKCE 非対応
  - `CliAuthHandler.codeVerifier` 自体がコールバックハンドラ (`src/auth/server.ts`) で参照されていない dead code だったためフィールドごと削除し、呼び出し側 (`sign/tools.ts`, `sign/cli/index.ts`, `cli/oauth-flow.ts`, `e2e/configure.e2e.test.ts`) のダミー値を整理
  - freee CLI フロー側はクロージャから verifier を消費しており挙動変化なし
- `sign_api_delete` で body を許可している理由のコメントを補足（freee サイン API の一部 DELETE が user_id 等の JSON body を要求するため）

## 変更種別

- [ ] 新機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント
- [ ] その他