### PR TITLE
Harden Claude workflow with explicit tool allowlist

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,5 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@dde2242db6af13460b916652159b6ba19a598f30 # v1.0.120
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowed-tools "Bash(ls:*),Bash(pnpm install),Bash(pnpm typecheck),Bash(pnpm test:*),Bash(pnpm lint),Bash(pnpm format),Bash(pnpm build)"
           additional_permissions: |
             actions: read


### PR DESCRIPTION
### Motivation
- Close a security regression where the Claude GitHub Action could be triggered from public issue/PR comments and run without an enforced command allowlist, risking secret/OIDC-token exfiltration and runner abuse. 
- Restore the previous intent of constraining Claude's shell tool usage after the v1 migration removed the active `allowed_tools` restriction.

### Description
- Added an explicit `claude_args` setting to `.github/workflows/claude.yml` that configures `--allowed-tools` to a restrictive list: `Bash(ls:*),Bash(pnpm install),Bash(pnpm typecheck),Bash(pnpm test:*),Bash(pnpm lint),Bash(pnpm format),Bash(pnpm build)`.
- The change is minimal (two-line insertion) and preserves existing workflow triggers, permissions, and other behavior.

### Testing
- Verified workflow YAML parses successfully with Ruby using `ruby -ryaml -e 'YAML.load_file(".github/workflows/claude.yml"); puts "yaml ok"'` (succeeded).
- Attempted Python-based YAML parse but it failed due to the environment missing `PyYAML` (test failure is environmental, not a YAML syntax error).
- Inspected the diff with `git diff` and committed the change with `git commit` (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0fd9d73274832babb9dd07dd2529f7)