### PR TITLE
feat: Codex プラグイン定義を追加

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "freee-mcp-marketplace",
+  "interface": {
+    "displayName": "freee MCP"
+  },
+  "plugins": [
+    {
+      "name": "freee-mcp",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "description": "freee API を MCP 経由で操作するためのプラグイン。MCP サーバー設定と Agent Skills（API リファレンス・操作レシピ）をまとめて提供。OAuth 認証とトークン管理を自動化し、経費申請、会計データ取得、人事情報管理など、freee の様々な機能を利用可能。",
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.changeset/codex-plugin-definition.md
+++ b/.changeset/codex-plugin-definition.md
@@ -1,0 +1,9 @@
+---
+"freee-mcp": minor
+---
+
+Codex プラグイン定義を追加
+
+- `.codex-plugin/plugin.json` を追加し、OpenAI Codex のプラグインとして MCP サーバーと Agent Skills をまとめて利用可能に
+- `.agents/plugins/marketplace.json`（Codex マーケットプレースカタログ）を追加
+- README に Codex でのインストール手順を追記

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "freee-mcp",
+  "version": "0.29.0",
+  "description": "freee API を MCP 経由で操作するためのスキル。詳細なAPIリファレンスと freee-mcp を使用した API 呼び出しガイドを提供。",
+  "author": {
+    "name": "freee"
+  },
+  "homepage": "https://github.com/freee/freee-mcp",
+  "repository": "https://github.com/freee/freee-mcp",
+  "license": "Apache-2.0",
+  "mcpServers": {
+    "freee": {
+      "type": "http",
+      "url": "https://mcp.freee.co.jp/mcp"
+    }
+  },
+  "skills": "./skills"
+}

--- a/README.md
+++ b/README.md
@@ -151,6 +151,23 @@ Claude Code のプロンプト内からも実行できます:
 /plugin install freee-mcp@freee-mcp-marketplace
 ```
 
+## Codex Plugin として使う
+
+OpenAI Codex でもプラグインとしてインストールすると、MCP サーバーと Agent Skills（API リファレンス・操作レシピ）がまとめて利用できます。
+
+Codex App / CLI / IDE 拡張で、マーケットプレースを追加してからプラグインをインストールします。
+
+CLI の場合:
+
+```bash
+codex plugin marketplace add freee/freee-mcp
+codex plugin install freee-mcp
+```
+
+Codex App では「Add Marketplace」から `freee/freee-mcp` を追加し、一覧から `freee-mcp` をインストールしてください。
+
+プラグイン定義は `.codex-plugin/plugin.json`、マーケットプレースカタログは `.agents/plugins/marketplace.json` にあります。
+
 ## Agent Skills の内容
 
 | API      | 内容                                             | ファイル数 |


### PR DESCRIPTION
## 概要

OpenAI Codex でプラグインとしてインストールできるよう、Codex 用のプラグイン定義ファイルを追加します。既存の Claude Code プラグイン（`.claude-plugin/`）と同等に、MCP サーバー設定と Agent Skills（API リファレンス・操作レシピ）をまとめて利用できるようにします。

「codex desktop から簡単にインストールできるか」という調査の結果、Codex（2026年3月の Plugin Marketplace 以降）には Claude Code とほぼ同等のプラグイン機構があり、必要なマニフェストを置けば `codex plugin marketplace add freee/freee-mcp` → install で導入できることを確認しました。

## 変更内容

- `.codex-plugin/plugin.json` を追加（Codex プラグインの必須マニフェスト）
  - `.claude-plugin/plugin.json` と同等の内容。remote MCP（`https://mcp.freee.co.jp/mcp`）を `mcpServers` に設定し、`skills` に `./skills` を指定
- `.agents/plugins/marketplace.json` を追加（Codex マーケットプレースカタログ）
  - `codex plugin marketplace add freee/freee-mcp` / Codex App の「Add Marketplace」からの検出用
- README に「Codex Plugin として使う」セクションを追記
- changeset（minor）を追加

## インストール方法（追加後）

```bash
codex plugin marketplace add freee/freee-mcp
codex plugin install freee-mcp
```

Codex App では「Add Marketplace」から `freee/freee-mcp` を追加し、一覧から `freee-mcp` をインストール。

## 確認した仕様 / 留意点

- 必須ファイルは `.codex-plugin/plugin.json` のみ。`skills/` や MCP 設定はプラグインルートに置く
- プラグインの `.mcp.json` は `mcpServers`（camelCase）を期待する（`mcp_servers` は `~/.codex/config.toml` 側の表記。openai/codex#22105）。本 PR では plugin.json にインラインで `mcpServers` を記述
- リポジトリ単位の検出にはマーケットプレースカタログが必要なため `.agents/plugins/marketplace.json` を併設

## 未検証 / フォローアップ候補

公式ドキュメント（developers.openai.com/codex）が取得できず、実機 Codex での動作確認は未実施です。以下は実環境での検証が望ましいです。

- `.agents/plugins/marketplace.json` のスキーマ（`source` オブジェクト形式・`category` 等）が現行 Codex の検証を通るか
- plugin.json の `mcpServers` がインライン記述で受理されるか（パス参照 `.mcp.json` を要求する場合は要調整。なお既存の root `.mcp.json` はローカル開発用 stdio 設定のため流用していません）
- ローカルマーケットプレースで skill が露出しないバグ（openai/codex#22078）の影響。GitHub 経由配布では回避見込み

## バージョン同期について

`.codex-plugin/plugin.json` の `version` は現行の `0.29.0` に合わせています。リリース時に `.claude-plugin/*` や `apm.yml` のバージョンを更新する処理の対象に、本ファイルも追加する必要があります。

## テスト

- `bun run typecheck`：パス
- `bun run lint`：既存の info 1件のみ（本変更とは無関係）
- `bun run test:run`：818 件パス
- `bun run build`：成功

（変更は JSON / Markdown のみで、ソースコードへの影響はありません）

https://claude.ai/code/session_01LQFnhr3ZBSLoQyezcm2eLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQFnhr3ZBSLoQyezcm2eLC)_