### PR TITLE
fix: SERVER_INSTRUCTIONSにIT管理API追加 & file_uploadにAbortSignalタイムアウト追加

### DIFF
--- a/src/api/file-upload.ts
+++ b/src/api/file-upload.ts
@@ -8,6 +8,7 @@ import type { ApiCallErrorType } from '../server/request-context.js';
 import { getCurrentRecorder } from '../server/request-context.js';
 import { getUserAgent } from '../server/user-agent.js';
 import { resolveCompanyId, type TokenContext } from '../storage/context.js';
+import { FETCH_TIMEOUT_API_MS } from '../constants.js';
 import { formatApiErrorMessage, formatResponseErrorInfo } from '../utils/error.js';
 
 const MAX_FILE_SIZE_BYTES = 64 * 1024 * 1024; // 64MB
@@ -160,6 +161,7 @@ export async function uploadReceipt(
       method: 'POST',
       headers,
       body: formData,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_API_MS),
     });
   } catch (fetchError) {
     const errorType: ApiCallErrorType =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -62,7 +62,7 @@ export const FREEE_TOKEN_ENDPOINT = 'https://accounts.secure.freee.co.jp/public_
 export const FREEE_OAUTH_SCOPE = 'read write';
 
 export const SERVER_INSTRUCTIONS =
-  'freee APIと連携するMCPサーバー。会計・人事労務・請求書・工数管理・販売APIをサポート。詳細ガイドはfreee-api-skill skillを参照。skillが未インストールの場合は npx skills add freee/freee-mcp で追加';
+  'freee APIと連携するMCPサーバー。会計・人事労務・請求書・工数管理・販売・IT管理APIをサポート。詳細ガイドはfreee-api-skill skillを参照。skillが未インストールの場合は npx skills add freee/freee-mcp で追加';
 
 export const REFRESH_TOKEN_TTL_SECONDS = 90 * 24 * 60 * 60; // 90 days
 


### PR DESCRIPTION
## 概要

2つのバグ修正をまとめて対応します。

### 修正1: SERVER_INSTRUCTIONSにIT管理APIを追加 (fixes #483)

`src/constants.ts` の `SERVER_INSTRUCTIONS` が対応API一覧から `IT管理` を漏らしていました。  
「会計・人事労務・請求書・工数管理・販売API」→「会計・人事労務・請求書・工数管理・販売・IT管理API」に修正。

### 修正2: file_uploadのfetchにAbortSignal.timeoutを追加 (fixes #482)

`src/api/file-upload.ts` の `uploadReceipt` 内の `fetch()` に `AbortSignal.timeout(FETCH_TIMEOUT_API_MS)` が設定されていませんでした。  
`makeApiRequest` と同じ 30秒タイムアウトを適用します。

## 変更ファイル

- `src/constants.ts`: SERVER_INSTRUCTIONSにIT管理APIを追加
- `src/api/file-upload.ts`: FETCH_TIMEOUT_API_MSをimportし、fetchにsignal追加