### PR TITLE
feat: support FREEE_MCP_CONFIG_DIR env var to override config directory

### DIFF
--- a/.changeset/freee-mcp-config-dir-env.md
+++ b/.changeset/freee-mcp-config-dir-env.md
@@ -1,0 +1,9 @@
+---
+"freee-mcp": minor
+---
+
+`FREEE_MCP_CONFIG_DIR` 環境変数で設定ディレクトリを上書きできるようにしました。
+
+- 優先順: `FREEE_MCP_CONFIG_DIR` → `$XDG_CONFIG_HOME/freee-mcp` → `~/.config/freee-mcp`
+- `XDG_CONFIG_HOME` と異なり freee-mcp 専用に隔離でき、開発・テスト用途で他の XDG 対応ツールへの副作用を避けられる
+- `configure` / `sign configure` の保存先メッセージを解決後の実パスに変更

--- a/src/cli/configuration.ts
+++ b/src/cli/configuration.ts
@@ -1,4 +1,6 @@
+import path from 'node:path';
 import { type FullConfig, saveFullConfig } from '../config/companies.js';
+import { getConfigDir } from '../constants.js';
 import type { Company, Credentials, SelectedCompany } from './types.js';
 
 export async function saveConfig(
@@ -26,7 +28,8 @@ export async function saveConfig(
   });
 
   await saveFullConfig(fullConfig);
+  const configDir = getConfigDir();
   console.log('設定情報を保存しました。\n');
-  console.log('認証情報は ~/.config/freee-mcp/config.json に保存されました。');
-  console.log('トークンは ~/.config/freee-mcp/tokens.json に保存されました。\n');
+  console.log(`認証情報は ${path.join(configDir, 'config.json')} に保存されました。`);
+  console.log(`トークンは ${path.join(configDir, 'tokens.json')} に保存されました。\n`);
 }

--- a/src/constants.test.ts
+++ b/src/constants.test.ts
@@ -1,0 +1,47 @@
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { APP_NAME, getConfigDir } from './constants.js';
+
+const originalFreeeMcpConfigDir = process.env.FREEE_MCP_CONFIG_DIR;
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+
+function restoreEnv(name: string, original: string | undefined): void {
+  if (original !== undefined) {
+    process.env[name] = original;
+  } else {
+    delete process.env[name];
+  }
+}
+
+describe('getConfigDir', () => {
+  beforeEach(() => {
+    delete process.env.FREEE_MCP_CONFIG_DIR;
+    delete process.env.XDG_CONFIG_HOME;
+  });
+
+  afterEach(() => {
+    restoreEnv('FREEE_MCP_CONFIG_DIR', originalFreeeMcpConfigDir);
+    restoreEnv('XDG_CONFIG_HOME', originalXdgConfigHome);
+  });
+
+  it('falls back to ~/.config/freee-mcp when no env vars are set', () => {
+    expect(getConfigDir()).toBe(path.join(os.homedir(), '.config', APP_NAME));
+  });
+
+  it('uses $XDG_CONFIG_HOME/freee-mcp when XDG_CONFIG_HOME is set', () => {
+    process.env.XDG_CONFIG_HOME = '/tmp/xdg-config';
+    expect(getConfigDir()).toBe(path.join('/tmp/xdg-config', APP_NAME));
+  });
+
+  it('uses FREEE_MCP_CONFIG_DIR as-is without appending APP_NAME', () => {
+    process.env.FREEE_MCP_CONFIG_DIR = '/tmp/freee-mcp-isolated';
+    expect(getConfigDir()).toBe('/tmp/freee-mcp-isolated');
+  });
+
+  it('prefers FREEE_MCP_CONFIG_DIR over XDG_CONFIG_HOME', () => {
+    process.env.FREEE_MCP_CONFIG_DIR = '/tmp/freee-mcp-isolated';
+    process.env.XDG_CONFIG_HOME = '/tmp/xdg-config';
+    expect(getConfigDir()).toBe('/tmp/freee-mcp-isolated');
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,11 +15,15 @@ export const APP_NAME = 'freee-mcp';
 
 /**
  * Get the configuration directory path.
- * Respects XDG Base Directory specification:
- * - Uses XDG_CONFIG_HOME if set
- * - Falls back to ~/.config/freee-mcp
+ * Precedence:
+ * 1. FREEE_MCP_CONFIG_DIR — freee-mcp specific override (no APP_NAME suffix appended)
+ * 2. $XDG_CONFIG_HOME/freee-mcp — XDG Base Directory
+ * 3. ~/.config/freee-mcp — default
  */
 export function getConfigDir(): string {
+  if (process.env.FREEE_MCP_CONFIG_DIR) {
+    return process.env.FREEE_MCP_CONFIG_DIR;
+  }
   return process.env.XDG_CONFIG_HOME
     ? path.join(process.env.XDG_CONFIG_HOME, APP_NAME)
     : path.join(os.homedir(), '.config', APP_NAME);

--- a/src/sign/cli/index.ts
+++ b/src/sign/cli/index.ts
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto';
+import path from 'node:path';
 import open from 'open';
 import prompts from 'prompts';
 import {
@@ -12,7 +13,7 @@ import {
   getTargetDisplayName,
   type McpTarget,
 } from '../../config/mcp-config.js';
-import { AUTH_TIMEOUT_MS } from '../../constants.js';
+import { AUTH_TIMEOUT_MS, getConfigDir } from '../../constants.js';
 import { clearSignConfig, loadSignConfig, saveSignConfig } from '../config.js';
 import { buildSignAuthUrl, exchangeSignCodeForTokens } from '../oauth.js';
 import { collectSignCredentials, type SignCredentials } from './prompts.js';
@@ -147,9 +148,10 @@ export async function signConfigure(options: SignConfigureOptions = {}): Promise
 
   stopCallbackServer();
 
+  const configDir = getConfigDir();
   console.log('設定情報を保存しました。\n');
-  console.log('認証情報は ~/.config/freee-mcp/sign-config.json に保存されました。');
-  console.log('トークンは ~/.config/freee-mcp/sign-tokens.json に保存されました。\n');
+  console.log(`認証情報は ${path.join(configDir, 'sign-config.json')} に保存されました。`);
+  console.log(`トークンは ${path.join(configDir, 'sign-tokens.json')} に保存されました。\n`);
 
   await configureSignMcp();
 


### PR DESCRIPTION
## Summary / 概要

Closes #486

freee-mcp 専用の環境変数 `FREEE_MCP_CONFIG_DIR` を追加し、`XDG_CONFIG_HOME` を変えずに freee-mcp の設定ディレクトリだけを隔離できるようにします。

`XDG_CONFIG_HOME` をオーバーライドする方法は他の XDG 対応ツールにも影響するため、開発・テスト・submodule 利用時に副作用が出ます。ツール固有 env var を導入することで、freee-mcp の設定だけを別ディレクトリへ向けることができます。

## Changes / 変更点

- `getConfigDir()` の precedence を更新:
  1. `FREEE_MCP_CONFIG_DIR` (新規 / そのままのパスを使用、`freee-mcp` サフィックスは付与しない)
  2. `$XDG_CONFIG_HOME/freee-mcp`
  3. `~/.config/freee-mcp` (既定)
- `configure` / `sign configure` の保存先メッセージを、ハードコードされた `~/.config/freee-mcp/...` から `getConfigDir()` ベースの実パスに変更
- `src/constants.test.ts` を追加し、3 段階の precedence を検証

既存挙動は変えていません (`FREEE_MCP_CONFIG_DIR` 未設定時は従来通り)。

## Usage / 使い方

```bash
FREEE_MCP_CONFIG_DIR=/path/to/freee-mcp-config npx freee-mcp configure
```

保存されるファイル:

```text
/path/to/freee-mcp-config/config.json
/path/to/freee-mcp-config/tokens.json
/path/to/freee-mcp-config/sign-config.json
/path/to/freee-mcp-config/sign-tokens.json
```

## Test plan / 確認

- [x] `bun run build`
- [x] `bun run test:run src/constants.test.ts` (4 件追加・全 pass)
- [x] `bun run lint` (本変更分の指摘なし)
- [ ] 手動: `FREEE_MCP_CONFIG_DIR=/tmp/freee-mcp-test npx freee-mcp configure` で隔離ディレクトリに保存されること

> [!NOTE]
> リポジトリ全体の `bun run typecheck` / `bun run test:run` には main ブランチ時点で既に通らない箇所がありますが、本 PR の変更とは無関係です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)